### PR TITLE
Optimize redundant scan passes & add Core profiling hooks

### DIFF
--- a/MLVScan.Core.Tests/Integration/AssemblyScannerTests.cs
+++ b/MLVScan.Core.Tests/Integration/AssemblyScannerTests.cs
@@ -276,7 +276,8 @@ public class AssemblyScannerTests
     [Fact]
     public void CreateAssemblyTelemetryId_StripsAbsolutePath()
     {
-        var assemblyId = AssemblyScanner.CreateAssemblyTelemetryId(@"C:\Users\ghost\Desktop\sample\Example.dll");
+        var assemblyPath = Path.Combine(Path.GetTempPath(), "MLVScan.Core.Tests", "Example.dll");
+        var assemblyId = AssemblyScanner.CreateAssemblyTelemetryId(assemblyPath);
 
         assemblyId.Should().Be("Example.dll");
     }

--- a/MLVScan.Core.Tests/Integration/AssemblyScannerTests.cs
+++ b/MLVScan.Core.Tests/Integration/AssemblyScannerTests.cs
@@ -272,4 +272,28 @@ public class AssemblyScannerTests
 
         findings.Count.Should().BeGreaterThanOrEqualTo(2);
     }
+
+    [Fact]
+    public void CreateAssemblyTelemetryId_StripsAbsolutePath()
+    {
+        var assemblyId = AssemblyScanner.CreateAssemblyTelemetryId(@"C:\Users\ghost\Desktop\sample\Example.dll");
+
+        assemblyId.Should().Be("Example.dll");
+    }
+
+    [Fact]
+    public void CreateStreamTelemetryId_PreservesRelativeVirtualPath()
+    {
+        var assemblyId = AssemblyScanner.CreateStreamTelemetryId(@"corpus\Example.dll");
+
+        assemblyId.Should().Be(@"corpus\Example.dll");
+    }
+
+    [Fact]
+    public void CreateStreamTelemetryId_StripsAbsoluteVirtualPath()
+    {
+        var assemblyId = AssemblyScanner.CreateStreamTelemetryId(@"C:\Users\ghost\Desktop\sample\Example.dll");
+
+        assemblyId.Should().Be("Example.dll");
+    }
 }

--- a/MLVScan.Core.Tests/Performance/FalsePositiveCorpusPerformanceTests.cs
+++ b/MLVScan.Core.Tests/Performance/FalsePositiveCorpusPerformanceTests.cs
@@ -1,0 +1,237 @@
+using System.Diagnostics;
+using System.Text.Json;
+using FluentAssertions;
+using MLVScan.Core.Tests.TestUtilities.Performance;
+using MLVScan.Services;
+using MLVScan.Services.Diagnostics;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace MLVScan.Core.Tests.Performance;
+
+public class FalsePositiveCorpusPerformanceTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public FalsePositiveCorpusPerformanceTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [SkippableFact]
+    [Trait("Category", "Performance")]
+    public void Scan_AllFalsePositiveAssemblies_ProducesStableBenchmark()
+    {
+        var falsePositivesFolder = FindFalsePositivesFolder();
+        Skip.If(falsePositivesFolder == null,
+            "FALSE_POSITIVES folder not found. This benchmark requires local sample assemblies.");
+
+        var assemblyPaths = Directory
+            .EnumerateFiles(falsePositivesFolder!, "*", SearchOption.AllDirectories)
+            .Where(IsAssemblySampleFile)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        assemblyPaths.Should().NotBeEmpty("FALSE_POSITIVES should contain benchmark assemblies");
+
+        const int warmupRuns = 1;
+        const int measuredRuns = 3;
+        var findingCounts = new List<int>(measuredRuns);
+
+        for (var run = 0; run < warmupRuns; run++)
+        {
+            RunCorpus(assemblyPaths, captureProfiles: false);
+        }
+
+        var measurement = PerfMeasurement.Measure("FalsePositiveCorpus", 0, measuredRuns, () =>
+        {
+            var runResult = RunCorpus(assemblyPaths, captureProfiles: false);
+            findingCounts.Add(runResult.TotalFindings);
+        });
+
+        var baselineRun = RunCorpus(assemblyPaths, captureProfiles: true);
+
+        findingCounts.Should().OnlyContain(count => count == findingCounts[0],
+            "benchmark runs should produce a stable finding count across the same corpus");
+
+        _output.WriteLine($"Corpus root: {falsePositivesFolder}");
+        _output.WriteLine($"Assemblies scanned: {assemblyPaths.Length}");
+        _output.WriteLine($"Warmup findings: {baselineRun.TotalFindings}");
+        _output.WriteLine($"Measured runs (ms): {string.Join(", ", measurement.DurationsMs)}");
+        _output.WriteLine(
+            $"Summary: min={measurement.MinMs} avg={measurement.AverageMs:F1} p95={measurement.P95Ms} max={measurement.MaxMs}");
+        _output.WriteLine(
+            $"Average per assembly: {(measurement.AverageMs / assemblyPaths.Length):F1}ms | findings per run: {findingCounts[0]}");
+
+        var profileArtifactPath = TryWriteProfileArtifact(falsePositivesFolder!, baselineRun);
+        if (profileArtifactPath != null)
+        {
+            _output.WriteLine($"Profile artifact: {profileArtifactPath}");
+
+            foreach (var phase in SummarizePhases(baselineRun).Take(10))
+            {
+                _output.WriteLine(
+                    $"Phase: {phase.Name} | total={phase.TotalMs:F1}ms | avg/assembly={phase.AverageMs:F2}ms | count={phase.Count}");
+            }
+        }
+
+        foreach (var assembly in baselineRun.Assemblies
+                     .OrderByDescending(result => result.DurationMs)
+                     .Take(10))
+        {
+            _output.WriteLine(
+                $"Slowest: {Path.GetFileName(assembly.Path)} | {assembly.DurationMs}ms | findings={assembly.Findings}");
+        }
+    }
+
+    private static CorpusRunResult RunCorpus(IReadOnlyList<string> assemblyPaths, bool captureProfiles)
+    {
+        var scanner = new AssemblyScanner(RuleFactory.CreateDefaultRules());
+        var stopwatch = Stopwatch.StartNew();
+        var perAssembly = new List<AssemblyRunResult>(assemblyPaths.Count);
+        var totalFindings = 0;
+
+        foreach (var assemblyPath in assemblyPaths)
+        {
+            var assemblyStopwatch = Stopwatch.StartNew();
+            var findings = scanner.Scan(assemblyPath).ToList();
+            assemblyStopwatch.Stop();
+
+            totalFindings += findings.Count;
+            perAssembly.Add(new AssemblyRunResult(
+                assemblyPath,
+                assemblyStopwatch.ElapsedMilliseconds,
+                findings.Count,
+                captureProfiles ? scanner.GetLastProfileSnapshot() : null));
+        }
+
+        stopwatch.Stop();
+        return new CorpusRunResult(stopwatch.ElapsedMilliseconds, totalFindings, perAssembly);
+    }
+
+    private static string? TryWriteProfileArtifact(string falsePositivesFolder, CorpusRunResult run)
+    {
+        if (run.Assemblies.All(static assembly => assembly.Profile == null))
+        {
+            return null;
+        }
+
+        var repositoryRoot = FindRepositoryRoot(falsePositivesFolder);
+        var outputDirectory = Path.Combine(repositoryRoot, "MLVScan.Core", "MLVScan.Core.Tests", "TestResults",
+            "Performance");
+        Directory.CreateDirectory(outputDirectory);
+
+        var outputPath = Path.Combine(outputDirectory,
+            $"false-positive-corpus-profile-{DateTime.UtcNow:yyyyMMdd-HHmmss}.json");
+
+        var payload = new CorpusProfileArtifact
+        {
+            GeneratedUtc = DateTime.UtcNow,
+            CorpusRoot = falsePositivesFolder,
+            AssemblyCount = run.Assemblies.Count,
+            TotalDurationMs = run.TotalDurationMs,
+            TotalFindings = run.TotalFindings,
+            PhaseTotals = SummarizePhases(run).ToArray(),
+            Assemblies = run.Assemblies
+        };
+
+        var json = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+        {
+            WriteIndented = true
+        });
+
+        File.WriteAllText(outputPath, json);
+        return outputPath;
+    }
+
+    private static IEnumerable<PhaseSummary> SummarizePhases(CorpusRunResult run)
+    {
+        return run.Assemblies
+            .Where(static assembly => assembly.Profile != null)
+            .SelectMany(static assembly => assembly.Profile!.Phases)
+            .GroupBy(static phase => phase.Name, StringComparer.Ordinal)
+            .Select(group => new PhaseSummary(
+                group.Key,
+                group.Sum(phase => TicksToMilliseconds(phase.ElapsedTicks)),
+                group.Average(phase => TicksToMilliseconds(phase.ElapsedTicks)),
+                group.Sum(static phase => phase.Count)))
+            .OrderByDescending(static phase => phase.TotalMs);
+    }
+
+    private static string FindRepositoryRoot(string falsePositivesFolder)
+    {
+        var current = Directory.GetParent(falsePositivesFolder)?.FullName;
+        while (current != null)
+        {
+            if (File.Exists(Path.Combine(current, "AGENTS.md")))
+            {
+                return current;
+            }
+
+            current = Directory.GetParent(current)?.FullName;
+        }
+
+        throw new DirectoryNotFoundException("Repository root not found for performance artifact output.");
+    }
+
+    private static double TicksToMilliseconds(long ticks)
+    {
+        return ticks * 1000d / Stopwatch.Frequency;
+    }
+
+    private static bool IsAssemblySampleFile(string path)
+    {
+        var extension = Path.GetExtension(path);
+        return extension.Equals(".dll", StringComparison.OrdinalIgnoreCase)
+               || extension.Equals(".exe", StringComparison.OrdinalIgnoreCase)
+               || extension.Equals(".winmd", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? FindFalsePositivesFolder()
+    {
+        var currentDir = Directory.GetCurrentDirectory();
+
+        while (currentDir != null)
+        {
+            var direct = Path.Combine(currentDir, "FALSE_POSITIVES");
+            if (Directory.Exists(direct))
+            {
+                return direct;
+            }
+
+            var nested = Path.Combine(currentDir, "MLVScan.Core", "FALSE_POSITIVES");
+            if (Directory.Exists(nested))
+            {
+                return nested;
+            }
+
+            currentDir = Directory.GetParent(currentDir)?.FullName;
+        }
+
+        return null;
+    }
+
+    private sealed record CorpusRunResult(long TotalDurationMs, int TotalFindings, IReadOnlyList<AssemblyRunResult> Assemblies);
+
+    private sealed record AssemblyRunResult(string Path, long DurationMs, int Findings, ScanProfileSnapshot? Profile);
+
+    private sealed record PhaseSummary(string Name, double TotalMs, double AverageMs, int Count);
+
+    private sealed class CorpusProfileArtifact
+    {
+        public DateTime GeneratedUtc { get; init; }
+
+        public string CorpusRoot { get; init; } = string.Empty;
+
+        public int AssemblyCount { get; init; }
+
+        public long TotalDurationMs { get; init; }
+
+        public int TotalFindings { get; init; }
+
+        public IReadOnlyList<PhaseSummary> PhaseTotals { get; init; } = Array.Empty<PhaseSummary>();
+
+        public IReadOnlyList<AssemblyRunResult> Assemblies { get; init; } = Array.Empty<AssemblyRunResult>();
+    }
+}

--- a/MLVScan.Core.Tests/Performance/FalsePositiveCorpusPerformanceTests.cs
+++ b/MLVScan.Core.Tests/Performance/FalsePositiveCorpusPerformanceTests.cs
@@ -57,7 +57,7 @@ public class FalsePositiveCorpusPerformanceTests
 
         _output.WriteLine($"Corpus root: {falsePositivesFolder}");
         _output.WriteLine($"Assemblies scanned: {assemblyPaths.Length}");
-        _output.WriteLine($"Warmup findings: {baselineRun.TotalFindings}");
+        _output.WriteLine($"Baseline findings: {baselineRun.TotalFindings}");
         _output.WriteLine($"Measured runs (ms): {string.Join(", ", measurement.DurationsMs)}");
         _output.WriteLine(
             $"Summary: min={measurement.MinMs} avg={measurement.AverageMs:F1} p95={measurement.P95Ms} max={measurement.MaxMs}");
@@ -123,7 +123,7 @@ public class FalsePositiveCorpusPerformanceTests
         Directory.CreateDirectory(outputDirectory);
 
         var outputPath = Path.Combine(outputDirectory,
-            $"false-positive-corpus-profile-{DateTime.UtcNow:yyyyMMdd-HHmmss}.json");
+            $"false-positive-corpus-profile-{DateTime.UtcNow:yyyyMMdd-HHmmssfff}.json");
 
         var payload = new CorpusProfileArtifact
         {

--- a/MLVScan.Core.Tests/Performance/FalsePositiveCorpusPerformanceTests.cs
+++ b/MLVScan.Core.Tests/Performance/FalsePositiveCorpusPerformanceTests.cs
@@ -41,16 +41,16 @@ public class FalsePositiveCorpusPerformanceTests
 
         for (var run = 0; run < warmupRuns; run++)
         {
-            RunCorpus(assemblyPaths, captureProfiles: false);
+            RunCorpus(falsePositivesFolder!, assemblyPaths, captureProfiles: false);
         }
 
         var measurement = PerfMeasurement.Measure("FalsePositiveCorpus", 0, measuredRuns, () =>
         {
-            var runResult = RunCorpus(assemblyPaths, captureProfiles: false);
+            var runResult = RunCorpus(falsePositivesFolder!, assemblyPaths, captureProfiles: false);
             findingCounts.Add(runResult.TotalFindings);
         });
 
-        var baselineRun = RunCorpus(assemblyPaths, captureProfiles: true);
+        var baselineRun = RunCorpus(falsePositivesFolder!, assemblyPaths, captureProfiles: true);
 
         findingCounts.Should().OnlyContain(count => count == findingCounts[0],
             "benchmark runs should produce a stable finding count across the same corpus");
@@ -85,7 +85,8 @@ public class FalsePositiveCorpusPerformanceTests
         }
     }
 
-    private static CorpusRunResult RunCorpus(IReadOnlyList<string> assemblyPaths, bool captureProfiles)
+    private static CorpusRunResult RunCorpus(string falsePositivesFolder, IReadOnlyList<string> assemblyPaths,
+        bool captureProfiles)
     {
         var scanner = new AssemblyScanner(RuleFactory.CreateDefaultRules());
         var stopwatch = Stopwatch.StartNew();
@@ -98,9 +99,10 @@ public class FalsePositiveCorpusPerformanceTests
             var findings = scanner.Scan(assemblyPath).ToList();
             assemblyStopwatch.Stop();
 
+            var assemblyId = Path.GetRelativePath(falsePositivesFolder, assemblyPath);
             totalFindings += findings.Count;
             perAssembly.Add(new AssemblyRunResult(
-                assemblyPath,
+                assemblyId,
                 assemblyStopwatch.ElapsedMilliseconds,
                 findings.Count,
                 captureProfiles ? scanner.GetLastProfileSnapshot() : null));
@@ -117,9 +119,7 @@ public class FalsePositiveCorpusPerformanceTests
             return null;
         }
 
-        var repositoryRoot = FindRepositoryRoot(falsePositivesFolder);
-        var outputDirectory = Path.Combine(repositoryRoot, "MLVScan.Core", "MLVScan.Core.Tests", "TestResults",
-            "Performance");
+        var outputDirectory = GetPerformanceArtifactDirectory();
         Directory.CreateDirectory(outputDirectory);
 
         var outputPath = Path.Combine(outputDirectory,
@@ -128,7 +128,8 @@ public class FalsePositiveCorpusPerformanceTests
         var payload = new CorpusProfileArtifact
         {
             GeneratedUtc = DateTime.UtcNow,
-            CorpusRoot = falsePositivesFolder,
+            CorpusRoot = Path.GetFileName(falsePositivesFolder.TrimEnd(Path.DirectorySeparatorChar,
+                Path.AltDirectorySeparatorChar)),
             AssemblyCount = run.Assemblies.Count,
             TotalDurationMs = run.TotalDurationMs,
             TotalFindings = run.TotalFindings,
@@ -159,20 +160,9 @@ public class FalsePositiveCorpusPerformanceTests
             .OrderByDescending(static phase => phase.TotalMs);
     }
 
-    private static string FindRepositoryRoot(string falsePositivesFolder)
+    private static string GetPerformanceArtifactDirectory()
     {
-        var current = Directory.GetParent(falsePositivesFolder)?.FullName;
-        while (current != null)
-        {
-            if (File.Exists(Path.Combine(current, "AGENTS.md")))
-            {
-                return current;
-            }
-
-            current = Directory.GetParent(current)?.FullName;
-        }
-
-        throw new DirectoryNotFoundException("Repository root not found for performance artifact output.");
+        return Path.Combine(Path.GetTempPath(), "MLVScanTests", "TestResults", "Performance");
     }
 
     private static double TicksToMilliseconds(long ticks)

--- a/MLVScan.Core.Tests/Unit/Services/InstructionAnalyzerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/InstructionAnalyzerTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using MLVScan.Models;
+using MLVScan.Models.Rules;
 using MLVScan.Services;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -62,7 +63,7 @@ public class InstructionAnalyzerTests
     }
 
     [Fact]
-    public void AnalyzeInstructions_SkipsDirectFindingWhenSameRuleAlreadyProducedContextualFinding()
+    public void AnalyzeInstructions_PreservesDirectFindingWhenSameRuleAlsoProducesContextualFinding()
     {
         var config = new ScanConfig();
         var rule = new CountingContextualAndDirectRule(matchMethodName: "InvokePayload", emitContextualFinding: true);
@@ -72,8 +73,8 @@ public class InstructionAnalyzerTests
         var result = analyzer.AnalyzeInstructions(method, method.Body.Instructions, new MethodSignals(),
             method.DeclaringType!.FullName);
 
-        result.Findings.Should().ContainSingle();
-        result.Findings[0].Description.Should().Be("contextual");
+        result.Findings.Should().HaveCount(2);
+        result.Findings.Select(f => f.Description).Should().Contain(new[] { "contextual", "Matched InvokePayload" });
         rule.IsSuspiciousCallCount.Should().Be(1);
         rule.ContextualCallCount.Should().Be(1);
     }
@@ -93,6 +94,40 @@ public class InstructionAnalyzerTests
         result.Findings[0].Description.Should().Be("Matched InvokePayload");
         rule.IsSuspiciousCallCount.Should().Be(1);
         rule.ContextualCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void AnalyzeInstructions_WithNullMethodSignals_ProvidesNonNullSignalBagToRuleCallbacks()
+    {
+        var config = new ScanConfig { EnableMultiSignalDetection = false };
+        var rule = new NullSafeContextualRule();
+        var analyzer = CreateAnalyzer(config, new IScanRule[] { rule });
+        var method = CreateMethodCalling("InvokePayload");
+
+        var result = analyzer.AnalyzeInstructions(method, method.Body.Instructions, null, method.DeclaringType!.FullName);
+
+        result.Findings.Should().ContainSingle();
+        rule.ContextualReceivedNull.Should().BeFalse();
+        rule.SuppressReceivedNull.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AnalyzeInstructions_WithoutReflectionRule_StillRunsReflectionBypassDetector()
+    {
+        var config = new ScanConfig();
+        var analyzer = CreateAnalyzer(config, new IScanRule[] { new ProcessStartRule() });
+        var method = CreateReflectionInvokeMethodWithSuspiciousStrings();
+        var methodSignals = new MethodSignals
+        {
+            HasProcessLikeCall = true
+        };
+
+        var result = analyzer.AnalyzeInstructions(method, method.Body.Instructions, methodSignals,
+            method.DeclaringType!.FullName);
+
+        result.Findings.Should().ContainSingle();
+        result.Findings[0].Description.Should().Contain("reflection bypass");
+        result.Findings[0].RuleId.Should().Be("ProcessStartRule");
     }
 
     private static InstructionAnalyzer CreateAnalyzer(ScanConfig config, IEnumerable<IScanRule> rules)
@@ -122,6 +157,30 @@ public class InstructionAnalyzerTests
         var calledType = new TypeReference("Test", "Target", module, module.TypeSystem.CoreLibrary);
         var calledMethod = new MethodReference(calledMethodName, module.TypeSystem.Void, calledType);
         method.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Call, calledMethod));
+        method.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Ret));
+        type.Methods.Add(method);
+
+        return method;
+    }
+
+    private static MethodDefinition CreateReflectionInvokeMethodWithSuspiciousStrings()
+    {
+        var assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition("InstructionAnalyzerReflectionTest", new Version(1, 0, 0, 0)),
+            "InstructionAnalyzerReflectionTest",
+            ModuleKind.Dll);
+        var module = assembly.MainModule;
+        var type = new TypeDefinition("Test", "ReflectionType", TypeAttributes.Public | TypeAttributes.Class,
+            module.TypeSystem.Object);
+        module.Types.Add(type);
+
+        var method = new MethodDefinition("Run", MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Void);
+        method.Body = new MethodBody(method);
+        var methodInfoType = new TypeReference("System.Reflection", "MethodInfo", module, module.TypeSystem.CoreLibrary);
+        var invokeMethod = new MethodReference("Invoke", module.TypeSystem.Object, methodInfoType);
+        method.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Ldstr, "Start"));
+        method.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Call, invokeMethod));
         method.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Ret));
         type.Methods.Add(method);
 
@@ -201,6 +260,35 @@ public class InstructionAnalyzerTests
             Mono.Collections.Generic.Collection<Instruction> instructions, int instructionIndex)
         {
             return $"Matched {method.Name}";
+        }
+    }
+
+    private sealed class NullSafeContextualRule : IScanRule
+    {
+        public bool ContextualReceivedNull { get; private set; }
+        public bool SuppressReceivedNull { get; private set; }
+
+        public string Description => "Null-safe contextual rule";
+        public Severity Severity => Severity.Medium;
+        public string RuleId => "NullSafeContextualRule";
+        public bool RequiresCompanionFinding => false;
+
+        public bool IsSuspicious(MethodReference method) => method.Name == "InvokePayload";
+
+        public IEnumerable<ScanFinding> AnalyzeContextualPattern(MethodReference method,
+            Mono.Collections.Generic.Collection<Instruction> instructions, int instructionIndex,
+            MethodSignals methodSignals)
+        {
+            ContextualReceivedNull = methodSignals == null;
+            return Enumerable.Empty<ScanFinding>();
+        }
+
+        public bool ShouldSuppressFinding(MethodReference method,
+            Mono.Collections.Generic.Collection<Instruction> instructions, int instructionIndex, MethodSignals methodSignals,
+            MethodSignals? typeSignals = null)
+        {
+            SuppressReceivedNull = methodSignals == null;
+            return false;
         }
     }
 }

--- a/MLVScan.Core.Tests/Unit/Services/InstructionAnalyzerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/InstructionAnalyzerTests.cs
@@ -1,0 +1,206 @@
+using FluentAssertions;
+using MLVScan.Models;
+using MLVScan.Services;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xunit;
+
+namespace MLVScan.Core.Tests.Unit.Services;
+
+public class InstructionAnalyzerTests
+{
+    [Fact]
+    public void AnalyzeInstructions_WithMatchingDirectRule_CallsIsSuspiciousOnce()
+    {
+        var config = new ScanConfig();
+        var rule = new CountingSuspiciousRule(matchMethodName: "InvokePayload");
+        var analyzer = CreateAnalyzer(config, new IScanRule[] { rule });
+        var method = CreateMethodCalling("InvokePayload");
+
+        var result = analyzer.AnalyzeInstructions(method, method.Body.Instructions, new MethodSignals(),
+            method.DeclaringType!.FullName);
+
+        result.Findings.Should().ContainSingle();
+        result.Findings[0].RuleId.Should().Be("CountingSuspiciousRule");
+        rule.IsSuspiciousCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void AnalyzeInstructions_UsesFirstMatchingRuleWithoutDoubleEvaluatingLaterRules()
+    {
+        var config = new ScanConfig();
+        var firstRule = new CountingSuspiciousRule(matchMethodName: "InvokePayload", ruleId: "FirstRule");
+        var secondRule = new CountingSuspiciousRule(matchMethodName: "InvokePayload", ruleId: "SecondRule");
+        var analyzer = CreateAnalyzer(config, new IScanRule[] { firstRule, secondRule });
+        var method = CreateMethodCalling("InvokePayload");
+
+        var result = analyzer.AnalyzeInstructions(method, method.Body.Instructions, new MethodSignals(),
+            method.DeclaringType!.FullName);
+
+        result.Findings.Should().ContainSingle();
+        result.Findings[0].RuleId.Should().Be("FirstRule");
+        firstRule.IsSuspiciousCallCount.Should().Be(1);
+        secondRule.IsSuspiciousCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void AnalyzeInstructions_WhenFirstRuleDoesNotMatch_EvaluatesSecondRuleOnce()
+    {
+        var config = new ScanConfig();
+        var firstRule = new CountingSuspiciousRule(matchMethodName: "SomethingElse", ruleId: "FirstRule");
+        var secondRule = new CountingSuspiciousRule(matchMethodName: "InvokePayload", ruleId: "SecondRule");
+        var analyzer = CreateAnalyzer(config, new IScanRule[] { firstRule, secondRule });
+        var method = CreateMethodCalling("InvokePayload");
+
+        var result = analyzer.AnalyzeInstructions(method, method.Body.Instructions, new MethodSignals(),
+            method.DeclaringType!.FullName);
+
+        result.Findings.Should().ContainSingle();
+        result.Findings[0].RuleId.Should().Be("SecondRule");
+        firstRule.IsSuspiciousCallCount.Should().Be(1);
+        secondRule.IsSuspiciousCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void AnalyzeInstructions_SkipsDirectFindingWhenSameRuleAlreadyProducedContextualFinding()
+    {
+        var config = new ScanConfig();
+        var rule = new CountingContextualAndDirectRule(matchMethodName: "InvokePayload", emitContextualFinding: true);
+        var analyzer = CreateAnalyzer(config, new IScanRule[] { rule });
+        var method = CreateMethodCalling("InvokePayload");
+
+        var result = analyzer.AnalyzeInstructions(method, method.Body.Instructions, new MethodSignals(),
+            method.DeclaringType!.FullName);
+
+        result.Findings.Should().ContainSingle();
+        result.Findings[0].Description.Should().Be("contextual");
+        rule.IsSuspiciousCallCount.Should().Be(1);
+        rule.ContextualCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void AnalyzeInstructions_StillCreatesDirectFindingWhenContextualRuleReturnsNoFindings()
+    {
+        var config = new ScanConfig();
+        var rule = new CountingContextualAndDirectRule(matchMethodName: "InvokePayload", emitContextualFinding: false);
+        var analyzer = CreateAnalyzer(config, new IScanRule[] { rule });
+        var method = CreateMethodCalling("InvokePayload");
+
+        var result = analyzer.AnalyzeInstructions(method, method.Body.Instructions, new MethodSignals(),
+            method.DeclaringType!.FullName);
+
+        result.Findings.Should().ContainSingle();
+        result.Findings[0].Description.Should().Be("Matched InvokePayload");
+        rule.IsSuspiciousCallCount.Should().Be(1);
+        rule.ContextualCallCount.Should().Be(1);
+    }
+
+    private static InstructionAnalyzer CreateAnalyzer(ScanConfig config, IEnumerable<IScanRule> rules)
+    {
+        var signalTracker = new SignalTracker(config);
+        var snippetBuilder = new CodeSnippetBuilder();
+        var stringPatternDetector = new StringPatternDetector();
+        var reflectionDetector = new ReflectionDetector(rules, signalTracker, stringPatternDetector, snippetBuilder);
+        return new InstructionAnalyzer(rules, signalTracker, reflectionDetector, stringPatternDetector,
+            snippetBuilder, config, null);
+    }
+
+    private static MethodDefinition CreateMethodCalling(string calledMethodName)
+    {
+        var assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition("InstructionAnalyzerTest", new Version(1, 0, 0, 0)),
+            "InstructionAnalyzerTest",
+            ModuleKind.Dll);
+        var module = assembly.MainModule;
+        var type = new TypeDefinition("Test", "Type", TypeAttributes.Public | TypeAttributes.Class,
+            module.TypeSystem.Object);
+        module.Types.Add(type);
+
+        var method = new MethodDefinition("Run", MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Void);
+        method.Body = new MethodBody(method);
+        var calledType = new TypeReference("Test", "Target", module, module.TypeSystem.CoreLibrary);
+        var calledMethod = new MethodReference(calledMethodName, module.TypeSystem.Void, calledType);
+        method.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Call, calledMethod));
+        method.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Ret));
+        type.Methods.Add(method);
+
+        return method;
+    }
+
+    private sealed class CountingSuspiciousRule : IScanRule
+    {
+        private readonly string _matchMethodName;
+
+        public CountingSuspiciousRule(string matchMethodName, string ruleId = "CountingSuspiciousRule")
+        {
+            _matchMethodName = matchMethodName;
+            RuleId = ruleId;
+        }
+
+        public int IsSuspiciousCallCount { get; private set; }
+
+        public string Description => "Counting suspicious rule";
+        public Severity Severity => Severity.Medium;
+        public string RuleId { get; }
+        public bool RequiresCompanionFinding => false;
+
+        public bool IsSuspicious(MethodReference method)
+        {
+            IsSuspiciousCallCount++;
+            return method.Name == _matchMethodName;
+        }
+
+        public string GetFindingDescription(MethodDefinition containingMethod, MethodReference method,
+            Mono.Collections.Generic.Collection<Instruction> instructions, int instructionIndex)
+        {
+            return $"Matched {method.Name}";
+        }
+    }
+
+    private sealed class CountingContextualAndDirectRule : IScanRule
+    {
+        private readonly string _matchMethodName;
+        private readonly bool _emitContextualFinding;
+
+        public CountingContextualAndDirectRule(string matchMethodName, bool emitContextualFinding)
+        {
+            _matchMethodName = matchMethodName;
+            _emitContextualFinding = emitContextualFinding;
+        }
+
+        public int IsSuspiciousCallCount { get; private set; }
+        public int ContextualCallCount { get; private set; }
+
+        public string Description => "Counting contextual rule";
+        public Severity Severity => Severity.Medium;
+        public string RuleId => "CountingContextualRule";
+        public bool RequiresCompanionFinding => false;
+
+        public bool IsSuspicious(MethodReference method)
+        {
+            IsSuspiciousCallCount++;
+            return method.Name == _matchMethodName;
+        }
+
+        public IEnumerable<ScanFinding> AnalyzeContextualPattern(MethodReference method,
+            Mono.Collections.Generic.Collection<Instruction> instructions, int instructionIndex,
+            MethodSignals methodSignals)
+        {
+            ContextualCallCount++;
+
+            if (!_emitContextualFinding || method.Name != _matchMethodName)
+            {
+                return Enumerable.Empty<ScanFinding>();
+            }
+
+            return new[] { new ScanFinding("context", "contextual", Severity.Medium) };
+        }
+
+        public string GetFindingDescription(MethodDefinition containingMethod, MethodReference method,
+            Mono.Collections.Generic.Collection<Instruction> instructions, int instructionIndex)
+        {
+            return $"Matched {method.Name}";
+        }
+    }
+}

--- a/MLVScan.Core.Tests/Unit/Services/LocalVariableAnalyzerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/LocalVariableAnalyzerTests.cs
@@ -70,6 +70,22 @@ public class LocalVariableAnalyzerTests
         methodSignals.HasTriggeredRuleOtherThan("DifferentRule").Should().BeTrue();
     }
 
+    [Fact]
+    public void AnalyzeLocalVariables_WithSuspiciousProcessVariable_PropagatesTypeLevelSignal()
+    {
+        var config = new ScanConfig { AnalyzeLocalVariables = true, EnableMultiSignalDetection = true };
+        var tracker = new SignalTracker(config);
+        var analyzer = new LocalVariableAnalyzer(new IScanRule[] { new SuspiciousLocalVariableRule() }, tracker, config);
+        var method = CreateMethodWithLocal("System.Diagnostics.Process");
+        var methodSignals = new MethodSignals();
+        var typeSignals = tracker.GetOrCreateTypeSignals(method.DeclaringType!.FullName);
+
+        analyzer.AnalyzeLocalVariables(method, method.Body.Variables, methodSignals).ToList();
+
+        typeSignals.Should().NotBeNull();
+        typeSignals!.HasSuspiciousLocalVariables.Should().BeTrue();
+    }
+
     private static MethodDefinition CreateMethodWithLocal(string localVariableTypeName)
     {
         var assembly = AssemblyDefinition.CreateAssembly(

--- a/MLVScan.Core.Tests/Unit/Services/LocalVariableAnalyzerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/LocalVariableAnalyzerTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using MLVScan.Models;
+using MLVScan.Models.Rules;
 using MLVScan.Services;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -26,53 +27,50 @@ public class LocalVariableAnalyzerTests
     {
         var config = new ScanConfig { AnalyzeLocalVariables = false };
         var tracker = new SignalTracker(config);
-        var analyzer = new LocalVariableAnalyzer(new[] { new LocalRuleStub("RuleA", false, new[] { new ScanFinding("L", "D") }) }, tracker, config);
-        var method = CreateMethodWithLocal();
-
-        var findings = analyzer.AnalyzeLocalVariables(method, method.Body.Variables, new MethodSignals());
-
-        findings.Should().BeEmpty();
-    }
-
-    [Fact]
-    public void AnalyzeLocalVariables_CompanionRuleWithoutOtherTriggers_SkipsFinding()
-    {
-        var config = new ScanConfig { AnalyzeLocalVariables = true, EnableMultiSignalDetection = true };
-        var tracker = new SignalTracker(config);
-        var analyzer = new LocalVariableAnalyzer(new[]
-        {
-            new LocalRuleStub("CompanionRule", true, new[] { new ScanFinding("Test.Method", "Companion finding", Severity.High) })
-        }, tracker, config);
-        var method = CreateMethodWithLocal();
+        var analyzer = new LocalVariableAnalyzer(new IScanRule[] { new SuspiciousLocalVariableRule() }, tracker, config);
+        var method = CreateMethodWithLocal("System.Diagnostics.Process");
         var methodSignals = new MethodSignals();
 
-        var findings = analyzer.AnalyzeLocalVariables(method, method.Body.Variables, methodSignals).ToList();
+        var findings = analyzer.AnalyzeLocalVariables(method, method.Body.Variables, methodSignals);
 
         findings.Should().BeEmpty();
         methodSignals.HasSuspiciousLocalVariables.Should().BeFalse();
     }
 
     [Fact]
-    public void AnalyzeLocalVariables_WithAllowedFinding_AddsFindingAndMarksSignals()
+    public void AnalyzeLocalVariables_IgnoresNonLocalVariableRules()
     {
         var config = new ScanConfig { AnalyzeLocalVariables = true, EnableMultiSignalDetection = true };
         var tracker = new SignalTracker(config);
-        var rule = new LocalRuleStub("LocalRule", false, new[]
-        {
-            new ScanFinding("Test.Method", "Local variable suspicious", Severity.Low)
-        });
-        var analyzer = new LocalVariableAnalyzer(new[] { rule }, tracker, config);
-        var method = CreateMethodWithLocal();
+        var rule = new LocalRuleStub();
+        var analyzer = new LocalVariableAnalyzer(new IScanRule[] { rule }, tracker, config);
+        var method = CreateMethodWithLocal("System.Diagnostics.Process");
         var methodSignals = new MethodSignals();
 
         var findings = analyzer.AnalyzeLocalVariables(method, method.Body.Variables, methodSignals).ToList();
 
-        findings.Should().ContainSingle();
+        findings.Should().BeEmpty();
+        methodSignals.HasSuspiciousLocalVariables.Should().BeFalse();
+        rule.AnalyzeInstructionsCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void AnalyzeLocalVariables_WithSuspiciousProcessVariable_MarksSignalsWithoutStandaloneFinding()
+    {
+        var config = new ScanConfig { AnalyzeLocalVariables = true, EnableMultiSignalDetection = true };
+        var tracker = new SignalTracker(config);
+        var analyzer = new LocalVariableAnalyzer(new IScanRule[] { new SuspiciousLocalVariableRule() }, tracker, config);
+        var method = CreateMethodWithLocal("System.Diagnostics.Process");
+        var methodSignals = new MethodSignals();
+
+        var findings = analyzer.AnalyzeLocalVariables(method, method.Body.Variables, methodSignals).ToList();
+
+        findings.Should().BeEmpty();
         methodSignals.HasSuspiciousLocalVariables.Should().BeTrue();
         methodSignals.HasTriggeredRuleOtherThan("DifferentRule").Should().BeTrue();
     }
 
-    private static MethodDefinition CreateMethodWithLocal()
+    private static MethodDefinition CreateMethodWithLocal(string localVariableTypeName)
     {
         var assembly = AssemblyDefinition.CreateAssembly(
             new AssemblyNameDefinition("LocalVarTestAssembly", new Version(1, 0, 0, 0)),
@@ -88,7 +86,10 @@ public class LocalVariableAnalyzerTests
             Body = new MethodBody(null!)
         };
         method.Body = new MethodBody(method);
-        method.Body.Variables.Add(new VariableDefinition(module.TypeSystem.String));
+        var variableType = localVariableTypeName == "System.Diagnostics.Process"
+            ? new TypeReference("System.Diagnostics", "Process", module, module.TypeSystem.CoreLibrary)
+            : module.TypeSystem.String;
+        method.Body.Variables.Add(new VariableDefinition(variableType));
         var il = method.Body.GetILProcessor();
         il.Append(il.Create(OpCodes.Nop));
         il.Append(il.Create(OpCodes.Ret));
@@ -99,23 +100,18 @@ public class LocalVariableAnalyzerTests
 
     private sealed class LocalRuleStub : IScanRule
     {
-        private readonly IReadOnlyCollection<ScanFinding> _findings;
-
-        public LocalRuleStub(string ruleId, bool requiresCompanionFinding, IEnumerable<ScanFinding> findings)
-        {
-            RuleId = ruleId;
-            RequiresCompanionFinding = requiresCompanionFinding;
-            _findings = findings.ToList();
-        }
-
+        public int AnalyzeInstructionsCallCount { get; private set; }
         public string Description => "Local variable rule stub";
         public Severity Severity => Severity.Low;
-        public string RuleId { get; }
-        public bool RequiresCompanionFinding { get; }
+        public string RuleId => "LocalRuleStub";
+        public bool RequiresCompanionFinding => false;
 
         public bool IsSuspicious(MethodReference method) => false;
 
         public IEnumerable<ScanFinding> AnalyzeInstructions(MethodDefinition method, Mono.Collections.Generic.Collection<Instruction> instructions, MethodSignals methodSignals)
-            => _findings;
+        {
+            AnalyzeInstructionsCallCount++;
+            return new[] { new ScanFinding("L", "D") };
+        }
     }
 }

--- a/MLVScan.Core.Tests/Unit/Services/MethodScannerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/MethodScannerTests.cs
@@ -86,6 +86,20 @@ public class MethodScannerTests
         result.Findings.Any(f => f.Description.StartsWith("Critical:")).Should().BeTrue();
     }
 
+    [Fact]
+    public void ScanMethod_WithLocalVariables_DoesNotReplayAnalyzeInstructionsForNonLocalRules()
+    {
+        var config = new ScanConfig { EnableMultiSignalDetection = true, AnalyzeLocalVariables = true };
+        var countingRule = new CountingAnalyzeInstructionRule();
+        var scanner = CreateScanner(config, new IScanRule[] { countingRule });
+        var method = CreateMethod(withLocalVariable: true);
+
+        var result = scanner.ScanMethod(method, "Test.Type");
+
+        result.Findings.Should().ContainSingle();
+        countingRule.AnalyzeInstructionsCallCount.Should().Be(1);
+    }
+
     private static MethodScanner CreateScanner(ScanConfig config, IEnumerable<IScanRule> rules)
     {
         var signalTracker = new SignalTracker(config);
@@ -98,7 +112,7 @@ public class MethodScannerTests
         return new MethodScanner(rules, signalTracker, instructionAnalyzer, snippetBuilder, localVariableAnalyzer, exceptionHandlerAnalyzer, config);
     }
 
-    private static MethodDefinition CreateMethod(bool withBody = true)
+    private static MethodDefinition CreateMethod(bool withBody = true, bool withLocalVariable = false)
     {
         var assembly = AssemblyDefinition.CreateAssembly(new AssemblyNameDefinition("MethodScannerTest", new Version(1, 0, 0, 0)), "MethodScannerTest", ModuleKind.Dll);
         var module = assembly.MainModule;
@@ -111,6 +125,11 @@ public class MethodScannerTests
         if (withBody)
         {
             method.Body = new MethodBody(method);
+            if (withLocalVariable)
+            {
+                method.Body.Variables.Add(new VariableDefinition(module.TypeSystem.String));
+            }
+
             method.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Ret));
         }
 
@@ -159,6 +178,25 @@ public class MethodScannerTests
             methodSignals.HasEncodedStrings = true;
             methodSignals.HasProcessLikeCall = true;
             return Enumerable.Empty<ScanFinding>();
+        }
+    }
+
+    private sealed class CountingAnalyzeInstructionRule : IScanRule
+    {
+        public int AnalyzeInstructionsCallCount { get; private set; }
+
+        public string Description => "Counting rule";
+        public Severity Severity => Severity.Low;
+        public string RuleId => "CountingRule";
+        public bool RequiresCompanionFinding => false;
+
+        public bool IsSuspicious(MethodReference method) => false;
+
+        public IEnumerable<ScanFinding> AnalyzeInstructions(MethodDefinition method,
+            Mono.Collections.Generic.Collection<Instruction> instructions, MethodSignals methodSignals)
+        {
+            AnalyzeInstructionsCallCount++;
+            return new[] { new ScanFinding($"{method.DeclaringType?.FullName}.{method.Name}", "counted", Severity.Low) };
         }
     }
 }

--- a/MLVScan.Core.Tests/Unit/Services/TypeScannerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/TypeScannerTests.cs
@@ -77,6 +77,48 @@ public class TypeScannerTests
         findings.Any(f => f.Location.Contains("Inner.Run")).Should().BeTrue();
     }
 
+    [Fact]
+    public void ScanType_WithPropertyAccessor_AnnotatesWithoutRescanningMethod()
+    {
+        var config = new ScanConfig { EnableMultiSignalDetection = false, AnalyzePropertyAccessors = true };
+        var countingRule = new CountingAnalyzeInstructionRule();
+        var rules = new IScanRule[] { countingRule };
+
+        var signalTracker = new SignalTracker(config);
+        var snippetBuilder = new CodeSnippetBuilder();
+        var stringPatternDetector = new StringPatternDetector();
+        var reflectionDetector = new ReflectionDetector(rules, signalTracker, stringPatternDetector, snippetBuilder);
+        var localVariableAnalyzer = new LocalVariableAnalyzer(rules, signalTracker, config);
+        var exceptionHandlerAnalyzer = new ExceptionHandlerAnalyzer(rules, signalTracker, snippetBuilder, config);
+        var instructionAnalyzer = new InstructionAnalyzer(rules, signalTracker, reflectionDetector, stringPatternDetector, snippetBuilder, config, null);
+        var methodScanner = new MethodScanner(rules, signalTracker, instructionAnalyzer, snippetBuilder, localVariableAnalyzer, exceptionHandlerAnalyzer, config);
+        var propertyEventScanner = new PropertyEventScanner(methodScanner, config);
+        var typeScanner = new TypeScanner(methodScanner, signalTracker, reflectionDetector, snippetBuilder, propertyEventScanner, rules, config);
+
+        var assembly = AssemblyDefinition.CreateAssembly(new AssemblyNameDefinition("PropertyTypeScan", new Version(1, 0, 0, 0)), "PropertyTypeScan", ModuleKind.Dll);
+        var module = assembly.MainModule;
+        var type = new TypeDefinition("Test", "HasProperty", TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(type);
+
+        var getter = new MethodDefinition("get_Name", MethodAttributes.Public, module.TypeSystem.String);
+        getter.Body = new MethodBody(getter);
+        getter.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Ldstr, "value"));
+        getter.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Ret));
+        type.Methods.Add(getter);
+
+        var property = new PropertyDefinition("Name", PropertyAttributes.None, module.TypeSystem.String)
+        {
+            GetMethod = getter
+        };
+        type.Properties.Add(property);
+
+        var findings = typeScanner.ScanType(type).ToList();
+
+        findings.Should().ContainSingle();
+        findings[0].Description.Should().Contain("found in property getter: Name");
+        countingRule.AnalyzeInstructionsCallCount.Should().Be(1);
+    }
+
     private static TypeDefinition CreateTypeWithReflectionAndProcessMethods()
     {
         var assembly = AssemblyDefinition.CreateAssembly(new AssemblyNameDefinition("TypeScan", new Version(1, 0, 0, 0)), "TypeScan", ModuleKind.Dll);
@@ -107,5 +149,27 @@ public class TypeScannerTests
         type.Methods.Add(processMethod);
 
         return type;
+    }
+
+    private sealed class CountingAnalyzeInstructionRule : IScanRule
+    {
+        public int AnalyzeInstructionsCallCount { get; private set; }
+
+        public string Description => "Counting rule";
+        public Severity Severity => Severity.Low;
+        public string RuleId => "CountingRule";
+        public bool RequiresCompanionFinding => false;
+
+        public bool IsSuspicious(MethodReference method) => false;
+
+        public IEnumerable<ScanFinding> AnalyzeInstructions(MethodDefinition method,
+            Mono.Collections.Generic.Collection<Instruction> instructions, MethodSignals methodSignals)
+        {
+            AnalyzeInstructionsCallCount++;
+            return new[]
+            {
+                new ScanFinding($"{method.DeclaringType?.FullName}.{method.Name}", "counted", Severity.Low, "snippet")
+            };
+        }
     }
 }

--- a/MLVScan.Core.csproj
+++ b/MLVScan.Core.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
+    <EnableMlvScanProfiling>false</EnableMlvScanProfiling>
     
     <!-- NuGet Package Metadata -->
     <PackageId>MLVScan.Core</PackageId>
@@ -21,6 +22,10 @@
     <!-- Assembly Info -->
     <AssemblyName>MLVScan.Core</AssemblyName>
     <RootNamespace>MLVScan</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(EnableMlvScanProfiling)' == 'true'">
+    <DefineConstants>$(DefineConstants);MLVSCAN_PROFILING</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("MLVScan.Core.Tests")]

--- a/Services/AssemblyScanner.cs
+++ b/Services/AssemblyScanner.cs
@@ -89,7 +89,8 @@ namespace MLVScan.Services
             if (!File.Exists(assemblyPath))
                 throw new FileNotFoundException("Assembly file not found", assemblyPath);
 
-            _telemetry.BeginAssembly(assemblyPath);
+            var assemblyId = CreateAssemblyTelemetryId(assemblyPath);
+            _telemetry.BeginAssembly(assemblyId);
             _telemetry.IncrementCounter("Assemblies.Scanned");
             var totalStart = _telemetry.StartTimestamp();
             var findings = new List<ScanFinding>();
@@ -163,7 +164,7 @@ namespace MLVScan.Services
             if (assemblyStream.CanSeek)
                 assemblyStream.Position = 0;
 
-            var assemblyId = virtualPath ?? "<stream>";
+            var assemblyId = CreateStreamTelemetryId(virtualPath);
             _telemetry.BeginAssembly(assemblyId);
             _telemetry.IncrementCounter("Assemblies.Scanned");
             var totalStart = _telemetry.StartTimestamp();
@@ -305,6 +306,26 @@ namespace MLVScan.Services
             }
 
             return findings;
+        }
+
+        internal static string CreateAssemblyTelemetryId(string assemblyPath)
+        {
+            return Path.GetFileName(assemblyPath);
+        }
+
+        internal static string CreateStreamTelemetryId(string? virtualPath)
+        {
+            if (string.IsNullOrWhiteSpace(virtualPath))
+            {
+                return "<stream>";
+            }
+
+            if (Path.IsPathRooted(virtualPath))
+            {
+                return Path.GetFileName(virtualPath);
+            }
+
+            return virtualPath;
         }
 
         internal ScanProfileSnapshot? GetLastProfileSnapshot()

--- a/Services/AssemblyScanner.cs
+++ b/Services/AssemblyScanner.cs
@@ -1,6 +1,7 @@
 using MLVScan.Abstractions;
 using MLVScan.Models;
 using MLVScan.Models.Rules;
+using MLVScan.Services.Diagnostics;
 using Mono.Cecil;
 
 namespace MLVScan.Services
@@ -26,6 +27,7 @@ namespace MLVScan.Services
         private readonly DataFlowAnalyzer _dataFlowAnalyzer;
         private readonly IAssemblyResolverProvider _resolverProvider;
         private readonly ScanConfig _config;
+        private readonly ScanTelemetryHub _telemetry;
 
         /// <summary>
         /// Creates a new AssemblyScanner with the specified rules and configuration.
@@ -43,6 +45,7 @@ namespace MLVScan.Services
             _config = config ?? new ScanConfig();
             _resolverProvider = resolverProvider ?? DefaultAssemblyResolverProvider.Instance;
             _rules = rules;
+            _telemetry = new ScanTelemetryHub();
 
             // Create all services using composition
             var snippetBuilder = new CodeSnippetBuilder();
@@ -53,20 +56,20 @@ namespace MLVScan.Services
             _callGraphBuilder = new CallGraphBuilder(rules, snippetBuilder, entryPointProvider);
 
             // Create data flow analyzer for tracking data movement through operations
-            _dataFlowAnalyzer = new DataFlowAnalyzer(rules, snippetBuilder);
+            _dataFlowAnalyzer = new DataFlowAnalyzer(rules, snippetBuilder, _telemetry);
 
             var reflectionDetector =
                 new ReflectionDetector(rules, signalTracker, stringPatternDetector, snippetBuilder);
             var instructionAnalyzer = new InstructionAnalyzer(rules, signalTracker, reflectionDetector,
-                stringPatternDetector, snippetBuilder, _config, _callGraphBuilder);
+                stringPatternDetector, snippetBuilder, _config, _telemetry, _callGraphBuilder);
             var localVariableAnalyzer = new LocalVariableAnalyzer(rules, signalTracker, _config);
             var exceptionHandlerAnalyzer = new ExceptionHandlerAnalyzer(rules, signalTracker, snippetBuilder, _config);
             var methodScanner = new MethodScanner(rules, signalTracker, instructionAnalyzer, snippetBuilder,
-                localVariableAnalyzer, exceptionHandlerAnalyzer, _config);
+                localVariableAnalyzer, exceptionHandlerAnalyzer, _config, _telemetry);
             var propertyEventScanner = new PropertyEventScanner(methodScanner, _config);
 
             _typeScanner = new TypeScanner(methodScanner, signalTracker, reflectionDetector, snippetBuilder,
-                propertyEventScanner, rules, _config);
+                propertyEventScanner, rules, _config, _telemetry);
             _metadataScanner = new MetadataScanner(rules);
             _dllImportScanner = new DllImportScanner(rules, _callGraphBuilder);
         }
@@ -86,6 +89,9 @@ namespace MLVScan.Services
             if (!File.Exists(assemblyPath))
                 throw new FileNotFoundException("Assembly file not found", assemblyPath);
 
+            _telemetry.BeginAssembly(assemblyPath);
+            _telemetry.IncrementCounter("Assemblies.Scanned");
+            var totalStart = _telemetry.StartTimestamp();
             var findings = new List<ScanFinding>();
 
             try
@@ -102,18 +108,29 @@ namespace MLVScan.Services
                     AssemblyResolver = _resolverProvider.CreateResolver(),
                 };
 
-                var assembly = AssemblyDefinition.ReadAssembly(assemblyPath, readerParameters);
+                var readAssemblyStart = _telemetry.StartTimestamp();
+                using var assembly = AssemblyDefinition.ReadAssembly(assemblyPath, readerParameters);
+                _telemetry.AddPhaseElapsed("AssemblyScanner.ReadAssembly", readAssemblyStart);
+                var scanAssemblyStart = _telemetry.StartTimestamp();
                 ScanAssembly(assembly, findings);
+                _telemetry.AddPhaseElapsed("AssemblyScanner.ScanAssembly", scanAssemblyStart);
 
                 // Build consolidated call chain findings
+                var callChainStart = _telemetry.StartTimestamp();
                 var callChainFindings = _callGraphBuilder.BuildCallChainFindings();
+                _telemetry.AddPhaseElapsed("AssemblyScanner.BuildCallChainFindings", callChainStart);
                 findings.AddRange(callChainFindings);
 
                 // Build data flow findings
+                var dataFlowFindingsStart = _telemetry.StartTimestamp();
                 var dataFlowFindings = _dataFlowAnalyzer.BuildDataFlowFindings();
+                _telemetry.AddPhaseElapsed("AssemblyScanner.BuildDataFlowFindings", dataFlowFindingsStart);
                 findings.AddRange(dataFlowFindings);
 
+                var correlationStart = _telemetry.StartTimestamp();
                 CorrelateDataFlowIntoExecutionFindings(findings);
+                _telemetry.AddPhaseElapsed("AssemblyScanner.CorrelateDataFlowIntoExecutionFindings",
+                    correlationStart);
             }
             catch (Exception)
             {
@@ -123,7 +140,10 @@ namespace MLVScan.Services
                     Severity.Low) { RuleId = "AssemblyScanner" });
             }
 
-            return FilterEmptyFindings(findings);
+            _telemetry.AddPhaseElapsed("AssemblyScanner.Total", totalStart);
+            var filteredFindings = FilterEmptyFindings(findings).ToList();
+            _telemetry.CompleteAssembly(findings.Count, filteredFindings.Count);
+            return filteredFindings;
         }
 
         /// <summary>
@@ -143,6 +163,10 @@ namespace MLVScan.Services
             if (assemblyStream.CanSeek)
                 assemblyStream.Position = 0;
 
+            var assemblyId = virtualPath ?? "<stream>";
+            _telemetry.BeginAssembly(assemblyId);
+            _telemetry.IncrementCounter("Assemblies.Scanned");
+            var totalStart = _telemetry.StartTimestamp();
             var findings = new List<ScanFinding>();
 
             try
@@ -159,18 +183,29 @@ namespace MLVScan.Services
                     AssemblyResolver = _resolverProvider.CreateResolver(),
                 };
 
-                var assembly = AssemblyDefinition.ReadAssembly(assemblyStream, readerParameters);
+                var readAssemblyStart = _telemetry.StartTimestamp();
+                using var assembly = AssemblyDefinition.ReadAssembly(assemblyStream, readerParameters);
+                _telemetry.AddPhaseElapsed("AssemblyScanner.ReadAssembly", readAssemblyStart);
+                var scanAssemblyStart = _telemetry.StartTimestamp();
                 ScanAssembly(assembly, findings);
+                _telemetry.AddPhaseElapsed("AssemblyScanner.ScanAssembly", scanAssemblyStart);
 
                 // Build consolidated call chain findings
+                var callChainStart = _telemetry.StartTimestamp();
                 var callChainFindings = _callGraphBuilder.BuildCallChainFindings();
+                _telemetry.AddPhaseElapsed("AssemblyScanner.BuildCallChainFindings", callChainStart);
                 findings.AddRange(callChainFindings);
 
                 // Build data flow findings
+                var dataFlowFindingsStart = _telemetry.StartTimestamp();
                 var dataFlowFindings = _dataFlowAnalyzer.BuildDataFlowFindings();
+                _telemetry.AddPhaseElapsed("AssemblyScanner.BuildDataFlowFindings", dataFlowFindingsStart);
                 findings.AddRange(dataFlowFindings);
 
+                var correlationStart = _telemetry.StartTimestamp();
                 CorrelateDataFlowIntoExecutionFindings(findings);
+                _telemetry.AddPhaseElapsed("AssemblyScanner.CorrelateDataFlowIntoExecutionFindings",
+                    correlationStart);
             }
             catch (Exception)
             {
@@ -180,37 +215,53 @@ namespace MLVScan.Services
                     Severity.Low) { RuleId = "AssemblyScanner" });
             }
 
-            return FilterEmptyFindings(findings);
+            _telemetry.AddPhaseElapsed("AssemblyScanner.Total", totalStart);
+            var filteredFindings = FilterEmptyFindings(findings).ToList();
+            _telemetry.CompleteAssembly(findings.Count, filteredFindings.Count);
+            return filteredFindings;
         }
 
         private void ScanAssembly(AssemblyDefinition assembly, List<ScanFinding> findings)
         {
+            if (_config.DetectAssemblyMetadata)
+            {
+                var metadataStart = _telemetry.StartTimestamp();
+                findings.AddRange(_metadataScanner.ScanAssemblyMetadata(assembly));
+                _telemetry.AddPhaseElapsed("AssemblyScanner.MetadataScanner", metadataStart);
+            }
+
             foreach (var module in assembly.Modules)
             {
-                // Scan assembly metadata for hidden payloads
-                if (_config.DetectAssemblyMetadata)
-                {
-                    findings.AddRange(_metadataScanner.ScanAssemblyMetadata(assembly));
-                }
+                _telemetry.IncrementCounter("Assembly.ModulesScanned");
+                _telemetry.IncrementCounter("Assembly.TopLevelTypesScanned", module.Types.Count);
 
                 // Scan for P/Invoke declarations - these are registered with CallGraphBuilder
                 // and findings are generated later in BuildCallChainFindings()
+                var dllImportStart = _telemetry.StartTimestamp();
                 _dllImportScanner.ScanForDllImports(module);
+                _telemetry.AddPhaseElapsed("AssemblyScanner.DllImportScanner", dllImportStart);
 
                 foreach (var type in module.Types)
                 {
+                    var typeScanStart = _telemetry.StartTimestamp();
                     findings.AddRange(_typeScanner.ScanType(type));
+                    _telemetry.AddPhaseElapsed("AssemblyScanner.TypeScanner", typeScanStart);
 
                     // Phase 1: Analyze data flow for each method in the type (single-method analysis)
                     foreach (var method in EnumerateMethodsRecursively(type))
                     {
+                        var dataFlowMethodStart = _telemetry.StartTimestamp();
                         _dataFlowAnalyzer.AnalyzeMethod(method);
+                        _telemetry.AddPhaseElapsed("AssemblyScanner.DataFlowAnalyzeMethod",
+                            dataFlowMethodStart);
                     }
                 }
             }
 
             // Phase 2: Analyze cross-method data flows after all methods have been processed
+            var crossMethodStart = _telemetry.StartTimestamp();
             _dataFlowAnalyzer.AnalyzeCrossMethodFlows();
+            _telemetry.AddPhaseElapsed("AssemblyScanner.DataFlowAnalyzeCrossMethodFlows", crossMethodStart);
 
             // Phase 3: Allow rules to refine findings using post-analysis information
             // (e.g., recursive embedded resource scanning, DataFlowAnalyzer chain correlation)
@@ -218,7 +269,10 @@ namespace MLVScan.Services
             {
                 foreach (var rule in _rules)
                 {
+                    _telemetry.IncrementCounter("Assembly.PostAnalysisRuleInvocations");
+                    var postAnalysisStart = _telemetry.StartTimestamp();
                     var refinedFindings = rule.PostAnalysisRefine(module, findings);
+                    _telemetry.AddPhaseElapsed("AssemblyScanner.PostAnalysisRefine", postAnalysisStart);
                     findings.AddRange(refinedFindings);
                 }
             }
@@ -251,6 +305,11 @@ namespace MLVScan.Services
             }
 
             return findings;
+        }
+
+        internal ScanProfileSnapshot? GetLastProfileSnapshot()
+        {
+            return _telemetry.GetLastSnapshot();
         }
 
         private static void CorrelateDataFlowIntoExecutionFindings(List<ScanFinding> findings)

--- a/Services/AssemblyScanner.cs
+++ b/Services/AssemblyScanner.cs
@@ -310,7 +310,7 @@ namespace MLVScan.Services
 
         internal static string CreateAssemblyTelemetryId(string assemblyPath)
         {
-            return Path.GetFileName(assemblyPath);
+            return GetPathLeaf(assemblyPath);
         }
 
         internal static string CreateStreamTelemetryId(string? virtualPath)
@@ -320,12 +320,40 @@ namespace MLVScan.Services
                 return "<stream>";
             }
 
-            if (Path.IsPathRooted(virtualPath))
+            if (IsAbsoluteLikePath(virtualPath))
             {
-                return Path.GetFileName(virtualPath);
+                return GetPathLeaf(virtualPath);
             }
 
             return virtualPath;
+        }
+
+        private static bool IsAbsoluteLikePath(string path)
+        {
+            if (Path.IsPathRooted(path))
+            {
+                return true;
+            }
+
+            if (path.Length >= 3 &&
+                char.IsLetter(path[0]) &&
+                path[1] == ':' &&
+                (path[2] == Path.DirectorySeparatorChar ||
+                 path[2] == Path.AltDirectorySeparatorChar ||
+                 path[2] == '\\' ||
+                 path[2] == '/'))
+            {
+                return true;
+            }
+
+            return path.StartsWith(@"\\", StringComparison.Ordinal) ||
+                   path.StartsWith("//", StringComparison.Ordinal);
+        }
+
+        private static string GetPathLeaf(string path)
+        {
+            int separatorIndex = Math.Max(path.LastIndexOf('/'), path.LastIndexOf('\\'));
+            return separatorIndex >= 0 ? path[(separatorIndex + 1)..] : path;
         }
 
         internal ScanProfileSnapshot? GetLastProfileSnapshot()

--- a/Services/DataFlowAnalyzer.cs
+++ b/Services/DataFlowAnalyzer.cs
@@ -7,17 +7,32 @@ using System.ComponentModel;
 
 namespace MLVScan.Services
 {
+    /// <summary>
+    /// Legacy configuration for the data-flow analysis pipeline.
+    /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("Use ScanConfig to control data flow behavior. DataFlowAnalyzerConfig is an internal pipeline detail and will be removed in v2.0.")]
     public class DataFlowAnalyzerConfig
     {
+        /// <summary>
+        /// Gets or sets a value indicating whether inter-procedural flow analysis is enabled.
+        /// </summary>
         public bool EnableCrossMethodAnalysis { get; set; } = true;
 
+        /// <summary>
+        /// Gets or sets the maximum depth explored when following call chains.
+        /// </summary>
         public int MaxCallChainDepth { get; set; } = 5;
 
+        /// <summary>
+        /// Gets or sets a value indicating whether return values should be tracked through the flow graph.
+        /// </summary>
         public bool EnableReturnValueTracking { get; set; } = true;
     }
 
+    /// <summary>
+    /// Builds method and cross-method data-flow chains for suspicious operations.
+    /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class DataFlowAnalyzer
     {
@@ -28,12 +43,23 @@ namespace MLVScan.Services
         private readonly ScanTelemetryHub _telemetry;
 
 #pragma warning disable CS0618
+        /// <summary>
+        /// Initializes the analyzer with the default legacy configuration.
+        /// </summary>
+        /// <param name="rules">The scan rules used when translating chains into findings.</param>
+        /// <param name="snippetBuilder">Builds code snippets for emitted findings.</param>
         public DataFlowAnalyzer(IEnumerable<IScanRule> rules, CodeSnippetBuilder snippetBuilder)
             : this(rules, snippetBuilder, new DataFlowAnalyzerConfig(), new ScanTelemetryHub())
         {
         }
 #pragma warning restore CS0618
 
+        /// <summary>
+        /// Initializes the analyzer with an explicit legacy configuration.
+        /// </summary>
+        /// <param name="rules">The scan rules used when translating chains into findings.</param>
+        /// <param name="snippetBuilder">Builds code snippets for emitted findings.</param>
+        /// <param name="config">The legacy data-flow configuration to apply.</param>
         [Obsolete("Use the overloads that rely on ScanConfig-driven behavior. DataFlowAnalyzerConfig is an internal pipeline detail and will be removed in v2.0.")]
         public DataFlowAnalyzer(
             IEnumerable<IScanRule> rules,
@@ -43,6 +69,7 @@ namespace MLVScan.Services
         {
         }
 
+#pragma warning disable CS0618
         internal DataFlowAnalyzer(
             IEnumerable<IScanRule> rules,
             CodeSnippetBuilder snippetBuilder,
@@ -79,16 +106,23 @@ namespace MLVScan.Services
 
             _patternEvaluator = new DataFlowPatternEvaluator();
             _methodAnalyzer = new DataFlowMethodAnalyzer(operationClassifier, _patternEvaluator, nodeFactory);
-#pragma warning disable CS0618
             _crossMethodAnalyzer = new CrossMethodDataFlowAnalyzer(_patternEvaluator, nodeFactory, config);
-#pragma warning restore CS0618
         }
+#pragma warning restore CS0618
 
+        /// <summary>
+        /// Clears any previously collected flow state.
+        /// </summary>
         public void Clear()
         {
             _state.Clear();
         }
 
+        /// <summary>
+        /// Analyzes a single method and records the discovered data-flow chains.
+        /// </summary>
+        /// <param name="method">The method to analyze.</param>
+        /// <returns>The chains discovered within the method body.</returns>
         public List<DataFlowChain> AnalyzeMethod(MethodDefinition method)
         {
             if (method?.Body == null || method.Body.Instructions.Count == 0)
@@ -109,6 +143,9 @@ namespace MLVScan.Services
             return analysis.Chains;
         }
 
+        /// <summary>
+        /// Expands the recorded method flows across call boundaries.
+        /// </summary>
         public void AnalyzeCrossMethodFlows()
         {
             var crossMethodStart = _telemetry.StartTimestamp();
@@ -128,6 +165,10 @@ namespace MLVScan.Services
                 _state.CrossMethodChains.Count(static chain => chain.IsSuspicious));
         }
 
+        /// <summary>
+        /// Materializes findings from the recorded flow chains.
+        /// </summary>
+        /// <returns>The findings emitted from suspicious data-flow patterns.</returns>
         public IEnumerable<ScanFinding> BuildDataFlowFindings()
         {
             var buildFindingsStart = _telemetry.StartTimestamp();
@@ -154,14 +195,26 @@ namespace MLVScan.Services
             return findings;
         }
 
+        /// <summary>
+        /// Gets the number of intra-method chains currently stored.
+        /// </summary>
         public int DataFlowChainCount => _state.MethodDataFlows.Values.Sum(static list => list.Count);
 
+        /// <summary>
+        /// Gets the number of suspicious intra-method chains currently stored.
+        /// </summary>
         public int SuspiciousChainCount => _state.MethodDataFlows.Values
             .SelectMany(static list => list)
             .Count(static chain => chain.IsSuspicious);
 
+        /// <summary>
+        /// Gets the number of cross-method chains currently stored.
+        /// </summary>
         public int CrossMethodChainCount => _state.CrossMethodChains.Count;
 
+        /// <summary>
+        /// Gets the number of suspicious cross-method chains currently stored.
+        /// </summary>
         public int SuspiciousCrossMethodChainCount => _state.CrossMethodChains.Count(static chain => chain.IsSuspicious);
     }
 }

--- a/Services/DataFlowAnalyzer.cs
+++ b/Services/DataFlowAnalyzer.cs
@@ -1,6 +1,7 @@
 using MLVScan.Models;
 using MLVScan.Models.Rules;
 using MLVScan.Services.DataFlow;
+using MLVScan.Services.Diagnostics;
 using Mono.Cecil;
 using System.ComponentModel;
 
@@ -24,10 +25,11 @@ namespace MLVScan.Services
         private readonly DataFlowMethodAnalyzer _methodAnalyzer;
         private readonly CrossMethodDataFlowAnalyzer _crossMethodAnalyzer;
         private readonly DataFlowPatternEvaluator _patternEvaluator;
+        private readonly ScanTelemetryHub _telemetry;
 
 #pragma warning disable CS0618
         public DataFlowAnalyzer(IEnumerable<IScanRule> rules, CodeSnippetBuilder snippetBuilder)
-            : this(rules, snippetBuilder, new DataFlowAnalyzerConfig())
+            : this(rules, snippetBuilder, new DataFlowAnalyzerConfig(), new ScanTelemetryHub())
         {
         }
 #pragma warning restore CS0618
@@ -37,6 +39,23 @@ namespace MLVScan.Services
             IEnumerable<IScanRule> rules,
             CodeSnippetBuilder snippetBuilder,
             DataFlowAnalyzerConfig config)
+            : this(rules, snippetBuilder, config, new ScanTelemetryHub())
+        {
+        }
+
+        internal DataFlowAnalyzer(
+            IEnumerable<IScanRule> rules,
+            CodeSnippetBuilder snippetBuilder,
+            ScanTelemetryHub telemetry)
+            : this(rules, snippetBuilder, new DataFlowAnalyzerConfig(), telemetry)
+        {
+        }
+
+        internal DataFlowAnalyzer(
+            IEnumerable<IScanRule> rules,
+            CodeSnippetBuilder snippetBuilder,
+            DataFlowAnalyzerConfig config,
+            ScanTelemetryHub telemetry)
         {
             if (rules == null)
             {
@@ -52,6 +71,8 @@ namespace MLVScan.Services
             {
                 throw new ArgumentNullException(nameof(config));
             }
+
+            _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
 
             var operationClassifier = new DataFlowOperationClassifier();
             var nodeFactory = new DataFlowNodeFactory(snippetBuilder);
@@ -72,28 +93,44 @@ namespace MLVScan.Services
         {
             if (method?.Body == null || method.Body.Instructions.Count == 0)
             {
+                _telemetry.IncrementCounter("DataFlowAnalyzer.MethodsSkipped");
                 return new List<DataFlowChain>();
             }
 
+            var analysisStart = _telemetry.StartTimestamp();
             var analysis = _methodAnalyzer.AnalyzeMethod(method);
+            _telemetry.AddPhaseElapsed("DataFlowAnalyzer.AnalyzeMethod", analysisStart);
             _state.StoreMethodAnalysis(analysis);
+            _telemetry.IncrementCounter("DataFlowAnalyzer.MethodsAnalyzed");
+            _telemetry.IncrementCounter("DataFlowAnalyzer.MethodChainsBuilt", analysis.Chains.Count);
+            _telemetry.IncrementCounter("DataFlowAnalyzer.SuspiciousMethodChains",
+                analysis.Chains.Count(static chain => chain.IsSuspicious));
 
             return analysis.Chains;
         }
 
         public void AnalyzeCrossMethodFlows()
         {
-            foreach (var chain in _crossMethodAnalyzer.Analyze(_state))
+            var crossMethodStart = _telemetry.StartTimestamp();
+            var chains = _crossMethodAnalyzer.Analyze(_state);
+            _telemetry.AddPhaseElapsed("DataFlowAnalyzer.AnalyzeCrossMethodFlows", crossMethodStart);
+            _telemetry.IncrementCounter("DataFlowAnalyzer.CrossMethodChainsBuilt", chains.Count);
+
+            foreach (var chain in chains)
             {
                 if (chain.IsSuspicious)
                 {
                     _state.CrossMethodChains.Add(chain);
                 }
             }
+
+            _telemetry.IncrementCounter("DataFlowAnalyzer.SuspiciousCrossMethodChains",
+                _state.CrossMethodChains.Count(static chain => chain.IsSuspicious));
         }
 
         public IEnumerable<ScanFinding> BuildDataFlowFindings()
         {
+            var buildFindingsStart = _telemetry.StartTimestamp();
             var findings = new List<ScanFinding>();
 
             foreach (var chain in _state.MethodDataFlows.Values.SelectMany(static list => list))
@@ -112,6 +149,8 @@ namespace MLVScan.Services
                 }
             }
 
+            _telemetry.AddPhaseElapsed("DataFlowAnalyzer.BuildDataFlowFindings", buildFindingsStart);
+            _telemetry.IncrementCounter("DataFlowAnalyzer.FindingsEmitted", findings.Count);
             return findings;
         }
 

--- a/Services/Diagnostics/ScanTelemetryHub.cs
+++ b/Services/Diagnostics/ScanTelemetryHub.cs
@@ -1,0 +1,332 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace MLVScan.Services.Diagnostics
+{
+    internal sealed class ScanTelemetryHub
+    {
+        private ScanProfileSnapshot? _lastSnapshot;
+
+#if MLVSCAN_PROFILING
+        private ScanProfileSession? _currentSession;
+#endif
+
+        public void BeginAssembly(string assemblyId)
+        {
+#if MLVSCAN_PROFILING
+            _currentSession = new ScanProfileSession(assemblyId);
+#else
+            _ = assemblyId;
+#endif
+            _lastSnapshot = null;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public long StartTimestamp()
+        {
+#if MLVSCAN_PROFILING
+            return Stopwatch.GetTimestamp();
+#else
+            return 0;
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AddPhaseElapsed(string phaseName, long startTimestamp)
+        {
+#if MLVSCAN_PROFILING
+            if (_currentSession == null || startTimestamp == 0)
+            {
+                return;
+            }
+
+            _currentSession.AddPhaseElapsed(phaseName, Stopwatch.GetTimestamp() - startTimestamp);
+#else
+            _ = phaseName;
+            _ = startTimestamp;
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void IncrementCounter(string counterName, long delta = 1)
+        {
+#if MLVSCAN_PROFILING
+            if (_currentSession == null)
+            {
+                return;
+            }
+
+            _currentSession.IncrementCounter(counterName, delta);
+#else
+            _ = counterName;
+            _ = delta;
+#endif
+        }
+
+        public void RecordTypeSample(
+            string typeName,
+            long startTimestamp,
+            int methodCount,
+            int nestedTypeCount,
+            int findingsCount,
+            int pendingReflectionCount)
+        {
+#if MLVSCAN_PROFILING
+            if (_currentSession == null || startTimestamp == 0)
+            {
+                return;
+            }
+
+            _currentSession.AddTypeSample(
+                typeName,
+                Stopwatch.GetTimestamp() - startTimestamp,
+                methodCount,
+                nestedTypeCount,
+                findingsCount,
+                pendingReflectionCount);
+#else
+            _ = typeName;
+            _ = startTimestamp;
+            _ = methodCount;
+            _ = nestedTypeCount;
+            _ = findingsCount;
+            _ = pendingReflectionCount;
+#endif
+        }
+
+        public void RecordMethodSample(
+            string methodName,
+            long startTimestamp,
+            int instructionCount,
+            int findingsCount,
+            int localVariableCount,
+            int exceptionHandlerCount,
+            int pendingReflectionCount)
+        {
+#if MLVSCAN_PROFILING
+            if (_currentSession == null || startTimestamp == 0)
+            {
+                return;
+            }
+
+            _currentSession.AddMethodSample(
+                methodName,
+                Stopwatch.GetTimestamp() - startTimestamp,
+                instructionCount,
+                findingsCount,
+                localVariableCount,
+                exceptionHandlerCount,
+                pendingReflectionCount);
+#else
+            _ = methodName;
+            _ = startTimestamp;
+            _ = instructionCount;
+            _ = findingsCount;
+            _ = localVariableCount;
+            _ = exceptionHandlerCount;
+            _ = pendingReflectionCount;
+#endif
+        }
+
+        public void CompleteAssembly(int findingsBeforeFilter, int findingsAfterFilter)
+        {
+#if MLVSCAN_PROFILING
+            if (_currentSession == null)
+            {
+                _lastSnapshot = null;
+                return;
+            }
+
+            _currentSession.IncrementCounter("Findings.BeforeFilter", findingsBeforeFilter);
+            _currentSession.IncrementCounter("Findings.AfterFilter", findingsAfterFilter);
+            _currentSession.TotalElapsedTicks = Stopwatch.GetTimestamp() - _currentSession.StartTimestamp;
+            _lastSnapshot = _currentSession.ToSnapshot();
+            _currentSession = null;
+#else
+            _ = findingsBeforeFilter;
+            _ = findingsAfterFilter;
+            _lastSnapshot = null;
+#endif
+        }
+
+        public ScanProfileSnapshot? GetLastSnapshot()
+        {
+            return _lastSnapshot;
+        }
+    }
+
+    internal sealed class ScanProfileSnapshot
+    {
+        public string AssemblyId { get; set; } = string.Empty;
+
+        public long TotalElapsedTicks { get; set; }
+
+        public IReadOnlyList<ScanProfilePhaseTiming> Phases { get; set; } = Array.Empty<ScanProfilePhaseTiming>();
+
+        public IReadOnlyDictionary<string, long> Counters { get; set; } =
+            new Dictionary<string, long>(StringComparer.Ordinal);
+
+        public IReadOnlyList<ScanProfileTypeSample> SlowTypes { get; set; } = Array.Empty<ScanProfileTypeSample>();
+
+        public IReadOnlyList<ScanProfileMethodSample> SlowMethods { get; set; } =
+            Array.Empty<ScanProfileMethodSample>();
+    }
+
+    internal sealed class ScanProfilePhaseTiming
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public long ElapsedTicks { get; set; }
+
+        public int Count { get; set; }
+    }
+
+    internal sealed class ScanProfileTypeSample
+    {
+        public string TypeName { get; set; } = string.Empty;
+
+        public long ElapsedTicks { get; set; }
+
+        public int MethodCount { get; set; }
+
+        public int NestedTypeCount { get; set; }
+
+        public int FindingsCount { get; set; }
+
+        public int PendingReflectionCount { get; set; }
+    }
+
+    internal sealed class ScanProfileMethodSample
+    {
+        public string MethodName { get; set; } = string.Empty;
+
+        public long ElapsedTicks { get; set; }
+
+        public int InstructionCount { get; set; }
+
+        public int FindingsCount { get; set; }
+
+        public int LocalVariableCount { get; set; }
+
+        public int ExceptionHandlerCount { get; set; }
+
+        public int PendingReflectionCount { get; set; }
+    }
+
+#if MLVSCAN_PROFILING
+    internal sealed class ScanProfileSession
+    {
+        private const int MaxTopSamples = 20;
+
+        private readonly Dictionary<string, ScanPhaseAccumulator> _phases = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, long> _counters = new(StringComparer.Ordinal);
+        private readonly List<ScanProfileTypeSample> _typeSamples = new();
+        private readonly List<ScanProfileMethodSample> _methodSamples = new();
+
+        public ScanProfileSession(string assemblyId)
+        {
+            AssemblyId = assemblyId;
+            StartTimestamp = Stopwatch.GetTimestamp();
+        }
+
+        public string AssemblyId { get; }
+
+        public long StartTimestamp { get; }
+
+        public long TotalElapsedTicks { get; set; }
+
+        public void AddPhaseElapsed(string phaseName, long elapsedTicks)
+        {
+            if (!_phases.TryGetValue(phaseName, out var accumulator))
+            {
+                accumulator = new ScanPhaseAccumulator();
+                _phases[phaseName] = accumulator;
+            }
+
+            accumulator.ElapsedTicks += elapsedTicks;
+            accumulator.Count++;
+        }
+
+        public void IncrementCounter(string counterName, long delta)
+        {
+            _counters[counterName] = _counters.TryGetValue(counterName, out var current)
+                ? current + delta
+                : delta;
+        }
+
+        public void AddTypeSample(
+            string typeName,
+            long elapsedTicks,
+            int methodCount,
+            int nestedTypeCount,
+            int findingsCount,
+            int pendingReflectionCount)
+        {
+            _typeSamples.Add(new ScanProfileTypeSample
+            {
+                TypeName = typeName,
+                ElapsedTicks = elapsedTicks,
+                MethodCount = methodCount,
+                NestedTypeCount = nestedTypeCount,
+                FindingsCount = findingsCount,
+                PendingReflectionCount = pendingReflectionCount
+            });
+        }
+
+        public void AddMethodSample(
+            string methodName,
+            long elapsedTicks,
+            int instructionCount,
+            int findingsCount,
+            int localVariableCount,
+            int exceptionHandlerCount,
+            int pendingReflectionCount)
+        {
+            _methodSamples.Add(new ScanProfileMethodSample
+            {
+                MethodName = methodName,
+                ElapsedTicks = elapsedTicks,
+                InstructionCount = instructionCount,
+                FindingsCount = findingsCount,
+                LocalVariableCount = localVariableCount,
+                ExceptionHandlerCount = exceptionHandlerCount,
+                PendingReflectionCount = pendingReflectionCount
+            });
+        }
+
+        public ScanProfileSnapshot ToSnapshot()
+        {
+            return new ScanProfileSnapshot
+            {
+                AssemblyId = AssemblyId,
+                TotalElapsedTicks = TotalElapsedTicks,
+                Phases = _phases
+                    .OrderByDescending(static pair => pair.Value.ElapsedTicks)
+                    .Select(static pair => new ScanProfilePhaseTiming
+                    {
+                        Name = pair.Key,
+                        ElapsedTicks = pair.Value.ElapsedTicks,
+                        Count = pair.Value.Count
+                    })
+                    .ToArray(),
+                Counters = new Dictionary<string, long>(_counters, StringComparer.Ordinal),
+                SlowTypes = _typeSamples
+                    .OrderByDescending(static sample => sample.ElapsedTicks)
+                    .Take(MaxTopSamples)
+                    .ToArray(),
+                SlowMethods = _methodSamples
+                    .OrderByDescending(static sample => sample.ElapsedTicks)
+                    .Take(MaxTopSamples)
+                    .ToArray()
+            };
+        }
+    }
+
+    internal sealed class ScanPhaseAccumulator
+    {
+        public long ElapsedTicks { get; set; }
+
+        public int Count { get; set; }
+    }
+#endif
+}

--- a/Services/Helpers/RuleOverrideChecker.cs
+++ b/Services/Helpers/RuleOverrideChecker.cs
@@ -1,0 +1,20 @@
+using MLVScan.Models;
+using System.Reflection;
+
+namespace MLVScan.Services.Helpers
+{
+    internal static class RuleOverrideChecker
+    {
+        public static bool OverridesRuleMethod(IScanRule rule, string methodName, params Type[] parameterTypes)
+        {
+            var method = rule.GetType().GetMethod(
+                methodName,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                binder: null,
+                types: parameterTypes,
+                modifiers: null);
+
+            return method != null && method.DeclaringType != typeof(IScanRule);
+        }
+    }
+}

--- a/Services/InstructionAnalyzer.cs
+++ b/Services/InstructionAnalyzer.cs
@@ -5,7 +5,6 @@ using MLVScan.Services.Helpers;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using System.ComponentModel;
-using System.Reflection;
 
 namespace MLVScan.Services
 {
@@ -73,7 +72,7 @@ namespace MLVScan.Services
 
             _rules = rules.ToArray();
             _contextualPatternRules = _rules
-                .Where(static rule => OverridesRuleMethod(rule, nameof(IScanRule.AnalyzeContextualPattern),
+                .Where(static rule => RuleOverrideChecker.OverridesRuleMethod(rule, nameof(IScanRule.AnalyzeContextualPattern),
                     typeof(MethodReference),
                     typeof(Mono.Collections.Generic.Collection<Instruction>),
                     typeof(int),
@@ -385,13 +384,12 @@ namespace MLVScan.Services
                         {
                             result.Findings.Add(finding);
                             _telemetry.IncrementCounter("InstructionAnalyzer.ReflectionBypassFindings");
-                            var reflectionRuleForFinding = _rules.FirstOrDefault(r => r is ReflectionRule);
-                            if (methodSignals != null && reflectionRuleForFinding != null &&
-                                !(reflectionRuleForFinding.RequiresCompanionFinding &&
-                                  finding.Severity == Severity.Low))
+                            if (methodSignals != null && _reflectionRule != null &&
+                                !(_reflectionRule.RequiresCompanionFinding &&
+                                   finding.Severity == Severity.Low))
                             {
                                 _signalTracker.MarkRuleTriggered(methodSignals, method.DeclaringType,
-                                    reflectionRuleForFinding.RuleId);
+                                    _reflectionRule.RuleId);
                             }
                         }
                     }
@@ -475,18 +473,6 @@ namespace MLVScan.Services
             }
 
             return false;
-        }
-
-        private static bool OverridesRuleMethod(IScanRule rule, string methodName, params Type[] parameterTypes)
-        {
-            var method = rule.GetType().GetMethod(
-                methodName,
-                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-                binder: null,
-                types: parameterTypes,
-                modifiers: null);
-
-            return method != null && method.DeclaringType != typeof(IScanRule);
         }
     }
 }

--- a/Services/InstructionAnalyzer.cs
+++ b/Services/InstructionAnalyzer.cs
@@ -1,9 +1,11 @@
 using MLVScan.Models;
 using MLVScan.Models.Rules;
+using MLVScan.Services.Diagnostics;
 using MLVScan.Services.Helpers;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using System.ComponentModel;
+using System.Reflection;
 
 namespace MLVScan.Services
 {
@@ -28,27 +30,51 @@ namespace MLVScan.Services
             "ByteArrayManipulationRule"
         };
 
-        private readonly IEnumerable<IScanRule> _rules;
+        private readonly IReadOnlyList<IScanRule> _rules;
+        private readonly IReadOnlyList<IScanRule> _contextualPatternRules;
         private readonly SignalTracker _signalTracker;
         private readonly ReflectionDetector _reflectionDetector;
         private readonly StringPatternDetector _stringPatternDetector;
         private readonly CodeSnippetBuilder _snippetBuilder;
         private readonly ScanConfig _config;
         private readonly CallGraphBuilder? _callGraphBuilder;
+        private readonly IScanRule? _reflectionRule;
+        private readonly ScanTelemetryHub _telemetry;
 
         public InstructionAnalyzer(IEnumerable<IScanRule> rules, SignalTracker signalTracker,
             ReflectionDetector reflectionDetector,
             StringPatternDetector stringPatternDetector, CodeSnippetBuilder snippetBuilder, ScanConfig config,
             CallGraphBuilder? callGraphBuilder = null)
+            : this(rules, signalTracker, reflectionDetector, stringPatternDetector, snippetBuilder, config,
+                new ScanTelemetryHub(), callGraphBuilder)
         {
-            _rules = rules ?? throw new ArgumentNullException(nameof(rules));
+        }
+
+        internal InstructionAnalyzer(IEnumerable<IScanRule> rules, SignalTracker signalTracker,
+            ReflectionDetector reflectionDetector,
+            StringPatternDetector stringPatternDetector, CodeSnippetBuilder snippetBuilder, ScanConfig config,
+            ScanTelemetryHub telemetry, CallGraphBuilder? callGraphBuilder = null)
+        {
+            if (rules == null)
+                throw new ArgumentNullException(nameof(rules));
+
+            _rules = rules.ToArray();
+            _contextualPatternRules = _rules
+                .Where(static rule => OverridesRuleMethod(rule, nameof(IScanRule.AnalyzeContextualPattern),
+                    typeof(MethodReference),
+                    typeof(Mono.Collections.Generic.Collection<Instruction>),
+                    typeof(int),
+                    typeof(MethodSignals)))
+                .ToArray();
             _signalTracker = signalTracker ?? throw new ArgumentNullException(nameof(signalTracker));
             _reflectionDetector = reflectionDetector ?? throw new ArgumentNullException(nameof(reflectionDetector));
             _stringPatternDetector =
                 stringPatternDetector ?? throw new ArgumentNullException(nameof(stringPatternDetector));
             _snippetBuilder = snippetBuilder ?? throw new ArgumentNullException(nameof(snippetBuilder));
             _config = config ?? new ScanConfig();
+            _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
             _callGraphBuilder = callGraphBuilder;
+            _reflectionRule = _rules.FirstOrDefault(static rule => rule is ReflectionRule);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -68,10 +94,15 @@ namespace MLVScan.Services
             MethodSignals? methodSignals, string typeFullName)
         {
             var result = new InstructionAnalysisResult();
+            var analysisStart = _telemetry.StartTimestamp();
+            _telemetry.IncrementCounter("InstructionAnalyzer.MethodsAnalyzed");
+            _telemetry.IncrementCounter("InstructionAnalyzer.InstructionsVisited", instructions.Count);
 
             // Build set of instruction offsets inside exception handlers
             // These are analyzed by ExceptionHandlerAnalyzer with proper context, skip here to prevent duplicates
+            var exceptionOffsetStart = _telemetry.StartTimestamp();
             var exceptionHandlerOffsets = BuildExceptionHandlerOffsets(method, instructions);
+            _telemetry.AddPhaseElapsed("InstructionAnalyzer.BuildExceptionHandlerOffsets", exceptionOffsetStart);
 
             for (int i = 0; i < instructions.Count; i++)
             {
@@ -82,10 +113,16 @@ namespace MLVScan.Services
                     if ((instruction.OpCode == OpCodes.Call || instruction.OpCode == OpCodes.Callvirt) &&
                         instruction.Operand is MethodReference calledMethod)
                     {
+                        _telemetry.IncrementCounter("InstructionAnalyzer.CallInstructions");
+                        HashSet<string>? contextualRuleIdsWithFindings = null;
+
                         // Track signals for multi-pattern detection
                         if (methodSignals != null)
                         {
+                            var signalUpdateStart = _telemetry.StartTimestamp();
                             _signalTracker.UpdateMethodSignals(methodSignals, calledMethod, method.DeclaringType);
+                            _telemetry.AddPhaseElapsed("InstructionAnalyzer.UpdateMethodSignals",
+                                signalUpdateStart);
 
                             // Check for Environment.GetFolderPath with sensitive folder values (for signal tracking)
                             if (calledMethod.DeclaringType?.FullName == "System.Environment" &&
@@ -105,6 +142,7 @@ namespace MLVScan.Services
 
                         if (isCallToTrackedSuspiciousMethod)
                         {
+                            _telemetry.IncrementCounter("InstructionAnalyzer.CallGraphTrackedCalls");
                             // Register this call site with the call graph builder instead of creating a finding
                             var snippet = _snippetBuilder.BuildSnippet(instructions, i, 8);
                             var invocationContext =
@@ -116,7 +154,7 @@ namespace MLVScan.Services
                             // Mark rule as triggered for signal tracking
                             if (methodSignals != null)
                             {
-                                var rule = _rules.FirstOrDefault(r => r.IsSuspicious(calledMethod));
+                                var rule = FindFirstSuspiciousRule(calledMethod);
                                 if (rule != null)
                                 {
                                     _signalTracker.MarkRuleTriggered(methodSignals, method.DeclaringType, rule.RuleId);
@@ -131,11 +169,14 @@ namespace MLVScan.Services
                         // Those are already analyzed by ExceptionHandlerAnalyzer with proper context
                         if (!exceptionHandlerOffsets.Contains(instruction.Offset))
                         {
-                            // Call AnalyzeContextualPattern for all rules
-                            foreach (var rule in _rules)
+                            foreach (var rule in _contextualPatternRules)
                             {
+                                _telemetry.IncrementCounter("InstructionAnalyzer.ContextualRuleInvocations");
+                                var contextualRuleStart = _telemetry.StartTimestamp();
                                 var ruleFindings =
                                     rule.AnalyzeContextualPattern(calledMethod, instructions, i, methodSignals);
+                                _telemetry.AddPhaseElapsed("InstructionAnalyzer.ContextualRuleDispatch",
+                                    contextualRuleStart);
                                 foreach (var finding in ruleFindings)
                                 {
                                     // If rule requires companion finding, check if other rules have been triggered
@@ -168,6 +209,9 @@ namespace MLVScan.Services
                                     // Enrich finding with rule metadata
                                     finding.WithRuleMetadata(rule);
                                     result.Findings.Add(finding);
+                                    _telemetry.IncrementCounter("InstructionAnalyzer.ContextualFindings");
+                                    contextualRuleIdsWithFindings ??= new HashSet<string>(StringComparer.Ordinal);
+                                    contextualRuleIdsWithFindings.Add(rule.RuleId);
                                     if (methodSignals != null &&
                                         !(rule.RequiresCompanionFinding && finding.Severity == Severity.Low))
                                     {
@@ -177,12 +221,20 @@ namespace MLVScan.Services
                                 }
                             }
                         } // end exception handler skip
+                        else
+                        {
+                            _telemetry.IncrementCounter("InstructionAnalyzer.ExceptionHandlerSkippedCalls");
+                        }
 
                         // For reflection invocations, only flag if combined with other malicious patterns
+                        var reflectionHandlingStart = _telemetry.StartTimestamp();
                         bool isReflectionInvoke = _reflectionDetector.IsReflectionInvokeMethod(calledMethod);
+                        _telemetry.AddPhaseElapsed("InstructionAnalyzer.ReflectionInvokeCheck",
+                            reflectionHandlingStart);
                         if (isReflectionInvoke)
                         {
-                            var reflectionRule = _rules.FirstOrDefault(r => r is ReflectionRule);
+                            _telemetry.IncrementCounter("InstructionAnalyzer.ReflectionInvokes");
+                            var reflectionRule = _reflectionRule;
                             if (reflectionRule == null)
                                 continue;
 
@@ -210,6 +262,7 @@ namespace MLVScan.Services
                                 {
                                     result.PendingReflectionFindings.Add((method, instruction, i, instructions,
                                         methodSignals));
+                                    _telemetry.IncrementCounter("InstructionAnalyzer.PendingReflectionQueued");
                                 }
 
                                 continue;
@@ -224,6 +277,7 @@ namespace MLVScan.Services
                                 reflectionRule.Severity,
                                 snippet).WithRuleMetadata(reflectionRule);
                             result.Findings.Add(finding);
+                            _telemetry.IncrementCounter("InstructionAnalyzer.ReflectionFindings");
                             if (methodSignals != null && !(reflectionRule.RequiresCompanionFinding &&
                                                            finding.Severity == Severity.Low))
                             {
@@ -238,47 +292,69 @@ namespace MLVScan.Services
                         // but we also need to skip if the method is tracked (for methods matched by rules)
                         if (!exceptionHandlerOffsets.Contains(instruction.Offset) &&
                             !isCallToTrackedSuspiciousMethod &&
-                            !isReflectionInvoke &&
-                            _rules.Any(r => r.IsSuspicious(calledMethod)))
+                            !isReflectionInvoke)
                         {
-                            var rule = _rules.First(r => r.IsSuspicious(calledMethod));
-
-                            // Get type-level signals for cross-method detection (e.g., file writes in other methods)
-                            MethodSignals? typeSignals = null;
-                            if (!string.IsNullOrEmpty(typeFullName))
+                            var suspiciousRuleStart = _telemetry.StartTimestamp();
+                            var rule = FindFirstSuspiciousRule(calledMethod);
+                            _telemetry.AddPhaseElapsed("InstructionAnalyzer.FindFirstSuspiciousRule",
+                                suspiciousRuleStart);
+                            if (rule != null)
                             {
-                                typeSignals = _signalTracker.GetTypeSignals(typeFullName);
-                            }
+                                _telemetry.IncrementCounter("InstructionAnalyzer.DirectSuspiciousMatches");
+                                if (contextualRuleIdsWithFindings?.Contains(rule.RuleId) == true)
+                                {
+                                    continue;
+                                }
 
-                            // Check if rule wants to suppress this finding based on contextual analysis
-                            if (rule.ShouldSuppressFinding(calledMethod, instructions, i, methodSignals, typeSignals))
-                            {
-                                continue;
-                            }
+                                // Get type-level signals for cross-method detection (e.g., file writes in other methods)
+                                MethodSignals? typeSignals = null;
+                                if (!string.IsNullOrEmpty(typeFullName))
+                                {
+                                    typeSignals = _signalTracker.GetTypeSignals(typeFullName);
+                                }
 
-                            var snippet = _snippetBuilder.BuildSnippet(instructions, i, 2);
+                                // Check if rule wants to suppress this finding based on contextual analysis
+                                var suppressFindingStart = _telemetry.StartTimestamp();
+                                if (rule.ShouldSuppressFinding(calledMethod, instructions, i, methodSignals, typeSignals))
+                                {
+                                    _telemetry.AddPhaseElapsed("InstructionAnalyzer.ShouldSuppressFinding",
+                                        suppressFindingStart);
+                                    _telemetry.IncrementCounter("InstructionAnalyzer.SuppressedFindings");
+                                    continue;
+                                }
+                                _telemetry.AddPhaseElapsed("InstructionAnalyzer.ShouldSuppressFinding",
+                                    suppressFindingStart);
 
-                            var description = rule.GetFindingDescription(method, calledMethod, instructions, i);
+                                var snippet = _snippetBuilder.BuildSnippet(instructions, i, 2);
 
-                            var finding = new ScanFinding(
-                                $"{method.DeclaringType?.FullName}.{method.Name}:{instruction.Offset}",
-                                description,
-                                rule.Severity,
-                                snippet).WithRuleMetadata(rule);
-                            result.Findings.Add(finding);
-                            if (methodSignals != null &&
-                                !(rule.RequiresCompanionFinding && finding.Severity == Severity.Low))
-                            {
-                                _signalTracker.MarkRuleTriggered(methodSignals, method.DeclaringType, rule.RuleId);
+                                var description = rule.GetFindingDescription(method, calledMethod, instructions, i);
+
+                                var finding = new ScanFinding(
+                                    $"{method.DeclaringType?.FullName}.{method.Name}:{instruction.Offset}",
+                                    description,
+                                    rule.Severity,
+                                    snippet).WithRuleMetadata(rule);
+                                result.Findings.Add(finding);
+                                _telemetry.IncrementCounter("InstructionAnalyzer.DirectFindings");
+                                if (methodSignals != null &&
+                                    !(rule.RequiresCompanionFinding && finding.Severity == Severity.Low))
+                                {
+                                    _signalTracker.MarkRuleTriggered(methodSignals, method.DeclaringType,
+                                        rule.RuleId);
+                                }
                             }
                         }
 
                         // Check for reflection-based calls that might bypass detection
+                        var reflectionDetectorStart = _telemetry.StartTimestamp();
                         var reflectionFindings = _reflectionDetector.ScanForReflectionInvocation(method, instruction,
                             calledMethod, i, instructions, methodSignals);
+                        _telemetry.AddPhaseElapsed("InstructionAnalyzer.ReflectionDetector",
+                            reflectionDetectorStart);
                         foreach (var finding in reflectionFindings)
                         {
                             result.Findings.Add(finding);
+                            _telemetry.IncrementCounter("InstructionAnalyzer.ReflectionBypassFindings");
                             var reflectionRuleForFinding = _rules.FirstOrDefault(r => r is ReflectionRule);
                             if (methodSignals != null && reflectionRuleForFinding != null &&
                                 !(reflectionRuleForFinding.RequiresCompanionFinding &&
@@ -296,7 +372,21 @@ namespace MLVScan.Services
                 }
             }
 
+            _telemetry.AddPhaseElapsed("InstructionAnalyzer.AnalyzeInstructions", analysisStart);
             return result;
+        }
+
+        private IScanRule? FindFirstSuspiciousRule(MethodReference calledMethod)
+        {
+            foreach (var rule in _rules)
+            {
+                if (rule.IsSuspicious(calledMethod))
+                {
+                    return rule;
+                }
+            }
+
+            return null;
         }
 
         /// <summary>
@@ -346,6 +436,18 @@ namespace MLVScan.Services
             }
 
             return false;
+        }
+
+        private static bool OverridesRuleMethod(IScanRule rule, string methodName, params Type[] parameterTypes)
+        {
+            var method = rule.GetType().GetMethod(
+                methodName,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                binder: null,
+                types: parameterTypes,
+                modifiers: null);
+
+            return method != null && method.DeclaringType != typeof(IScanRule);
         }
     }
 }

--- a/Services/InstructionAnalyzer.cs
+++ b/Services/InstructionAnalyzer.cs
@@ -9,6 +9,9 @@ using System.Reflection;
 
 namespace MLVScan.Services
 {
+    /// <summary>
+    /// Analyzes method bodies for suspicious instruction-level patterns and contextual rule matches.
+    /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class InstructionAnalyzer
     {
@@ -41,6 +44,16 @@ namespace MLVScan.Services
         private readonly IScanRule? _reflectionRule;
         private readonly ScanTelemetryHub _telemetry;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InstructionAnalyzer"/> class.
+        /// </summary>
+        /// <param name="rules">The rules that participate in instruction analysis.</param>
+        /// <param name="signalTracker">Tracks method and type-level signals across analysis passes.</param>
+        /// <param name="reflectionDetector">Evaluates reflection-based bypass patterns.</param>
+        /// <param name="stringPatternDetector">Detects suspicious string-based context around calls.</param>
+        /// <param name="snippetBuilder">Builds snippets for emitted findings.</param>
+        /// <param name="config">Controls instruction-analysis behavior.</param>
+        /// <param name="callGraphBuilder">Optional call-graph collector used for consolidated findings.</param>
         public InstructionAnalyzer(IEnumerable<IScanRule> rules, SignalTracker signalTracker,
             ReflectionDetector reflectionDetector,
             StringPatternDetector stringPatternDetector, CodeSnippetBuilder snippetBuilder, ScanConfig config,
@@ -77,11 +90,20 @@ namespace MLVScan.Services
             _reflectionRule = _rules.FirstOrDefault(static rule => rule is ReflectionRule);
         }
 
+        /// <summary>
+        /// Represents the findings gathered from a single instruction-analysis pass.
+        /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public class InstructionAnalysisResult
         {
+            /// <summary>
+            /// Gets or sets the findings emitted during instruction analysis.
+            /// </summary>
             public List<ScanFinding> Findings { get; set; } = new List<ScanFinding>();
 
+            /// <summary>
+            /// Gets or sets reflection findings that must be revisited after type-level signals are collected.
+            /// </summary>
             public List<(MethodDefinition method, Instruction instruction, int index,
                     Mono.Collections.Generic.Collection<Instruction> instructions, MethodSignals? methodSignals)>
                 PendingReflectionFindings { get; set; } =
@@ -89,11 +111,20 @@ namespace MLVScan.Services
                     MethodSignals?)>();
         }
 
+        /// <summary>
+        /// Analyzes a method body for contextual rule matches, direct suspicious calls, and reflection bypasses.
+        /// </summary>
+        /// <param name="method">The method being analyzed.</param>
+        /// <param name="instructions">The method instructions.</param>
+        /// <param name="methodSignals">Optional signal state collected for the current method.</param>
+        /// <param name="typeFullName">The declaring type's full name for type-level signal correlation.</param>
+        /// <returns>The findings and deferred reflection work collected for the method.</returns>
         public InstructionAnalysisResult AnalyzeInstructions(MethodDefinition method,
             Mono.Collections.Generic.Collection<Instruction> instructions,
             MethodSignals? methodSignals, string typeFullName)
         {
             var result = new InstructionAnalysisResult();
+            var effectiveMethodSignals = methodSignals ?? _signalTracker.CreateMethodSignals() ?? new MethodSignals();
             var analysisStart = _telemetry.StartTimestamp();
             _telemetry.IncrementCounter("InstructionAnalyzer.MethodsAnalyzed");
             _telemetry.IncrementCounter("InstructionAnalyzer.InstructionsVisited", instructions.Count);
@@ -114,7 +145,6 @@ namespace MLVScan.Services
                         instruction.Operand is MethodReference calledMethod)
                     {
                         _telemetry.IncrementCounter("InstructionAnalyzer.CallInstructions");
-                        HashSet<string>? contextualRuleIdsWithFindings = null;
 
                         // Track signals for multi-pattern detection
                         if (methodSignals != null)
@@ -174,7 +204,8 @@ namespace MLVScan.Services
                                 _telemetry.IncrementCounter("InstructionAnalyzer.ContextualRuleInvocations");
                                 var contextualRuleStart = _telemetry.StartTimestamp();
                                 var ruleFindings =
-                                    rule.AnalyzeContextualPattern(calledMethod, instructions, i, methodSignals);
+                                    rule.AnalyzeContextualPattern(calledMethod, instructions, i,
+                                        effectiveMethodSignals);
                                 _telemetry.AddPhaseElapsed("InstructionAnalyzer.ContextualRuleDispatch",
                                     contextualRuleStart);
                                 foreach (var finding in ruleFindings)
@@ -210,8 +241,6 @@ namespace MLVScan.Services
                                     finding.WithRuleMetadata(rule);
                                     result.Findings.Add(finding);
                                     _telemetry.IncrementCounter("InstructionAnalyzer.ContextualFindings");
-                                    contextualRuleIdsWithFindings ??= new HashSet<string>(StringComparer.Ordinal);
-                                    contextualRuleIdsWithFindings.Add(rule.RuleId);
                                     if (methodSignals != null &&
                                         !(rule.RequiresCompanionFinding && finding.Severity == Severity.Low))
                                     {
@@ -235,54 +264,54 @@ namespace MLVScan.Services
                         {
                             _telemetry.IncrementCounter("InstructionAnalyzer.ReflectionInvokes");
                             var reflectionRule = _reflectionRule;
-                            if (reflectionRule == null)
-                                continue;
-
-                            // Check if strong companion rules have been triggered (not just any rule).
-                            bool hasOtherTriggeredRules =
-                                HasStrongReflectionCompanion(methodSignals, reflectionRule.RuleId);
-
-                            // Also check type-level triggered rules
-                            bool hasTypeLevelTriggeredRules = false;
-                            if (!string.IsNullOrEmpty(typeFullName))
+                            if (reflectionRule != null)
                             {
-                                var typeSignal = _signalTracker.GetTypeSignals(typeFullName);
-                                if (typeSignal != null)
-                                {
-                                    hasTypeLevelTriggeredRules =
-                                        HasStrongReflectionCompanion(typeSignal, reflectionRule.RuleId);
-                                }
-                            }
+                                // Check if strong companion rules have been triggered (not just any rule).
+                                bool hasOtherTriggeredRules =
+                                    HasStrongReflectionCompanion(methodSignals, reflectionRule.RuleId);
 
-                            // If no other rules have been triggered, queue for later processing
-                            if (!hasOtherTriggeredRules && !hasTypeLevelTriggeredRules)
-                            {
-                                // Queue for later processing after all methods in type are scanned
-                                if (_config.EnableMultiSignalDetection && method.DeclaringType != null)
+                                // Also check type-level triggered rules
+                                bool hasTypeLevelTriggeredRules = false;
+                                if (!string.IsNullOrEmpty(typeFullName))
                                 {
-                                    result.PendingReflectionFindings.Add((method, instruction, i, instructions,
-                                        methodSignals));
-                                    _telemetry.IncrementCounter("InstructionAnalyzer.PendingReflectionQueued");
+                                    var typeSignal = _signalTracker.GetTypeSignals(typeFullName);
+                                    if (typeSignal != null)
+                                    {
+                                        hasTypeLevelTriggeredRules =
+                                            HasStrongReflectionCompanion(typeSignal, reflectionRule.RuleId);
+                                    }
                                 }
 
-                                continue;
-                            }
+                                // If no other rules have been triggered, queue for later processing
+                                if (!hasOtherTriggeredRules && !hasTypeLevelTriggeredRules)
+                                {
+                                    // Queue for later processing after all methods in type are scanned
+                                    if (_config.EnableMultiSignalDetection && method.DeclaringType != null)
+                                    {
+                                        result.PendingReflectionFindings.Add((method, instruction, i, instructions,
+                                            methodSignals));
+                                        _telemetry.IncrementCounter("InstructionAnalyzer.PendingReflectionQueued");
+                                    }
+                                }
+                                else
+                                {
+                                    // Reflection combined with other triggered rules is suspicious
+                                    var snippet = _snippetBuilder.BuildSnippet(instructions, i, 2);
 
-                            // Reflection combined with other triggered rules is suspicious
-                            var snippet = _snippetBuilder.BuildSnippet(instructions, i, 2);
-
-                            var finding = new ScanFinding(
-                                $"{method.DeclaringType?.FullName}.{method.Name}:{instruction.Offset}",
-                                reflectionRule.Description + " (combined with other suspicious patterns)",
-                                reflectionRule.Severity,
-                                snippet).WithRuleMetadata(reflectionRule);
-                            result.Findings.Add(finding);
-                            _telemetry.IncrementCounter("InstructionAnalyzer.ReflectionFindings");
-                            if (methodSignals != null && !(reflectionRule.RequiresCompanionFinding &&
-                                                           finding.Severity == Severity.Low))
-                            {
-                                _signalTracker.MarkRuleTriggered(methodSignals, method.DeclaringType,
-                                    reflectionRule.RuleId);
+                                    var finding = new ScanFinding(
+                                        $"{method.DeclaringType?.FullName}.{method.Name}:{instruction.Offset}",
+                                        reflectionRule.Description + " (combined with other suspicious patterns)",
+                                        reflectionRule.Severity,
+                                        snippet).WithRuleMetadata(reflectionRule);
+                                    result.Findings.Add(finding);
+                                    _telemetry.IncrementCounter("InstructionAnalyzer.ReflectionFindings");
+                                    if (methodSignals != null && !(reflectionRule.RequiresCompanionFinding &&
+                                                                   finding.Severity == Severity.Low))
+                                    {
+                                        _signalTracker.MarkRuleTriggered(methodSignals, method.DeclaringType,
+                                            reflectionRule.RuleId);
+                                    }
+                                }
                             }
                         }
 
@@ -301,11 +330,6 @@ namespace MLVScan.Services
                             if (rule != null)
                             {
                                 _telemetry.IncrementCounter("InstructionAnalyzer.DirectSuspiciousMatches");
-                                if (contextualRuleIdsWithFindings?.Contains(rule.RuleId) == true)
-                                {
-                                    continue;
-                                }
-
                                 // Get type-level signals for cross-method detection (e.g., file writes in other methods)
                                 MethodSignals? typeSignals = null;
                                 if (!string.IsNullOrEmpty(typeFullName))
@@ -315,7 +339,8 @@ namespace MLVScan.Services
 
                                 // Check if rule wants to suppress this finding based on contextual analysis
                                 var suppressFindingStart = _telemetry.StartTimestamp();
-                                if (rule.ShouldSuppressFinding(calledMethod, instructions, i, methodSignals, typeSignals))
+                                if (rule.ShouldSuppressFinding(calledMethod, instructions, i, effectiveMethodSignals,
+                                        typeSignals))
                                 {
                                     _telemetry.AddPhaseElapsed("InstructionAnalyzer.ShouldSuppressFinding",
                                         suppressFindingStart);
@@ -334,6 +359,11 @@ namespace MLVScan.Services
                                     description,
                                     rule.Severity,
                                     snippet).WithRuleMetadata(rule);
+                                if (HasEquivalentFinding(result.Findings, finding))
+                                {
+                                    continue;
+                                }
+
                                 result.Findings.Add(finding);
                                 _telemetry.IncrementCounter("InstructionAnalyzer.DirectFindings");
                                 if (methodSignals != null &&
@@ -387,6 +417,15 @@ namespace MLVScan.Services
             }
 
             return null;
+        }
+
+        private static bool HasEquivalentFinding(IEnumerable<ScanFinding> findings, ScanFinding candidate)
+        {
+            return findings.Any(existing =>
+                string.Equals(existing.RuleId, candidate.RuleId, StringComparison.Ordinal) &&
+                string.Equals(existing.Location, candidate.Location, StringComparison.Ordinal) &&
+                string.Equals(existing.Description, candidate.Description, StringComparison.Ordinal) &&
+                existing.Severity == candidate.Severity);
         }
 
         /// <summary>

--- a/Services/LocalVariableAnalyzer.cs
+++ b/Services/LocalVariableAnalyzer.cs
@@ -14,15 +14,19 @@ namespace MLVScan.Services
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class LocalVariableAnalyzer
     {
-        private readonly IEnumerable<IScanRule> _rules;
+        private readonly IReadOnlyList<IScanRule> _localVariableRules;
         private readonly SignalTracker _signalTracker;
         private readonly ScanConfig _config;
 
         public LocalVariableAnalyzer(IEnumerable<IScanRule> rules, SignalTracker signalTracker, ScanConfig config)
         {
-            _rules = rules ?? throw new ArgumentNullException(nameof(rules));
+            if (rules == null)
+                throw new ArgumentNullException(nameof(rules));
             _signalTracker = signalTracker ?? throw new ArgumentNullException(nameof(signalTracker));
             _config = config ?? new ScanConfig();
+            _localVariableRules = rules
+                .Where(static rule => rule is SuspiciousLocalVariableRule)
+                .ToArray();
         }
 
         public IEnumerable<ScanFinding> AnalyzeLocalVariables(MethodDefinition method,
@@ -35,9 +39,7 @@ namespace MLVScan.Services
 
             try
             {
-                // Run AnalyzeInstructions on all rules (not just SuspiciousLocalVariableRule)
-                // This allows any rule to analyze local variables based on their own logic
-                foreach (var rule in _rules)
+                foreach (var rule in _localVariableRules)
                 {
                     var ruleFindings = rule.AnalyzeInstructions(method, method.Body.Instructions, methodSignals);
 

--- a/Services/LocalVariableAnalyzer.cs
+++ b/Services/LocalVariableAnalyzer.cs
@@ -86,9 +86,9 @@ namespace MLVScan.Services
                     }
                 }
 
-                if (methodSignals?.HasSuspiciousLocalVariables == true)
+                if (effectiveMethodSignals.HasSuspiciousLocalVariables)
                 {
-                    _signalTracker.MarkSuspiciousLocalVariables(methodSignals, method.DeclaringType);
+                    _signalTracker.MarkSuspiciousLocalVariables(effectiveMethodSignals, method.DeclaringType);
                 }
             }
             catch (Exception)

--- a/Services/LocalVariableAnalyzer.cs
+++ b/Services/LocalVariableAnalyzer.cs
@@ -18,21 +18,36 @@ namespace MLVScan.Services
         private readonly SignalTracker _signalTracker;
         private readonly ScanConfig _config;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LocalVariableAnalyzer"/> class.
+        /// </summary>
+        /// <param name="rules">The rules available to the local-variable pass.</param>
+        /// <param name="signalTracker">Tracks method and type-level signals.</param>
+        /// <param name="config">Controls whether local-variable analysis is enabled.</param>
         public LocalVariableAnalyzer(IEnumerable<IScanRule> rules, SignalTracker signalTracker, ScanConfig config)
         {
             if (rules == null)
                 throw new ArgumentNullException(nameof(rules));
             _signalTracker = signalTracker ?? throw new ArgumentNullException(nameof(signalTracker));
             _config = config ?? new ScanConfig();
+            // Only rules that explicitly inspect local-variable state participate in this early pass.
             _localVariableRules = rules
                 .Where(static rule => rule is SuspiciousLocalVariableRule)
                 .ToArray();
         }
 
+        /// <summary>
+        /// Analyzes method locals and updates supporting signals used by later rule passes.
+        /// </summary>
+        /// <param name="method">The method whose locals are being inspected.</param>
+        /// <param name="variables">The local variables declared in the method body.</param>
+        /// <param name="methodSignals">The current method signal bag.</param>
+        /// <returns>Any findings emitted by local-variable-aware rules.</returns>
         public IEnumerable<ScanFinding> AnalyzeLocalVariables(MethodDefinition method,
             Mono.Collections.Generic.Collection<VariableDefinition> variables, MethodSignals? methodSignals)
         {
             var findings = new List<ScanFinding>();
+            var effectiveMethodSignals = methodSignals ?? _signalTracker.CreateMethodSignals() ?? new MethodSignals();
 
             if (!_config.AnalyzeLocalVariables)
                 return findings;
@@ -41,7 +56,8 @@ namespace MLVScan.Services
             {
                 foreach (var rule in _localVariableRules)
                 {
-                    var ruleFindings = rule.AnalyzeInstructions(method, method.Body.Instructions, methodSignals);
+                    var ruleFindings = rule.AnalyzeInstructions(method, method.Body.Instructions,
+                        effectiveMethodSignals);
 
                     foreach (var finding in ruleFindings)
                     {
@@ -66,10 +82,13 @@ namespace MLVScan.Services
                             {
                                 _signalTracker.MarkRuleTriggered(methodSignals, method.DeclaringType, rule.RuleId);
                             }
-
-                            _signalTracker.MarkSuspiciousLocalVariables(methodSignals, method.DeclaringType);
                         }
                     }
+                }
+
+                if (methodSignals?.HasSuspiciousLocalVariables == true)
+                {
+                    _signalTracker.MarkSuspiciousLocalVariables(methodSignals, method.DeclaringType);
                 }
             }
             catch (Exception)
@@ -78,6 +97,11 @@ namespace MLVScan.Services
             }
 
             return findings;
+        }
+
+        internal IReadOnlyCollection<string> GetProcessedRuleIds()
+        {
+            return _localVariableRules.Select(static rule => rule.RuleId).ToArray();
         }
     }
 }

--- a/Services/MethodScanner.cs
+++ b/Services/MethodScanner.cs
@@ -1,29 +1,49 @@
 using MLVScan.Models;
 using MLVScan.Models.Rules;
+using MLVScan.Services.Diagnostics;
 using MLVScan.Services.Helpers;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using System.ComponentModel;
+using System.Reflection;
 
 namespace MLVScan.Services
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class MethodScanner
     {
-        private readonly IEnumerable<IScanRule> _rules;
+        private readonly IReadOnlyList<IScanRule> _rules;
+        private readonly IReadOnlyList<IScanRule> _stringLiteralRules;
         private readonly SignalTracker _signalTracker;
         private readonly InstructionAnalyzer _instructionAnalyzer;
         private readonly CodeSnippetBuilder _snippetBuilder;
         private readonly LocalVariableAnalyzer _localVariableAnalyzer;
         private readonly ExceptionHandlerAnalyzer _exceptionHandlerAnalyzer;
         private readonly ScanConfig _config;
+        private readonly ScanTelemetryHub _telemetry;
 
         public MethodScanner(IEnumerable<IScanRule> rules, SignalTracker signalTracker,
             InstructionAnalyzer instructionAnalyzer,
             CodeSnippetBuilder snippetBuilder, LocalVariableAnalyzer localVariableAnalyzer,
             ExceptionHandlerAnalyzer exceptionHandlerAnalyzer, ScanConfig config)
+            : this(rules, signalTracker, instructionAnalyzer, snippetBuilder, localVariableAnalyzer,
+                exceptionHandlerAnalyzer, config, new ScanTelemetryHub())
         {
-            _rules = rules ?? throw new ArgumentNullException(nameof(rules));
+        }
+
+        internal MethodScanner(IEnumerable<IScanRule> rules, SignalTracker signalTracker,
+            InstructionAnalyzer instructionAnalyzer,
+            CodeSnippetBuilder snippetBuilder, LocalVariableAnalyzer localVariableAnalyzer,
+            ExceptionHandlerAnalyzer exceptionHandlerAnalyzer, ScanConfig config, ScanTelemetryHub telemetry)
+        {
+            if (rules == null)
+                throw new ArgumentNullException(nameof(rules));
+
+            _rules = rules.ToArray();
+            _stringLiteralRules = _rules
+                .Where(static rule => OverridesRuleMethod(rule, nameof(IScanRule.AnalyzeStringLiteral),
+                    typeof(string), typeof(MethodDefinition), typeof(int)))
+                .ToArray();
             _signalTracker = signalTracker ?? throw new ArgumentNullException(nameof(signalTracker));
             _instructionAnalyzer = instructionAnalyzer ?? throw new ArgumentNullException(nameof(instructionAnalyzer));
             _snippetBuilder = snippetBuilder ?? throw new ArgumentNullException(nameof(snippetBuilder));
@@ -32,6 +52,7 @@ namespace MLVScan.Services
             _exceptionHandlerAnalyzer = exceptionHandlerAnalyzer ??
                                         throw new ArgumentNullException(nameof(exceptionHandlerAnalyzer));
             _config = config ?? new ScanConfig();
+            _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -49,12 +70,27 @@ namespace MLVScan.Services
         public MethodScanResult ScanMethod(MethodDefinition method, string typeFullName)
         {
             var result = new MethodScanResult();
+            var methodName = $"{method.DeclaringType?.FullName}.{method.Name}";
+            var methodStart = _telemetry.StartTimestamp();
+            var instructionCount = method.HasBody ? method.Body.Instructions.Count : 0;
+            var localVariableCount = method.HasBody && method.Body.HasVariables ? method.Body.Variables.Count : 0;
+            var exceptionHandlerCount = method.HasBody && method.Body.HasExceptionHandlers
+                ? method.Body.ExceptionHandlers.Count
+                : 0;
 
             try
             {
                 // Skip methods without a body (e.g., abstract or interface methods)
                 if (!method.HasBody)
+                {
+                    _telemetry.IncrementCounter("MethodScanner.MethodsWithoutBodySkipped");
                     return result;
+                }
+
+                _telemetry.IncrementCounter("MethodScanner.MethodsScanned");
+                _telemetry.IncrementCounter("MethodScanner.InstructionsVisited", instructionCount);
+                _telemetry.IncrementCounter("MethodScanner.LocalVariablesVisited", localVariableCount);
+                _telemetry.IncrementCounter("MethodScanner.ExceptionHandlersVisited", exceptionHandlerCount);
 
                 var instructions = method.Body.Instructions;
 
@@ -64,22 +100,28 @@ namespace MLVScan.Services
                 // Analyze local variables if present
                 if (method.Body.HasVariables)
                 {
+                    var localVariableStart = _telemetry.StartTimestamp();
                     var variableFindings =
                         _localVariableAnalyzer.AnalyzeLocalVariables(method, method.Body.Variables, methodSignals);
+                    _telemetry.AddPhaseElapsed("MethodScanner.AnalyzeLocalVariables", localVariableStart);
                     result.Findings.AddRange(variableFindings);
                 }
 
                 // Analyze exception handlers if present
                 if (method.Body.HasExceptionHandlers)
                 {
+                    var exceptionHandlerStart = _telemetry.StartTimestamp();
                     var handlerFindings = _exceptionHandlerAnalyzer.AnalyzeExceptionHandlers(
                         method, method.Body.ExceptionHandlers, methodSignals, typeFullName);
+                    _telemetry.AddPhaseElapsed("MethodScanner.AnalyzeExceptionHandlers", exceptionHandlerStart);
                     result.Findings.AddRange(handlerFindings);
                 }
 
                 // Call AnalyzeInstructions for all rules
+                var ruleInstructionPassStart = _telemetry.StartTimestamp();
                 foreach (var rule in _rules)
                 {
+                    _telemetry.IncrementCounter("MethodScanner.RuleInstructionPasses");
                     var ruleFindings = rule.AnalyzeInstructions(method, instructions, methodSignals);
                     foreach (var finding in ruleFindings)
                     {
@@ -119,8 +161,10 @@ namespace MLVScan.Services
                         }
                     }
                 }
+                _telemetry.AddPhaseElapsed("MethodScanner.RuleInstructionPasses", ruleInstructionPassStart);
 
                 // Scan for encoded strings in all ldstr instructions
+                var stringLiteralStart = _telemetry.StartTimestamp();
                 for (int i = 0; i < instructions.Count; i++)
                 {
                     var instruction = instructions[i];
@@ -128,8 +172,10 @@ namespace MLVScan.Services
                     // Check for encoded strings using rule analysis
                     if (instruction.OpCode == OpCodes.Ldstr && instruction.Operand is string strLiteral)
                     {
-                        foreach (var rule in _rules)
+                        _telemetry.IncrementCounter("MethodScanner.StringLiteralInstructions");
+                        foreach (var rule in _stringLiteralRules)
                         {
+                            _telemetry.IncrementCounter("MethodScanner.StringLiteralRulePasses");
                             var ruleFindings = rule.AnalyzeStringLiteral(strLiteral, method, i);
                             foreach (var finding in ruleFindings)
                             {
@@ -165,10 +211,13 @@ namespace MLVScan.Services
                         }
                     }
                 }
+                _telemetry.AddPhaseElapsed("MethodScanner.StringLiteralPasses", stringLiteralStart);
 
                 // Analyze instructions for method calls and suspicious patterns
+                var instructionAnalyzerStart = _telemetry.StartTimestamp();
                 var instructionResult =
                     _instructionAnalyzer.AnalyzeInstructions(method, instructions, methodSignals, typeFullName);
+                _telemetry.AddPhaseElapsed("MethodScanner.InstructionAnalyzer", instructionAnalyzerStart);
                 result.Findings.AddRange(instructionResult.Findings);
                 result.PendingReflectionFindings.AddRange(instructionResult.PendingReflectionFindings);
 
@@ -203,8 +252,32 @@ namespace MLVScan.Services
             {
                 // Skip method if it can't be properly analyzed
             }
+            finally
+            {
+                _telemetry.AddPhaseElapsed("MethodScanner.ScanMethod", methodStart);
+                _telemetry.RecordMethodSample(
+                    methodName,
+                    methodStart,
+                    instructionCount,
+                    result.Findings.Count,
+                    localVariableCount,
+                    exceptionHandlerCount,
+                    result.PendingReflectionFindings.Count);
+            }
 
             return result;
+        }
+
+        private static bool OverridesRuleMethod(IScanRule rule, string methodName, params Type[] parameterTypes)
+        {
+            var method = rule.GetType().GetMethod(
+                methodName,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                binder: null,
+                types: parameterTypes,
+                modifiers: null);
+
+            return method != null && method.DeclaringType != typeof(IScanRule);
         }
     }
 }

--- a/Services/MethodScanner.cs
+++ b/Services/MethodScanner.cs
@@ -5,7 +5,6 @@ using MLVScan.Services.Helpers;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using System.ComponentModel;
-using System.Reflection;
 
 namespace MLVScan.Services
 {
@@ -54,7 +53,7 @@ namespace MLVScan.Services
 
             _rules = rules.ToArray();
             _stringLiteralRules = _rules
-                .Where(static rule => OverridesRuleMethod(rule, nameof(IScanRule.AnalyzeStringLiteral),
+                .Where(static rule => RuleOverrideChecker.OverridesRuleMethod(rule, nameof(IScanRule.AnalyzeStringLiteral),
                     typeof(string), typeof(MethodDefinition), typeof(int)))
                 .ToArray();
             _signalTracker = signalTracker ?? throw new ArgumentNullException(nameof(signalTracker));
@@ -306,18 +305,6 @@ namespace MLVScan.Services
             }
 
             return result;
-        }
-
-        private static bool OverridesRuleMethod(IScanRule rule, string methodName, params Type[] parameterTypes)
-        {
-            var method = rule.GetType().GetMethod(
-                methodName,
-                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-                binder: null,
-                types: parameterTypes,
-                modifiers: null);
-
-            return method != null && method.DeclaringType != typeof(IScanRule);
         }
     }
 }

--- a/Services/MethodScanner.cs
+++ b/Services/MethodScanner.cs
@@ -9,6 +9,9 @@ using System.Reflection;
 
 namespace MLVScan.Services
 {
+    /// <summary>
+    /// Coordinates per-method rule execution across local-variable, exception-handler, string, and instruction passes.
+    /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class MethodScanner
     {
@@ -22,6 +25,16 @@ namespace MLVScan.Services
         private readonly ScanConfig _config;
         private readonly ScanTelemetryHub _telemetry;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MethodScanner"/> class.
+        /// </summary>
+        /// <param name="rules">The rules that participate in method scanning.</param>
+        /// <param name="signalTracker">Tracks method and type-level signals.</param>
+        /// <param name="instructionAnalyzer">Performs instruction-level contextual analysis.</param>
+        /// <param name="snippetBuilder">Builds snippets for emitted findings.</param>
+        /// <param name="localVariableAnalyzer">Performs the early local-variable signal pass.</param>
+        /// <param name="exceptionHandlerAnalyzer">Analyzes exception handlers separately from the main pass.</param>
+        /// <param name="config">Controls method-scanner behavior.</param>
         public MethodScanner(IEnumerable<IScanRule> rules, SignalTracker signalTracker,
             InstructionAnalyzer instructionAnalyzer,
             CodeSnippetBuilder snippetBuilder, LocalVariableAnalyzer localVariableAnalyzer,
@@ -55,11 +68,20 @@ namespace MLVScan.Services
             _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
         }
 
+        /// <summary>
+        /// Represents the aggregate result of scanning a single method.
+        /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public class MethodScanResult
         {
+            /// <summary>
+            /// Gets or sets the findings produced while scanning the method.
+            /// </summary>
             public List<ScanFinding> Findings { get; set; } = new List<ScanFinding>();
 
+            /// <summary>
+            /// Gets or sets reflection findings that must be revisited once type-level signals are known.
+            /// </summary>
             public List<(MethodDefinition method, Instruction instruction, int index,
                     Mono.Collections.Generic.Collection<Instruction> instructions, MethodSignals? methodSignals)>
                 PendingReflectionFindings { get; set; } =
@@ -67,6 +89,12 @@ namespace MLVScan.Services
                     MethodSignals?)>();
         }
 
+        /// <summary>
+        /// Scans a single method across all method-level analysis passes.
+        /// </summary>
+        /// <param name="method">The method to scan.</param>
+        /// <param name="typeFullName">The declaring type's full name for cross-method signal correlation.</param>
+        /// <returns>The findings and deferred reflection work collected for the method.</returns>
         public MethodScanResult ScanMethod(MethodDefinition method, string typeFullName)
         {
             var result = new MethodScanResult();
@@ -93,9 +121,11 @@ namespace MLVScan.Services
                 _telemetry.IncrementCounter("MethodScanner.ExceptionHandlersVisited", exceptionHandlerCount);
 
                 var instructions = method.Body.Instructions;
+                var processedLocalRuleIds = new HashSet<string>(StringComparer.Ordinal);
 
                 // Initialize signal tracking for this method
                 var methodSignals = _signalTracker.CreateMethodSignals();
+                var effectiveMethodSignals = methodSignals ?? new MethodSignals();
 
                 // Analyze local variables if present
                 if (method.Body.HasVariables)
@@ -105,6 +135,11 @@ namespace MLVScan.Services
                         _localVariableAnalyzer.AnalyzeLocalVariables(method, method.Body.Variables, methodSignals);
                     _telemetry.AddPhaseElapsed("MethodScanner.AnalyzeLocalVariables", localVariableStart);
                     result.Findings.AddRange(variableFindings);
+                    if (_config.AnalyzeLocalVariables)
+                    {
+                        processedLocalRuleIds = new HashSet<string>(_localVariableAnalyzer.GetProcessedRuleIds(),
+                            StringComparer.Ordinal);
+                    }
                 }
 
                 // Analyze exception handlers if present
@@ -121,8 +156,13 @@ namespace MLVScan.Services
                 var ruleInstructionPassStart = _telemetry.StartTimestamp();
                 foreach (var rule in _rules)
                 {
+                    if (processedLocalRuleIds.Contains(rule.RuleId))
+                    {
+                        continue;
+                    }
+
                     _telemetry.IncrementCounter("MethodScanner.RuleInstructionPasses");
-                    var ruleFindings = rule.AnalyzeInstructions(method, instructions, methodSignals);
+                    var ruleFindings = rule.AnalyzeInstructions(method, instructions, effectiveMethodSignals);
                     foreach (var finding in ruleFindings)
                     {
                         // If rule requires companion finding, check if other rules have been triggered

--- a/Services/PropertyEventScanner.cs
+++ b/Services/PropertyEventScanner.cs
@@ -20,6 +20,42 @@ namespace MLVScan.Services
             _config = config ?? new ScanConfig();
         }
 
+        public IReadOnlyDictionary<MethodDefinition, string> BuildAccessorContexts(TypeDefinition type)
+        {
+            var contexts = new Dictionary<MethodDefinition, string>();
+
+            if (!_config.AnalyzePropertyAccessors)
+                return contexts;
+
+            try
+            {
+                if (type.HasProperties)
+                {
+                    foreach (var property in type.Properties)
+                    {
+                        AddContext(contexts, property.GetMethod, $"found in property getter: {property.Name}");
+                        AddContext(contexts, property.SetMethod, $"found in property setter: {property.Name}");
+                    }
+                }
+
+                if (type.HasEvents)
+                {
+                    foreach (var evt in type.Events)
+                    {
+                        AddContext(contexts, evt.AddMethod, $"found in event add: {evt.Name}");
+                        AddContext(contexts, evt.RemoveMethod, $"found in event remove: {evt.Name}");
+                        AddContext(contexts, evt.InvokeMethod, $"found in event invoke: {evt.Name}");
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // Skip if accessor context discovery fails
+            }
+
+            return contexts;
+        }
+
         public IEnumerable<ScanFinding> ScanProperties(TypeDefinition type, string typeFullName)
         {
             var findings = new List<ScanFinding>();
@@ -169,6 +205,25 @@ namespace MLVScan.Services
             }
 
             return findings;
+        }
+
+        private static void AddContext(Dictionary<MethodDefinition, string> contexts, MethodDefinition? method,
+            string context)
+        {
+            if (method?.HasBody != true)
+                return;
+
+            if (contexts.TryGetValue(method, out var existingContext))
+            {
+                if (!existingContext.Contains(context, StringComparison.Ordinal))
+                {
+                    contexts[method] = $"{existingContext}; {context}";
+                }
+
+                return;
+            }
+
+            contexts[method] = context;
         }
     }
 }

--- a/Services/TypeScanner.cs
+++ b/Services/TypeScanner.cs
@@ -7,6 +7,9 @@ using System.ComponentModel;
 
 namespace MLVScan.Services
 {
+    /// <summary>
+    /// Scans a Cecil type definition and coordinates method, nested-type, and type-level signal processing.
+    /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class TypeScanner
     {
@@ -37,6 +40,16 @@ namespace MLVScan.Services
         private readonly ScanConfig _config;
         private readonly ScanTelemetryHub _telemetry;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TypeScanner"/> class.
+        /// </summary>
+        /// <param name="methodScanner">Scans methods declared on the type.</param>
+        /// <param name="signalTracker">Tracks type-level signals across methods.</param>
+        /// <param name="reflectionDetector">Processes deferred reflection findings.</param>
+        /// <param name="snippetBuilder">Builds snippets for emitted findings.</param>
+        /// <param name="propertyEventScanner">Provides accessor context annotations.</param>
+        /// <param name="rules">The rule set available to the type scanner.</param>
+        /// <param name="config">Controls type-scanner behavior.</param>
         public TypeScanner(MethodScanner methodScanner, SignalTracker signalTracker,
             ReflectionDetector reflectionDetector,
             CodeSnippetBuilder snippetBuilder, PropertyEventScanner propertyEventScanner, IEnumerable<IScanRule> rules,
@@ -62,6 +75,11 @@ namespace MLVScan.Services
             _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
         }
 
+        /// <summary>
+        /// Scans a type and its nested types for suspicious behavior.
+        /// </summary>
+        /// <param name="type">The type to scan.</param>
+        /// <returns>The findings produced for the type hierarchy.</returns>
         public IEnumerable<ScanFinding> ScanType(TypeDefinition type)
         {
             var findings = new List<ScanFinding>();
@@ -69,19 +87,21 @@ namespace MLVScan.Services
             var typeMethodCount = type.Methods.Count;
             var nestedTypeCount = type.NestedTypes.Count;
             var pendingReflectionCount = 0;
+            string typeFullName = type.FullName;
+            bool typeSignalsInitialized = false;
             _telemetry.IncrementCounter("TypeScanner.TypesScanned");
             _telemetry.IncrementCounter("TypeScanner.MethodsDiscovered", typeMethodCount);
             _telemetry.IncrementCounter("TypeScanner.NestedTypesDiscovered", nestedTypeCount);
 
             try
             {
-                string typeFullName = type.FullName;
                 var methodContexts = _propertyEventScanner.BuildAccessorContexts(type);
 
                 // Initialize type-level signal tracking for this type
                 if (_config.EnableMultiSignalDetection)
                 {
                     _signalTracker.GetOrCreateTypeSignals(typeFullName);
+                    typeSignalsInitialized = true;
                 }
 
                 // Queue of pending reflection findings that need type-level signals to be confirmed
@@ -89,29 +109,37 @@ namespace MLVScan.Services
                     new List<(MethodDefinition method, Instruction instruction, int index,
                         Mono.Collections.Generic.Collection<Instruction> instructions, MethodSignals? methodSignals)>();
 
-                // Scan methods in this type
-                foreach (var method in type.Methods)
+                try
                 {
-                    var methodResult = _methodScanner.ScanMethod(method, typeFullName);
-                    AnnotateFindings(methodResult.Findings, method, methodContexts);
-                    findings.AddRange(methodResult.Findings);
-                    pendingReflectionFindings.AddRange(methodResult.PendingReflectionFindings);
+                    // Scan methods in this type
+                    foreach (var method in type.Methods)
+                    {
+                        var methodResult = _methodScanner.ScanMethod(method, typeFullName);
+                        AnnotateFindings(methodResult.Findings, method, methodContexts);
+                        findings.AddRange(methodResult.Findings);
+                        pendingReflectionFindings.AddRange(methodResult.PendingReflectionFindings);
+                    }
+
+                    pendingReflectionCount = pendingReflectionFindings.Count;
+                    _telemetry.IncrementCounter("TypeScanner.PendingReflectionQueued", pendingReflectionCount);
+
+                    // After scanning all methods, check pending reflection findings with type-level signals
+                    if (_config.EnableMultiSignalDetection)
+                    {
+                        var pendingReflectionStart = _telemetry.StartTimestamp();
+                        ProcessPendingReflectionFindings(pendingReflectionFindings, typeFullName, findings,
+                            methodContexts);
+                        _telemetry.AddPhaseElapsed("TypeScanner.ProcessPendingReflectionFindings",
+                            pendingReflectionStart);
+                    }
                 }
-
-                pendingReflectionCount = pendingReflectionFindings.Count;
-                _telemetry.IncrementCounter("TypeScanner.PendingReflectionQueued", pendingReflectionCount);
-
-                // After scanning all methods, check pending reflection findings with type-level signals
-                if (_config.EnableMultiSignalDetection)
+                finally
                 {
-                    var pendingReflectionStart = _telemetry.StartTimestamp();
-                    ProcessPendingReflectionFindings(pendingReflectionFindings, typeFullName, findings, methodContexts);
-                    _telemetry.AddPhaseElapsed("TypeScanner.ProcessPendingReflectionFindings",
-                        pendingReflectionStart);
+                    if (typeSignalsInitialized)
+                    {
+                        _signalTracker.ClearTypeSignals(typeFullName);
+                    }
                 }
-
-                // Clear type signals after processing
-                _signalTracker.ClearTypeSignals(typeFullName);
 
                 // Recursively scan nested types
                 foreach (var nestedType in type.NestedTypes)

--- a/Services/TypeScanner.cs
+++ b/Services/TypeScanner.cs
@@ -1,5 +1,6 @@
 using MLVScan.Models;
 using MLVScan.Models.Rules;
+using MLVScan.Services.Diagnostics;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using System.ComponentModel;
@@ -34,11 +35,21 @@ namespace MLVScan.Services
         private readonly PropertyEventScanner _propertyEventScanner;
         private readonly IEnumerable<IScanRule> _rules;
         private readonly ScanConfig _config;
+        private readonly ScanTelemetryHub _telemetry;
 
         public TypeScanner(MethodScanner methodScanner, SignalTracker signalTracker,
             ReflectionDetector reflectionDetector,
             CodeSnippetBuilder snippetBuilder, PropertyEventScanner propertyEventScanner, IEnumerable<IScanRule> rules,
             ScanConfig config)
+            : this(methodScanner, signalTracker, reflectionDetector, snippetBuilder, propertyEventScanner, rules,
+                config, new ScanTelemetryHub())
+        {
+        }
+
+        internal TypeScanner(MethodScanner methodScanner, SignalTracker signalTracker,
+            ReflectionDetector reflectionDetector,
+            CodeSnippetBuilder snippetBuilder, PropertyEventScanner propertyEventScanner, IEnumerable<IScanRule> rules,
+            ScanConfig config, ScanTelemetryHub telemetry)
         {
             _methodScanner = methodScanner ?? throw new ArgumentNullException(nameof(methodScanner));
             _signalTracker = signalTracker ?? throw new ArgumentNullException(nameof(signalTracker));
@@ -48,15 +59,24 @@ namespace MLVScan.Services
                 propertyEventScanner ?? throw new ArgumentNullException(nameof(propertyEventScanner));
             _rules = rules ?? throw new ArgumentNullException(nameof(rules));
             _config = config ?? new ScanConfig();
+            _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
         }
 
         public IEnumerable<ScanFinding> ScanType(TypeDefinition type)
         {
             var findings = new List<ScanFinding>();
+            var typeStart = _telemetry.StartTimestamp();
+            var typeMethodCount = type.Methods.Count;
+            var nestedTypeCount = type.NestedTypes.Count;
+            var pendingReflectionCount = 0;
+            _telemetry.IncrementCounter("TypeScanner.TypesScanned");
+            _telemetry.IncrementCounter("TypeScanner.MethodsDiscovered", typeMethodCount);
+            _telemetry.IncrementCounter("TypeScanner.NestedTypesDiscovered", nestedTypeCount);
 
             try
             {
                 string typeFullName = type.FullName;
+                var methodContexts = _propertyEventScanner.BuildAccessorContexts(type);
 
                 // Initialize type-level signal tracking for this type
                 if (_config.EnableMultiSignalDetection)
@@ -73,22 +93,21 @@ namespace MLVScan.Services
                 foreach (var method in type.Methods)
                 {
                     var methodResult = _methodScanner.ScanMethod(method, typeFullName);
+                    AnnotateFindings(methodResult.Findings, method, methodContexts);
                     findings.AddRange(methodResult.Findings);
                     pendingReflectionFindings.AddRange(methodResult.PendingReflectionFindings);
                 }
 
-                // Scan property accessors
-                var propertyFindings = _propertyEventScanner.ScanProperties(type, typeFullName);
-                findings.AddRange(propertyFindings);
-
-                // Scan event handlers
-                var eventFindings = _propertyEventScanner.ScanEvents(type, typeFullName);
-                findings.AddRange(eventFindings);
+                pendingReflectionCount = pendingReflectionFindings.Count;
+                _telemetry.IncrementCounter("TypeScanner.PendingReflectionQueued", pendingReflectionCount);
 
                 // After scanning all methods, check pending reflection findings with type-level signals
                 if (_config.EnableMultiSignalDetection)
                 {
-                    ProcessPendingReflectionFindings(pendingReflectionFindings, typeFullName, findings);
+                    var pendingReflectionStart = _telemetry.StartTimestamp();
+                    ProcessPendingReflectionFindings(pendingReflectionFindings, typeFullName, findings, methodContexts);
+                    _telemetry.AddPhaseElapsed("TypeScanner.ProcessPendingReflectionFindings",
+                        pendingReflectionStart);
                 }
 
                 // Clear type signals after processing
@@ -104,6 +123,17 @@ namespace MLVScan.Services
             {
                 // Skip type if it can't be properly analyzed
             }
+            finally
+            {
+                _telemetry.AddPhaseElapsed("TypeScanner.ScanType", typeStart);
+                _telemetry.RecordTypeSample(
+                    type.FullName,
+                    typeStart,
+                    typeMethodCount,
+                    nestedTypeCount,
+                    findings.Count,
+                    pendingReflectionCount);
+            }
 
             return findings;
         }
@@ -112,7 +142,9 @@ namespace MLVScan.Services
             List<(MethodDefinition method, Instruction instruction, int index,
                     Mono.Collections.Generic.Collection<Instruction> instructions, MethodSignals? methodSignals)>
                 pendingReflectionFindings,
-            string typeFullName, List<ScanFinding> findings)
+            string typeFullName,
+            List<ScanFinding> findings,
+            IReadOnlyDictionary<MethodDefinition, string> methodContexts)
         {
             if (pendingReflectionFindings.Count == 0)
                 return;
@@ -131,6 +163,7 @@ namespace MLVScan.Services
             if (!hasTypeLevelTriggeredRules)
                 return;
 
+            var reflectionFindingsBefore = findings.Count;
             // Process each pending reflection finding
             foreach (var (method, instruction, index, instructions, methodSignals) in pendingReflectionFindings)
             {
@@ -141,6 +174,11 @@ namespace MLVScan.Services
                     reflectionRule.Description + " (combined with other suspicious patterns detected in this type)",
                     reflectionRule.Severity,
                     snippet) { RuleId = reflectionRule.RuleId, DeveloperGuidance = reflectionRule.DeveloperGuidance };
+                if (methodContexts.TryGetValue(method, out var context))
+                {
+                    finding.Description += $" ({context})";
+                }
+
                 findings.Add(finding);
                 // Mark rule as triggered
                 if (methodSignals != null)
@@ -148,6 +186,9 @@ namespace MLVScan.Services
                     _signalTracker.MarkRuleTriggered(methodSignals, method.DeclaringType, reflectionRule.RuleId);
                 }
             }
+
+            _telemetry.IncrementCounter("TypeScanner.PendingReflectionFindingsConfirmed",
+                findings.Count - reflectionFindingsBefore);
         }
 
         private static bool HasStrongReflectionCompanion(MethodSignals typeSignal, string reflectionRuleId)
@@ -162,6 +203,21 @@ namespace MLVScan.Services
             }
 
             return false;
+        }
+
+        private static void AnnotateFindings(List<ScanFinding> findings, MethodDefinition method,
+            IReadOnlyDictionary<MethodDefinition, string> methodContexts)
+        {
+            if (!methodContexts.TryGetValue(method, out var context))
+                return;
+
+            foreach (var finding in findings)
+            {
+                if (!finding.Description.Contains(context, StringComparison.Ordinal))
+                {
+                    finding.Description += $" ({context})";
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Reduce repeated work in the Core scan pipeline by removing redundant accessor rescans, avoiding local-variable rule replay through full instruction analysis, and tightening several hot method/type scan paths.

This also adds compile-gated profiling hooks and corpus performance coverage so hot spots can be measured in Release-style runs without adding production overhead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Eliminate redundant scan passes by filtering and precomputing rule subsets (local-variable, string-literal, contextual-pattern rules) to avoid re-analyzing instructions and re-scanning property/event accessors
- Add compile-gated profiling hooks via new ScanTelemetryHub and the MLVSCAN_PROFILING define to collect phase timings, counters, and per-item samples without production overhead
- Instrument core scanners (AssemblyScanner, MethodScanner, TypeScanner, InstructionAnalyzer, DataFlowAnalyzer) with telemetry: phase elapsed times, counters, per-method/type samples, and telemetry ID helpers
- Centralize property/event accessor context collection in PropertyEventScanner.BuildAccessorContexts and annotate findings with accessor context instead of rescanning
- Reduce allocation/iteration overhead by switching rule storage to IReadOnlyList and prefiltering rule subsets at construction time
- Improve local-variable analysis to only invoke relevant local-variable rules and propagate type-level signals more efficiently
- Add FalsePositiveCorpusPerformanceTests to benchmark corpus stability, capture optional profiling artifacts, and emit per-run timing summaries
- Expand unit and integration tests covering InstructionAnalyzer, LocalVariableAnalyzer, MethodScanner, TypeScanner, PropertyEventScanner, and AssemblyScanner telemetry helpers
- Expose assembly telemetry snapshot retrieval (GetLastProfileSnapshot) and deterministically dispose assembly reads for better resource handling

## Changes by Author

| Author | Added | Removed | Net |
|--------|------:|--------:|----:|
| ifBars | 43063 | 0 | 43063 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->