### PR TITLE
Fix malformed Unicode literal scan bypass

### DIFF
--- a/MLVScan.Core.Tests/Unit/Models/Rules/Helpers/InvisibleUnicodeAnalyzerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Models/Rules/Helpers/InvisibleUnicodeAnalyzerTests.cs
@@ -28,10 +28,11 @@ public class InvisibleUnicodeAnalyzerTests
     }
 
     [Theory]
-    [InlineData("\uD800")]
-    [InlineData("\uDC00")]
-    public void Analyze_DoesNotThrowForUnpairedSurrogate(string malformedLiteral)
+    [InlineData(0xD800)]
+    [InlineData(0xDC00)]
+    public void Analyze_DoesNotThrowForUnpairedSurrogate(int malformedCodeUnit)
     {
+        string malformedLiteral = new((char)malformedCodeUnit, 1);
         var act = () => InvisibleUnicodeAnalyzer.Analyze(malformedLiteral);
 
         act.Should().NotThrow();

--- a/MLVScan.Core.Tests/Unit/Models/Rules/Helpers/InvisibleUnicodeAnalyzerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Models/Rules/Helpers/InvisibleUnicodeAnalyzerTests.cs
@@ -26,4 +26,14 @@ public class InvisibleUnicodeAnalyzerTests
         analysis.HasVariationSelectorPayload.Should().BeFalse();
         analysis.DecodedText.Should().BeNull();
     }
+
+    [Theory]
+    [InlineData("\uD800")]
+    [InlineData("\uDC00")]
+    public void Analyze_DoesNotThrowForUnpairedSurrogate(string malformedLiteral)
+    {
+        var act = () => InvisibleUnicodeAnalyzer.Analyze(malformedLiteral);
+
+        act.Should().NotThrow();
+    }
 }

--- a/MLVScan.Core.Tests/Unit/Services/MethodScannerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/MethodScannerTests.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using FluentAssertions;
 using MLVScan.Abstractions;
 using MLVScan.Models;
+using MLVScan.Models.Rules;
 using MLVScan.Services;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -99,6 +100,36 @@ public class MethodScannerTests
 
         result.Findings.Should().ContainSingle();
         countingRule.AnalyzeInstructionsCallCount.Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData(0xD800)]
+    [InlineData(0xDC00)]
+    public void ScanMethod_UnpairedSurrogateDoesNotSuppressProcessStartFinding(int malformedCodeUnit)
+    {
+        var config = new ScanConfig { EnableMultiSignalDetection = true };
+        var scanner = CreateScanner(config, new IScanRule[]
+        {
+            new ObfuscatedReflectiveExecutionRule(),
+            new ProcessStartRule()
+        });
+        var method = CreateMethod();
+        var processor = method.Body.GetILProcessor();
+        var ret = method.Body.Instructions.Single();
+        var processStart = method.Module.ImportReference(
+            typeof(System.Diagnostics.Process).GetMethod(
+                nameof(System.Diagnostics.Process.Start),
+                new[] { typeof(string) })!);
+
+        processor.InsertBefore(ret, Instruction.Create(OpCodes.Ldstr, new string((char)malformedCodeUnit, 1)));
+        processor.InsertBefore(ret, Instruction.Create(OpCodes.Pop));
+        processor.InsertBefore(ret, Instruction.Create(OpCodes.Ldstr, "cmd.exe"));
+        processor.InsertBefore(ret, Instruction.Create(OpCodes.Call, processStart));
+        processor.InsertBefore(ret, Instruction.Create(OpCodes.Pop));
+
+        var result = scanner.ScanMethod(method, "Test.Type");
+
+        result.Findings.Should().Contain(finding => finding.RuleId == "ProcessStartRule");
     }
 
     private static MethodScanner CreateScanner(ScanConfig config, IEnumerable<IScanRule> rules)

--- a/Models/Rules/Helpers/InvisibleUnicodeAnalyzer.cs
+++ b/Models/Rules/Helpers/InvisibleUnicodeAnalyzer.cs
@@ -31,8 +31,11 @@ namespace MLVScan.Models.Rules.Helpers
 
             for (int i = 0; i < literal.Length; i++)
             {
-                int codePoint = char.ConvertToUtf32(literal, i);
-                if (char.IsSurrogatePair(literal, i))
+                bool isSurrogatePair = char.IsSurrogatePair(literal, i);
+                int codePoint = isSurrogatePair
+                    ? char.ConvertToUtf32(literal, i)
+                    : literal[i];
+                if (isSurrogatePair)
                 {
                     i++;
                 }


### PR DESCRIPTION
### Motivation
- An attacker-controlled string literal containing an unpaired UTF-16 surrogate caused `char.ConvertToUtf32` to throw.
- That exception escaped the early rule pass in `MethodScanner`, suppressing later rules such as `ProcessStartRule` for the same method.

### Fix
- Call `ConvertToUtf32` only for validated surrogate pairs and handle unpaired code units as individual characters.
- Cover both unpaired high and low surrogate inputs.
- Add an end-to-end `MethodScanner` regression proving malformed Unicode can no longer suppress a later `Process.Start` finding.

### Validation
- Vulnerable-code proof: `dotnet test MLVScan.Core.Tests/MLVScan.Core.Tests.csproj --no-restore --filter "FullyQualifiedName~ScanMethod_UnpairedSurrogateDoesNotSuppressProcessStartFinding" --verbosity minimal` fails both cases with an empty finding set when the source fix is temporarily reverted.
- Patched focused tests: `dotnet test MLVScan.Core.Tests/MLVScan.Core.Tests.csproj --no-restore --filter "FullyQualifiedName~InvisibleUnicodeAnalyzerTests|FullyQualifiedName~ScanMethod_UnpairedSurrogate" --verbosity minimal` — 6 passed, 0 failed, 0 skipped.
- Full solution: `dotnet test MLVScan.Core.sln --no-restore --verbosity minimal` — 1473 passed, 23 skipped, 1 failed. The existing failure is `FalsePositiveScanTests.Scan_AllFalsePositiveSamples_SummaryReport` for unrelated corpus samples AngleSharp.dll, SideHustle.dll, and Sideload.dll.
- `git diff --check` passed.