### PR TITLE
Prevent unresolved references from suppressing ProcessStart findings

### DIFF
--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -357,6 +357,41 @@ public class ProcessStartRuleTests
     }
 
     [Fact]
+    public void GetFindingDescription_WithUnresolvableUseShellExecuteValue_PreservesFindingDescription()
+    {
+        using var module = ModuleDefinition.CreateModule("TestAssembly", ModuleKind.Dll);
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Void);
+        module.Types.Add(new TypeDefinition("Tests", "TestType", TypeAttributes.Public)).Methods.Add(method);
+
+        var missingAssembly = new AssemblyNameReference("MissingDependency", new Version(1, 0, 0, 0));
+        module.AssemblyReferences.Add(missingAssembly);
+        var missingType = new TypeReference("MissingDependency", "Helper", module, missingAssembly);
+        var getFlag = new MethodReference("GetFlag", module.TypeSystem.Boolean, missingType)
+        {
+            HasThis = false
+        };
+        var processStartInfo = new TypeReference("System.Diagnostics", "ProcessStartInfo", module,
+            module.TypeSystem.CoreLibrary);
+        var process = new TypeReference("System.Diagnostics", "Process", module, module.TypeSystem.CoreLibrary);
+
+        var processor = method.Body.GetILProcessor();
+        processor.Emit(OpCodes.Ldstr, "cmd.exe");
+        processor.Emit(OpCodes.Callvirt,
+            new MethodReference("set_FileName", module.TypeSystem.Void, processStartInfo));
+        processor.Emit(OpCodes.Call, getFlag);
+        processor.Emit(OpCodes.Callvirt,
+            new MethodReference("set_UseShellExecute", module.TypeSystem.Void, processStartInfo));
+        var start = new MethodReference("Start", module.TypeSystem.Boolean, process);
+        processor.Emit(OpCodes.Callvirt, start);
+
+        string description = _rule.GetFindingDescription(method, start, method.Body.Instructions,
+            method.Body.Instructions.Count - 1);
+
+        description.Should().Contain("Target: \"cmd.exe\"");
+    }
+
+    [Fact]
     public void DetermineSeverity_KnownSafeToolWithCreateNoWindowAndPlaceholderArgs_ReturnsMedium()
     {
         var result = InvokeDetermineSeverity(

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -362,7 +362,9 @@ public class ProcessStartRuleTests
         using var module = ModuleDefinition.CreateModule("TestAssembly", ModuleKind.Dll);
         var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
             module.TypeSystem.Void);
-        module.Types.Add(new TypeDefinition("Tests", "TestType", TypeAttributes.Public)).Methods.Add(method);
+        var type = new TypeDefinition("Tests", "TestType", TypeAttributes.Public);
+        module.Types.Add(type);
+        type.Methods.Add(method);
 
         var missingAssembly = new AssemblyNameReference("MissingDependency", new Version(1, 0, 0, 0));
         module.AssemblyReferences.Add(missingAssembly);

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -819,7 +819,17 @@ namespace MLVScan.Models.Rules.Helpers
                 return true;
             }
 
-            var resolvedMethod = method.Resolve();
+            MethodDefinition? resolvedMethod;
+            try
+            {
+                resolvedMethod = method.Resolve();
+            }
+            catch (Exception)
+            {
+                // References originate in untrusted assemblies. Resolution is best-effort; an
+                // unavailable or malformed dependency must not abort the enclosing rule.
+                resolvedMethod = null;
+            }
             if (resolvedMethod != null && resolvedMethod.HasBody && context.Module != null &&
                 resolvedMethod.Module == context.Module)
             {


### PR DESCRIPTION
### Motivation
- ProcessStartInfo evasion-property enrichment resolves method references from attacker-controlled metadata.
- An unavailable or malformed dependency could throw from `MethodReference.Resolve()`, abort description construction, and make `InstructionAnalyzer` skip an otherwise verdict-critical `Process.Start` finding.

### Fix
- Make method-reference resolution best-effort inside `InstructionValueResolver`.
- Fall back to a dynamic unresolved value when metadata resolution throws, preserving the direct process-execution finding.
- Add a regression with a deliberately missing assembly reference.

### Validation
- Vulnerable-code proof: the focused regression fails with `Mono.Cecil.AssemblyResolutionException` when the guard is temporarily reverted.
- `dotnet test MLVScan.Core.Tests/MLVScan.Core.Tests.csproj --no-restore --filter "FullyQualifiedName~ProcessStartRuleTests|FullyQualifiedName~InstructionValueResolver" --verbosity minimal` — 78 passed, 0 failed, 0 skipped.
- `git diff --check` passed.