### PR TITLE
Fix persistence writes scanning clean

### DIFF
--- a/MLVScan.Core.Tests/Unit/Rules/PersistenceRuleSimpleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/PersistenceRuleSimpleTests.cs
@@ -16,15 +16,15 @@ public class PersistenceRuleSimpleTests
     }
 
     [Fact]
-    public void Severity_ReturnsMedium()
+    public void Severity_ReturnsHigh()
     {
-        _rule.Severity.Should().Be(Severity.Medium);
+        _rule.Severity.Should().Be(Severity.High);
     }
 
     [Fact]
-    public void RequiresCompanionFinding_ReturnsTrue()
+    public void RequiresCompanionFinding_ReturnsFalse()
     {
-        _rule.RequiresCompanionFinding.Should().BeTrue();
+        _rule.RequiresCompanionFinding.Should().BeFalse();
     }
 
     [Fact]

--- a/MLVScan.Core.Tests/Unit/Rules/PersistenceRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/PersistenceRuleTests.cs
@@ -21,7 +21,7 @@ public class PersistenceRuleTests
     [Fact]
     public void Description_ReturnsExpectedValue()
     {
-        _rule.Description.Should().Be("Detected file write to %TEMP% folder (companion finding).");
+        _rule.Description.Should().Be("Detected executable or script write to a persistence folder.");
     }
 
     [Fact]
@@ -33,9 +33,9 @@ public class PersistenceRuleTests
     [Theory]
     [InlineData(7, true, "Startup")]
     [InlineData(24, true, "CommonStartup")]
-    [InlineData(26, false, "ApplicationData")]
-    [InlineData(28, false, "LocalApplicationData")]
-    [InlineData(35, false, "CommonApplicationData")]
+    [InlineData(26, true, "ApplicationData")]
+    [InlineData(28, true, "LocalApplicationData")]
+    [InlineData(35, true, "CommonApplicationData")]
     [InlineData(36, true, "Windows")]
     [InlineData(37, true, "System")]
     [InlineData(5, false, "Folder(5)")]
@@ -175,7 +175,7 @@ public class PersistenceRuleTests
         Analyze(context, 1).Should().BeEmpty();
     }
 
-    [Fact(Skip = "Failing in CI - returns no findings when one is expected. Needs investigation.")]
+    [Fact]
     public void AnalyzeContextualPattern_DetectsPs1WriteToPersistenceLocation()
     {
         var context = CreateContext("System.IO.File", "Copy", builder =>
@@ -191,7 +191,7 @@ public class PersistenceRuleTests
     [InlineData(@"C:\Users\Test\AppData\Startup\config.txt", false)]
     [InlineData(@"C:\Temp\output.exe", false)]
     [InlineData("", false)]
-    [InlineData(@"C:\AppData\malware.exe", false)]
+    [InlineData(@"C:\Users\Test\Documents\malware.exe", false)]
     public void AnalyzeContextualPattern_DoesNotDetect_ForNonMatchingPaths(string path, bool useNops)
     {
         var context = CreateContext("System.IO.File", "Create", builder =>
@@ -244,7 +244,7 @@ public class PersistenceRuleTests
         Analyze(methodReference, context.Method, 0).Should().BeEmpty();
     }
 
-    [Theory(Skip = "Failing in CI - returns no findings when one is expected. Needs investigation.")]
+    [Theory]
     [InlineData("System.IO.File", "WriteAllText", @"C:\ProgramData\payload.exe", 1)]
     [InlineData("System.IO.Directory", "Move", @"C:\Users\Test\AppData\dest.exe", 2)]
     public void AnalyzeContextualPattern_DetectsTrackedSystemIoTypes(
@@ -266,7 +266,7 @@ public class PersistenceRuleTests
         Analyze(context, callIndex).Should().HaveCount(1);
     }
 
-    [Fact(Skip = "Failing in CI - returns no findings when one is expected. Needs investigation.")]
+    [Fact]
     public void AnalyzeContextualPattern_SearchesWithin10InstructionWindow()
     {
         var context = CreateContext("System.IO.File", "Create", builder =>
@@ -296,7 +296,7 @@ public class PersistenceRuleTests
         Analyze(context, 12).Should().BeEmpty();
     }
 
-    [Fact(Skip = "Failing in CI - returns no findings when one is expected. Needs investigation.")]
+    [Fact]
     public void AnalyzeContextualPattern_IncludesCodeSnippet()
     {
         var context = CreateContext("System.IO.File", "WriteAllText", builder =>
@@ -313,7 +313,7 @@ public class PersistenceRuleTests
         findings[0].CodeSnippet.Should().Contain("call");
     }
 
-    [Fact(Skip = "Failing in CI - returns no findings when one is expected. Needs investigation.")]
+    [Fact]
     public void AnalyzeContextualPattern_CaseInsensitiveDirectoryMatching()
     {
         var context = CreateContext("System.IO.File", "Create", builder =>

--- a/MLVScan.Core.Tests/Unit/Rules/PersistenceRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/PersistenceRuleTests.cs
@@ -234,6 +234,19 @@ public class PersistenceRuleTests
         Analyze(context, 4).Should().BeEmpty();
     }
 
+    [Fact]
+    public void AnalyzeContextualPattern_PrefersHighSeverityWhenTempAndSensitiveDestinationOverlap()
+    {
+        var context = CreateContext("System.IO.File", "Create", builder =>
+            builder.EmitString(@"%TEMP%\AppData\payload.exe"));
+
+        var findings = Analyze(context, 1);
+
+        findings.Should().ContainSingle();
+        findings[0].Severity.Should().Be(Severity.High);
+        findings[0].Description.Should().Contain("Potential persistence");
+    }
+
     [Theory]
     [InlineData(@"C:\Windows\payload.exe")]
     [InlineData(@"C:\Program Files\Example\payload.dll")]

--- a/MLVScan.Core.Tests/Unit/Rules/PersistenceRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/PersistenceRuleTests.cs
@@ -33,9 +33,9 @@ public class PersistenceRuleTests
     [Theory]
     [InlineData(7, true, "Startup")]
     [InlineData(24, true, "CommonStartup")]
-    [InlineData(26, true, "ApplicationData")]
-    [InlineData(28, true, "LocalApplicationData")]
-    [InlineData(35, true, "CommonApplicationData")]
+    [InlineData(26, false, "ApplicationData")]
+    [InlineData(28, false, "LocalApplicationData")]
+    [InlineData(35, false, "CommonApplicationData")]
     [InlineData(36, true, "Windows")]
     [InlineData(37, true, "System")]
     [InlineData(5, false, "Folder(5)")]
@@ -153,7 +153,7 @@ public class PersistenceRuleTests
     }
 
     [Fact]
-    public void AnalyzeContextualPattern_DoesNotDetect_WhenNoTempPath()
+    public void AnalyzeContextualPattern_DetectsExecutableWriteToAppDataWithoutTempPath()
     {
         var context = CreateContext("System.IO.File", "WriteAllBytes", builder =>
         {
@@ -161,7 +161,11 @@ public class PersistenceRuleTests
             builder.EmitString("content");
         });
 
-        Analyze(context, 2).Should().BeEmpty();
+        var findings = Analyze(context, 2);
+
+        findings.Should().ContainSingle();
+        findings[0].Severity.Should().Be(Severity.High);
+        findings[0].Description.Should().Contain("Potential persistence");
     }
 
     [Fact]

--- a/MLVScan.Core.Tests/Unit/Rules/PersistenceRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/PersistenceRuleTests.cs
@@ -55,9 +55,16 @@ public class PersistenceRuleTests
         {
             builder.EmitCall("System.IO.Path", "GetTempPath", builder.Module.TypeSystem.String);
             builder.EmitString("payload.exe");
+            builder.EmitCallWithParams(
+                "System.IO.Path",
+                "Combine",
+                builder.Module.TypeSystem.String,
+                builder.Module.TypeSystem.String,
+                builder.Module.TypeSystem.String);
+            builder.EmitString("content");
         });
 
-        var findings = Analyze(context, 2);
+        var findings = Analyze(context, 4);
 
         findings.Should().HaveCount(1);
         findings[0].Severity.Should().Be(Severity.Medium);
@@ -191,6 +198,53 @@ public class PersistenceRuleTests
         Analyze(context, 2).Should().HaveCount(1);
     }
 
+    [Fact]
+    public void AnalyzeContextualPattern_DoesNotTreatCopySourceAsDestination()
+    {
+        var context = CreateContext("System.IO.File", "Copy", builder =>
+        {
+            builder.EmitString(@"C:\Users\Test\AppData\payload.exe");
+            builder.EmitString(@"C:\Backup\payload.exe");
+        });
+
+        Analyze(context, 2).Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(@"C:\Temp\StartupHelper.exe")]
+    [InlineData(@"C:\Temp\AppDataExporter.exe")]
+    public void AnalyzeContextualPattern_DoesNotTreatFilenameAsSensitiveDirectory(string destination)
+    {
+        var context = CreateContext("System.IO.File", "Create", builder => builder.EmitString(destination));
+
+        Analyze(context, 1).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AnalyzeContextualPattern_DoesNotAssociateUnrelatedTempLookupWithWrite()
+    {
+        var context = CreateContext("System.IO.File", "WriteAllText", builder =>
+        {
+            builder.EmitCall("System.IO.Path", "GetTempPath", builder.Module.TypeSystem.String);
+            builder.Emit(OpCodes.Pop);
+            builder.EmitString(@"C:\Users\Test\Documents\output.exe");
+            builder.EmitString("content");
+        });
+
+        Analyze(context, 4).Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(@"C:\Windows\payload.exe")]
+    [InlineData(@"C:\Program Files\Example\payload.dll")]
+    [InlineData(@"C:\Program Files (x86)\Example\payload.cmd")]
+    public void AnalyzeContextualPattern_DetectsHardCodedSystemFolderDestinations(string destination)
+    {
+        var context = CreateContext("System.IO.File", "Create", builder => builder.EmitString(destination));
+
+        Analyze(context, 1).Should().ContainSingle();
+    }
+
     [Theory]
     [InlineData(@"C:\Users\Test\AppData\Startup\config.txt", false)]
     [InlineData(@"C:\Temp\output.exe", false)]
@@ -249,7 +303,7 @@ public class PersistenceRuleTests
     }
 
     [Theory]
-    [InlineData("System.IO.File", "WriteAllText", @"C:\ProgramData\payload.exe", 1)]
+    [InlineData("System.IO.File", "WriteAllText", @"C:\ProgramData\payload.exe", 2)]
     [InlineData("System.IO.Directory", "Move", @"C:\Users\Test\AppData\dest.exe", 2)]
     public void AnalyzeContextualPattern_DetectsTrackedSystemIoTypes(
         string declaringType,
@@ -259,12 +313,16 @@ public class PersistenceRuleTests
     {
         var context = CreateContext(declaringType, methodName, builder =>
         {
-            if (callIndex == 2)
+            if (methodName.Equals("Move", StringComparison.OrdinalIgnoreCase))
             {
                 builder.EmitString("source.exe");
             }
 
             builder.EmitString(targetPath);
+            if (methodName.Contains("Write", StringComparison.OrdinalIgnoreCase))
+            {
+                builder.EmitString("content");
+            }
         });
 
         Analyze(context, callIndex).Should().HaveCount(1);
@@ -286,7 +344,7 @@ public class PersistenceRuleTests
     }
 
     [Fact]
-    public void AnalyzeContextualPattern_DoesNotFindStringBeyond10InstructionWindow()
+    public void AnalyzeContextualPattern_ResolvesDestinationAcrossInterveningNops()
     {
         var context = CreateContext("System.IO.File", "Create", builder =>
         {
@@ -297,7 +355,7 @@ public class PersistenceRuleTests
             }
         });
 
-        Analyze(context, 12).Should().BeEmpty();
+        Analyze(context, 12).Should().ContainSingle();
     }
 
     [Fact]
@@ -306,10 +364,11 @@ public class PersistenceRuleTests
         var context = CreateContext("System.IO.File", "WriteAllText", builder =>
         {
             builder.EmitString(@"C:\Startup\payload.exe");
+            builder.EmitString("content");
             builder.Emit(OpCodes.Nop);
         });
 
-        var findings = Analyze(context, 2);
+        var findings = Analyze(context, 3);
 
         findings.Should().HaveCount(1);
         findings[0].CodeSnippet.Should().NotBeNullOrEmpty();
@@ -365,6 +424,18 @@ public class PersistenceRuleTests
             methodName,
             methodBuilder.Module.TypeSystem.Void,
             CreateTypeReference(methodBuilder.Module, declaringType));
+
+        int parameterCount = methodName.Equals(".ctor", StringComparison.OrdinalIgnoreCase)
+            ? 3
+            : methodName.Equals("Copy", StringComparison.OrdinalIgnoreCase) ||
+              methodName.Equals("Move", StringComparison.OrdinalIgnoreCase) ||
+              methodName.Contains("Write", StringComparison.OrdinalIgnoreCase)
+                ? 2
+                : 1;
+        for (int i = 0; i < parameterCount; i++)
+        {
+            writeMethod.Parameters.Add(new ParameterDefinition(methodBuilder.Module.TypeSystem.String));
+        }
 
         methodBuilder.EmitCallInternal(CreateCallStub(methodBuilder.Module, writeMethod));
         methodBuilder.EndMethod();

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -106,6 +106,32 @@ namespace MLVScan.Models.Rules.Helpers
         }
 
         /// <summary>
+        /// Tries to resolve one argument supplied to a call site.
+        /// </summary>
+        public static bool TryResolveCallArgumentDisplay(
+            MethodDefinition? containingMethod,
+            MethodReference calledMethod,
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            int callIndex,
+            int parameterIndex,
+            out string valueDisplay)
+        {
+            valueDisplay = "<unknown/non-literal>";
+            if (parameterIndex < 0 || parameterIndex >= calledMethod.Parameters.Count)
+                return false;
+
+            var context = new ResolverContext(containingMethod?.Module);
+            if (!TryResolveCallArguments(context, containingMethod, instructions, callIndex,
+                    calledMethod.Parameters.Count, null, 0, out var arguments))
+            {
+                return false;
+            }
+
+            valueDisplay = arguments[parameterIndex].Display;
+            return true;
+        }
+
+        /// <summary>
         /// Tries to recover a constant value assigned to <c>ProcessStartInfo.UseShellExecute</c>.
         /// </summary>
         /// <param name="containingMethod">The method containing the process launch.</param>

--- a/Models/Rules/PersistenceRule.cs
+++ b/Models/Rules/PersistenceRule.cs
@@ -6,7 +6,7 @@ using Mono.Cecil.Cil;
 namespace MLVScan.Models.Rules
 {
     /// <summary>
-    /// Companion rule that detects file writes to payload staging folders.
+    /// Detects file writes to payload staging and persistence folders.
     /// Triggers on Path.GetTempPath() writes and executable/script writes to sensitive folders.
     /// </summary>
     public class PersistenceRule : IScanRule
@@ -16,10 +16,10 @@ namespace MLVScan.Models.Rules
             ".exe", ".dll", ".bat", ".cmd", ".ps1", ".vbs", ".js", ".hta", ".scr", ".com"
         };
 
-        public string Description => "Detected file write to %TEMP% folder (companion finding).";
-        public Severity Severity => Severity.Medium;
+        public string Description => "Detected executable or script write to a persistence folder.";
+        public Severity Severity => Severity.High;
         public string RuleId => "PersistenceRule";
-        public bool RequiresCompanionFinding => true;
+        public bool RequiresCompanionFinding => false;
 
         public IDeveloperGuidance? DeveloperGuidance => new DeveloperGuidance(
             "Use your mod framework's configuration system instead of direct file I/O. " +
@@ -40,6 +40,9 @@ namespace MLVScan.Models.Rules
             return folderValue is
                 7 or  // Startup
                 24 or // CommonStartup
+                26 or // ApplicationData
+                28 or // LocalApplicationData
+                35 or // CommonApplicationData / ProgramData
                 36 or // Windows
                 37 or // System
                 38 or // ProgramFiles
@@ -142,8 +145,9 @@ namespace MLVScan.Models.Rules
                 }
             }
 
-            bool foundSensitivePayloadWrite = sensitiveFolderName != null &&
-                                              HasSuspiciousPayloadPath(instructions, instructionIndex);
+            bool foundSensitivePayloadWrite =
+                (sensitiveFolderName != null || HasSensitiveFolderLiteral(instructions, instructionIndex)) &&
+                HasSuspiciousPayloadPath(instructions, instructionIndex);
 
             if (foundTempPath || foundSensitivePayloadWrite)
             {
@@ -158,13 +162,13 @@ namespace MLVScan.Models.Rules
                 }
 
                 string description = foundTempPath
-                    ? "Potential payload drop: Writing to TEMP folder (companion finding)"
-                    : $"Potential payload drop: Writing executable/script payload to sensitive folder {sensitiveFolderName} (companion finding)";
+                    ? "Potential payload drop: Writing to TEMP folder"
+                    : $"Potential persistence: Writing executable/script payload to sensitive folder{(sensitiveFolderName == null ? string.Empty : $" {sensitiveFolderName}")}";
 
                 yield return new ScanFinding(
                     $"{method.DeclaringType.FullName}.{method.Name}:{instructions[instructionIndex].Offset}",
                     description,
-                    Severity.Medium,
+                    foundTempPath ? Severity.Medium : Severity.High,
                     snippetBuilder.ToString().TrimEnd());
             }
         }
@@ -182,7 +186,7 @@ namespace MLVScan.Models.Rules
             Mono.Collections.Generic.Collection<Instruction> instructions,
             int instructionIndex)
         {
-            int start = Math.Max(0, instructionIndex - 12);
+            int start = Math.Max(0, instructionIndex - 10);
             int end = Math.Min(instructions.Count, instructionIndex + 3);
 
             for (int i = start; i < end; i++)
@@ -202,6 +206,27 @@ namespace MLVScan.Models.Rules
             return false;
         }
 
+        private static bool HasSensitiveFolderLiteral(
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            int instructionIndex)
+        {
+            int start = Math.Max(0, instructionIndex - 10);
+            int end = Math.Min(instructions.Count, instructionIndex + 3);
+
+            for (int i = start; i < end; i++)
+            {
+                if (instructions[i].OpCode == OpCodes.Ldstr && instructions[i].Operand is string literal &&
+                    (literal.Contains("Startup", StringComparison.OrdinalIgnoreCase) ||
+                     literal.Contains("AppData", StringComparison.OrdinalIgnoreCase) ||
+                     literal.Contains("ProgramData", StringComparison.OrdinalIgnoreCase)))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private static bool IsFileWriteOperation(
             string typeName,
             string methodName,
@@ -211,7 +236,15 @@ namespace MLVScan.Models.Rules
             if (typeName.Equals("System.IO.File", StringComparison.OrdinalIgnoreCase) &&
                 (methodName.Contains("Write", StringComparison.OrdinalIgnoreCase) ||
                  methodName.Contains("Create", StringComparison.OrdinalIgnoreCase) ||
-                 methodName.Contains("Append", StringComparison.OrdinalIgnoreCase)))
+                 methodName.Contains("Append", StringComparison.OrdinalIgnoreCase) ||
+                 methodName.Equals("Copy", StringComparison.OrdinalIgnoreCase) ||
+                 methodName.Equals("Move", StringComparison.OrdinalIgnoreCase)))
+            {
+                return true;
+            }
+
+            if (typeName.Equals("System.IO.Directory", StringComparison.OrdinalIgnoreCase) &&
+                methodName.Equals("Move", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }

--- a/Models/Rules/PersistenceRule.cs
+++ b/Models/Rules/PersistenceRule.cs
@@ -40,9 +40,6 @@ namespace MLVScan.Models.Rules
             return folderValue is
                 7 or  // Startup
                 24 or // CommonStartup
-                26 or // ApplicationData
-                28 or // LocalApplicationData
-                35 or // CommonApplicationData / ProgramData
                 36 or // Windows
                 37 or // System
                 38 or // ProgramFiles

--- a/Models/Rules/PersistenceRule.cs
+++ b/Models/Rules/PersistenceRule.cs
@@ -1,5 +1,6 @@
 using MLVScan.Abstractions;
 using MLVScan.Models;
+using MLVScan.Models.Rules.Helpers;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 
@@ -112,8 +113,6 @@ namespace MLVScan.Models.Rules
                 }
             }
 
-            // Only flag if we find actual Path.GetTempPath() call
-            bool foundTempPath = false;
             string? sensitiveFolderName = null;
 
             for (int i = 0; i < instructions.Count; i++)
@@ -124,12 +123,6 @@ namespace MLVScan.Models.Rules
                     instr.Operand is MethodReference pathMethod)
                 {
                     var pathDeclaringType = pathMethod.DeclaringType?.FullName ?? "";
-
-                    if (pathDeclaringType == "System.IO.Path" && pathMethod.Name == "GetTempPath")
-                    {
-                        foundTempPath = true;
-                        break;
-                    }
 
                     if (pathDeclaringType == "System.Environment" && pathMethod.Name == "GetFolderPath")
                     {
@@ -142,9 +135,13 @@ namespace MLVScan.Models.Rules
                 }
             }
 
+            if (!TryResolveDestinationPath(method, instructions, instructionIndex, out string destinationPath))
+                yield break;
+
+            bool foundTempPath = HasDirectoryComponent(destinationPath, "%TEMP%");
             bool foundSensitivePayloadWrite =
-                (sensitiveFolderName != null || HasSensitiveFolderLiteral(instructions, instructionIndex)) &&
-                HasSuspiciousPayloadPath(instructions, instructionIndex);
+                HasSuspiciousPayloadExtension(destinationPath) &&
+                (sensitiveFolderName != null || HasSensitiveDirectoryComponent(destinationPath));
 
             if (foundTempPath || foundSensitivePayloadWrite)
             {
@@ -179,43 +176,41 @@ namespace MLVScan.Models.Rules
                        35;   // CommonApplicationData / ProgramData
         }
 
-        private static bool HasSuspiciousPayloadPath(
+        private static bool TryResolveDestinationPath(
+            MethodReference method,
             Mono.Collections.Generic.Collection<Instruction> instructions,
-            int instructionIndex)
+            int instructionIndex,
+            out string destinationPath)
         {
-            int start = Math.Max(0, instructionIndex - 10);
-            int end = Math.Min(instructions.Count, instructionIndex + 3);
-
-            for (int i = start; i < end; i++)
-            {
-                if (instructions[i].OpCode != OpCodes.Ldstr || instructions[i].Operand is not string literal)
-                    continue;
-
-                if (SuspiciousPayloadExtensions.Any(ext =>
-                        literal.EndsWith(ext, StringComparison.OrdinalIgnoreCase) ||
-                        literal.Contains(ext + "\"", StringComparison.OrdinalIgnoreCase) ||
-                        literal.Contains(ext + "'", StringComparison.OrdinalIgnoreCase)))
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            bool isCopyOrMove = method.Name.Equals("Copy", StringComparison.OrdinalIgnoreCase) ||
+                                method.Name.Equals("Move", StringComparison.OrdinalIgnoreCase);
+            int destinationParameterIndex = isCopyOrMove ? 1 : 0;
+            return InstructionValueResolver.TryResolveCallArgumentDisplay(
+                null, method, instructions, instructionIndex, destinationParameterIndex, out destinationPath);
         }
 
-        private static bool HasSensitiveFolderLiteral(
-            Mono.Collections.Generic.Collection<Instruction> instructions,
-            int instructionIndex)
+        private static bool HasSuspiciousPayloadExtension(string path)
         {
-            int start = Math.Max(0, instructionIndex - 10);
-            int end = Math.Min(instructions.Count, instructionIndex + 3);
+            return SuspiciousPayloadExtensions.Any(ext => path.EndsWith(ext, StringComparison.OrdinalIgnoreCase));
+        }
 
-            for (int i = start; i < end; i++)
+        private static bool HasSensitiveDirectoryComponent(string path)
+        {
+            return HasDirectoryComponent(path,
+                "Startup", "AppData", "ProgramData", "Windows", "System", "System32",
+                "Program Files", "Program Files (x86)", "ProgramFiles", "ProgramFilesX86");
+        }
+
+        private static bool HasDirectoryComponent(string path, params string[] expectedComponents)
+        {
+            string normalized = path.Replace('\\', '/').TrimEnd('/');
+            string[] components = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            int directoryComponentCount = Math.Max(0, components.Length - 1);
+
+            for (int i = 0; i < directoryComponentCount; i++)
             {
-                if (instructions[i].OpCode == OpCodes.Ldstr && instructions[i].Operand is string literal &&
-                    (literal.Contains("Startup", StringComparison.OrdinalIgnoreCase) ||
-                     literal.Contains("AppData", StringComparison.OrdinalIgnoreCase) ||
-                     literal.Contains("ProgramData", StringComparison.OrdinalIgnoreCase)))
+                if (expectedComponents.Any(expected =>
+                        components[i].Equals(expected, StringComparison.OrdinalIgnoreCase)))
                 {
                     return true;
                 }

--- a/Models/Rules/PersistenceRule.cs
+++ b/Models/Rules/PersistenceRule.cs
@@ -155,14 +155,14 @@ namespace MLVScan.Models.Rules
                     snippetBuilder.AppendLine(instructions[j].ToString());
                 }
 
-                string description = foundTempPath
-                    ? "Potential payload drop: Writing to TEMP folder"
-                    : $"Potential persistence: Writing executable/script payload to sensitive folder{(sensitiveFolderName == null ? string.Empty : $" {sensitiveFolderName}")}";
+                string description = foundSensitivePayloadWrite
+                    ? $"Potential persistence: Writing executable/script payload to sensitive folder{(sensitiveFolderName == null ? string.Empty : $" {sensitiveFolderName}")}"
+                    : "Potential payload drop: Writing to TEMP folder";
 
                 yield return new ScanFinding(
                     $"{method.DeclaringType.FullName}.{method.Name}:{instructions[instructionIndex].Offset}",
                     description,
-                    foundTempPath ? Severity.Medium : Severity.High,
+                    foundSensitivePayloadWrite ? Severity.High : Severity.Medium,
                     snippetBuilder.ToString().TrimEnd());
             }
         }


### PR DESCRIPTION
### Motivation
Standalone executable/script writes to Startup, AppData, ProgramData, and other persistence-sensitive folders could be suppressed as companion-only TEMP staging, allowing a clear persistence sample to scan without a blocking signal.

### Fix
- Restore `PersistenceRule` as a standalone High rule for executable/script writes to persistence-sensitive destinations.
- Keep TEMP-only staging Medium while ensuring a sensitive destination always takes High precedence.
- Resolve the actual path argument consumed by each file API; for `Copy`/`Move`, inspect only the destination.
- Match normalized directory components (Startup, AppData, ProgramData, Windows/System, and Program Files variants), avoiding filename-substring false positives.
- Keep AppData/ProgramData out of the scanner-wide sensitive-folder predicate and scope them to persistence writes, preserving benign network/config behavior.
- Expand supported write APIs and add regression coverage for direct literals, `Environment.GetFolderPath`, Copy/Move, unrelated TEMP lookups, path-component precision, and severity priority.

### Validation
- `dotnet test MLVScan.Core.Tests/MLVScan.Core.Tests.csproj --no-restore --filter "FullyQualifiedName~PersistenceRule|FullyQualifiedName~InstructionValueResolver|FullyQualifiedName~Scan_FalsePositiveSample_ShouldNotProduceFindings|FullyQualifiedName~QuarantineMalwareScanTests" --verbosity minimal` — 131 passed, 0 failed, 0 skipped.
- The full false-positive summary retains the existing unrelated AngleSharp, SideHustle, and Sideload baseline failures; the introduced eMployee.dll regression was removed and it again produces zero findings.
- `git diff --check` passed.
- All six automated review threads were addressed and resolved.