### PR TITLE
Prevent quadratic work in Base64 contextual suppression

### DIFF
--- a/MLVScan.Core.Tests/Unit/Rules/Base64RuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/Base64RuleTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using MLVScan.Core.Tests.TestUtilities;
 using MLVScan.Models;
 using MLVScan.Models.Rules;
+using MLVScan.Models.Rules.Helpers;
 using Mono.Cecil.Cil;
 using Xunit;
 
@@ -123,5 +124,29 @@ public class Base64RuleTests
         };
 
         _rule.ShouldSuppressFinding(methodRef, instructions, 1, new MethodSignals()).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_MultipleCallsInSameMethod_CollectsEvidenceOnce()
+    {
+        var methodRef = MethodReferenceFactory.Create("System.Convert", "FromBase64String");
+        var instructions = new Mono.Collections.Generic.Collection<Instruction>
+        {
+            Instruction.Create(OpCodes.Ldarg_0),
+            Instruction.Create(OpCodes.Call, methodRef),
+            Instruction.Create(OpCodes.Ldarg_0),
+            Instruction.Create(OpCodes.Call, methodRef)
+        };
+        int collectionCount = 0;
+        var rule = new Base64Rule(methodInstructions =>
+        {
+            collectionCount++;
+            return ObfuscatedExecutionHeuristics.CollectEvidence(methodInstructions);
+        });
+
+        rule.ShouldSuppressFinding(methodRef, instructions, 1, new MethodSignals()).Should().BeTrue();
+        rule.ShouldSuppressFinding(methodRef, instructions, 3, new MethodSignals()).Should().BeTrue();
+
+        collectionCount.Should().Be(1);
     }
 }

--- a/Models/Rules/Base64Rule.cs
+++ b/Models/Rules/Base64Rule.cs
@@ -3,6 +3,7 @@ using MLVScan.Models;
 using MLVScan.Models.Rules.Helpers;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+using System.Runtime.CompilerServices;
 
 namespace MLVScan.Models.Rules
 {
@@ -12,6 +13,25 @@ namespace MLVScan.Models.Rules
     /// </summary>
     public class Base64Rule : IScanRule
     {
+        private readonly Func<Mono.Collections.Generic.Collection<Instruction>, ObfuscatedExecutionEvidence>
+            _evidenceCollector;
+        private readonly ConditionalWeakTable<Mono.Collections.Generic.Collection<Instruction>,
+            Lazy<ObfuscatedExecutionEvidence>> _evidenceByMethod = new();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Base64Rule"/> class.
+        /// </summary>
+        public Base64Rule()
+            : this(ObfuscatedExecutionHeuristics.CollectEvidence)
+        {
+        }
+
+        internal Base64Rule(
+            Func<Mono.Collections.Generic.Collection<Instruction>, ObfuscatedExecutionEvidence> evidenceCollector)
+        {
+            _evidenceCollector = evidenceCollector ?? throw new ArgumentNullException(nameof(evidenceCollector));
+        }
+
         /// <summary>
         /// Gets the human-readable description for this rule.
         /// </summary>
@@ -85,8 +105,13 @@ namespace MLVScan.Models.Rules
             if (!IsSuspicious(method))
                 return true;
 
-            ObfuscatedExecutionEvidence evidence =
-                ObfuscatedExecutionHeuristics.CollectEvidence(instructions);
+            // Instruction collections are stable while a method is being analyzed. Cache the method-wide
+            // evidence so a method containing many Base64 calls is scanned only once, rather than once per call.
+            ObfuscatedExecutionEvidence evidence = _evidenceByMethod.GetValue(
+                instructions,
+                methodInstructions => new Lazy<ObfuscatedExecutionEvidence>(
+                    () => _evidenceCollector(methodInstructions),
+                    LazyThreadSafetyMode.ExecutionAndPublication)).Value;
 
             bool hasExecutionOrDynamicSink =
                 evidence.HasProcessLikeSink ||


### PR DESCRIPTION
### Motivation
`Base64Rule.ShouldSuppressFinding` performed a full-method evidence collection for every Base64 call. A method with K decode calls and N instructions therefore incurred O(K*N) work on attacker-controlled input.

### Fix
- Cache obfuscated-execution evidence once per instruction collection with a weak-key `ConditionalWeakTable`.
- Use thread-safe `Lazy` initialization so concurrent scans do not duplicate collection.
- Preserve the existing suppression decision while avoiding lifetime leaks.
- Add an injected collector regression proving two calls in one method collect evidence only once.

### Validation
- `dotnet test MLVScan.Core.Tests/MLVScan.Core.Tests.csproj --filter "FullyQualifiedName~Base64Rule" --verbosity minimal` — 18 passed, 0 failed, 0 skipped.
- GitHub reports no unresolved review threads; CodeRabbit status is successful.
- `git diff --check` passed in the generated task.