### PR TITLE
Fix hidden process dynamic loader detection bypass

### DIFF
--- a/MLVScan.Core.Tests/Unit/Services/ThreatFamilyClassifierTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/ThreatFamilyClassifierTests.cs
@@ -671,6 +671,10 @@ public class ThreatFamilyClassifierTests
         matches.Should().ContainSingle(match =>
             match.FamilyId == "family-dynamic-assembly-reflection-loader-v2" &&
             match.VariantId == "dynamic-code-loader-hidden-system-process");
+
+        var disposition = new ThreatDispositionClassifier().Classify(findings, matches);
+        disposition.Classification.Should().Be(ThreatDispositionClassification.KnownThreat);
+        disposition.PrimaryThreatFamilyId.Should().Be("family-dynamic-assembly-reflection-loader-v2");
     }
 
     [Fact]

--- a/MLVScan.Core.Tests/Unit/Services/ThreatFamilyClassifierTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/ThreatFamilyClassifierTests.cs
@@ -646,6 +646,34 @@ public class ThreatFamilyClassifierTests
     }
 
     [Fact]
+    public void Classify_WithPathBasedDynamicLoadAndHiddenSvchost_ReturnsDynamicAssemblyLoaderFamily()
+    {
+        var classifier = new ThreatFamilyClassifier();
+        var findings = new List<ScanFinding>
+        {
+            new("Plugin.Loader.Load:38",
+                "Detected dynamic assembly loading via Assembly.LoadFrom(string).",
+                Severity.High)
+            {
+                RuleId = "AssemblyDynamicLoadRule",
+                RiskScore = 60
+            },
+            new("Plugin.Runner.Start:42",
+                "Detected Process.Start call which could execute arbitrary programs. Target: \"svchost.exe\". Arguments: <unknown/no-arguments> [Evasion: CreateNoWindow=true, WindowStyle=Hidden] [LOLBin with hidden execution (CreateNoWindow, WindowStyle.Hidden)]",
+                Severity.Critical)
+            {
+                RuleId = "ProcessStartRule"
+            }
+        };
+
+        var matches = classifier.Classify(findings, null);
+
+        matches.Should().ContainSingle(match =>
+            match.FamilyId == "family-dynamic-assembly-reflection-loader-v2" &&
+            match.VariantId == "dynamic-code-loader-hidden-system-process");
+    }
+
+    [Fact]
     public void Classify_WithCorrelatedDownloadExecuteWithoutDataInfiltrationFinding_ReturnsWebDownloadFamily()
     {
         var classifier = new ThreatFamilyClassifier();

--- a/Services/ThreatIntel/ThreatFamilyCatalog.cs
+++ b/Services/ThreatIntel/ThreatFamilyCatalog.cs
@@ -611,7 +611,7 @@ internal static partial class ThreatFamilyCatalog
         var dynamicCodeFlow = context.FindDataFlow(DataFlowPattern.DynamicCodeLoading);
 
         if (processFinding == null ||
-            (dynamicCodeFlow == null && !IsHighRiskOpaqueDynamicLoad(dynamicLoadFinding)))
+            (dynamicLoadFinding == null && dynamicCodeFlow == null))
         {
             return null;
         }


### PR DESCRIPTION
### Motivation
Path-based dynamic loads such as `Assembly.LoadFrom` paired with a hidden system-process launch could miss the dynamic-loader threat family and fall through to a Clean disposition.

### Fix
- Let the hidden-system-process variant accept either an `AssemblyDynamicLoadRule` finding or a `DynamicCodeLoading` flow.
- Keep the existing opaque-load risk predicate as an additional signal, not the only gate for path-based loads.
- Add a regression for a High `Assembly.LoadFrom` finding plus hidden `svchost.exe`.
- Assert the complete family-to-disposition chain returns `KnownThreat`, not merely a family match.

### Validation
- `dotnet test MLVScan.Core.Tests/MLVScan.Core.Tests.csproj --no-restore --filter "FullyQualifiedName~ThreatFamilyClassifierTests|FullyQualifiedName~ThreatDispositionClassifierTests" --verbosity minimal` — 35 passed, 0 failed, 0 skipped.
- GitHub reports no unresolved review threads.
- `git diff --check` passed.