### PR TITLE
Bound decoded static strings during post-analysis

### DIFF
--- a/MLVScan.Core.Tests/Unit/Rules/ObfuscatedReflectiveExecutionRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ObfuscatedReflectiveExecutionRuleTests.cs
@@ -349,6 +349,41 @@ namespace MLVScan.Core.Tests.Unit.Rules
             findings.Should().BeEmpty();
         }
 
+        [Fact]
+        public void CollectDecodedStaticArrayStrings_SkipsOversizedFieldAndKeepsLaterMarkers()
+        {
+            var assembly = TestAssemblyBuilder.Create("StaticArrayBudget").Build();
+            ModuleDefinition module = assembly.MainModule;
+            var type = new TypeDefinition(
+                "TestNamespace",
+                "StaticData",
+                TypeAttributes.Public | TypeAttributes.Class,
+                module.TypeSystem.Object);
+            module.Types.Add(type);
+
+            type.Fields.Add(new FieldDefinition(
+                "Padding",
+                FieldAttributes.Private | FieldAttributes.Static | FieldAttributes.HasFieldRVA,
+                module.TypeSystem.Byte)
+            {
+                InitialValue = new byte[256 * 1024 + 1]
+            });
+            type.Fields.Add(new FieldDefinition(
+                "Marker",
+                FieldAttributes.Private | FieldAttributes.Static | FieldAttributes.HasFieldRVA,
+                module.TypeSystem.Byte)
+            {
+                InitialValue = System.Text.Encoding.ASCII.GetBytes("System.Net.WebClient")
+            });
+
+            var collect = typeof(ObfuscatedReflectiveExecutionRule).GetMethod(
+                "CollectDecodedStaticArrayStrings",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+            var decoded = (IReadOnlyList<string>)collect.Invoke(null, new object[] { module })!;
+
+            decoded.Should().Contain("System.Net.WebClient");
+        }
+
         private static (MethodDefinition Method, ModuleDefinition Module) CreateTestMethod()
         {
             var assembly = TestAssemblyBuilder.Create("TestAssembly").Build();

--- a/Models/Rules/ObfuscatedReflectiveExecutionRule.cs
+++ b/Models/Rules/ObfuscatedReflectiveExecutionRule.cs
@@ -118,13 +118,15 @@ namespace MLVScan.Models.Rules
             List<ScanFinding> priorFindings = existingFindings?.ToList() ?? new List<ScanFinding>();
             var findings = new List<ScanFinding>();
             IReadOnlyList<string> moduleDecodedStrings = CollectDecodedStaticArrayStrings(module);
+            var moduleDecodedMarkerCache = new Dictionary<string, bool>(StringComparer.Ordinal);
 
             foreach (var namespaceGroup in EnumerateTypes(module)
                          .Where(static type => !string.IsNullOrWhiteSpace(type.Namespace))
                          .GroupBy(static type => type.Namespace, StringComparer.Ordinal))
             {
                 RemoteConfigTempCmdStagerEvidence remoteConfigEvidence =
-                    CollectRemoteConfigTempCmdStagerEvidence(namespaceGroup, moduleDecodedStrings);
+                    CollectRemoteConfigTempCmdStagerEvidence(
+                        namespaceGroup, moduleDecodedStrings, moduleDecodedMarkerCache);
                 if (remoteConfigEvidence.ShouldReport)
                 {
                     findings.Add(new ScanFinding(
@@ -321,10 +323,13 @@ namespace MLVScan.Models.Rules
 
         private static RemoteConfigTempCmdStagerEvidence CollectRemoteConfigTempCmdStagerEvidence(
             IEnumerable<TypeDefinition> namespaceTypes,
-            IReadOnlyList<string> moduleDecodedStrings)
+            IReadOnlyList<string> moduleDecodedStrings,
+            IDictionary<string, bool> moduleDecodedMarkerCache)
         {
             var evidence = new RemoteConfigTempCmdStagerEvidence();
-            var recoveredStrings = new HashSet<string>(moduleDecodedStrings, StringComparer.OrdinalIgnoreCase);
+            // Module-wide decoded strings are read-only evidence. Keep namespace-local strings separate so
+            // every namespace does not copy and rehash the same attacker-controlled module collection.
+            var recoveredStrings = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (TypeDefinition type in namespaceTypes)
             {
@@ -461,33 +466,52 @@ namespace MLVScan.Models.Rules
                 }
             }
 
-            if (recoveredStrings.Any(value => ContainsMarker(value, "System.Net.WebClient", "WebClient")) &&
-                recoveredStrings.Any(value => ContainsMarker(value, "DownloadString", "DownloadFile")))
+            if (ContainsRecoveredMarker(recoveredStrings, moduleDecodedStrings, moduleDecodedMarkerCache, "System.Net.WebClient", "WebClient") &&
+                ContainsRecoveredMarker(recoveredStrings, moduleDecodedStrings, moduleDecodedMarkerCache, "DownloadString", "DownloadFile"))
             {
                 evidence.HasReflectedNetworkDownload = true;
             }
 
-            if (recoveredStrings.Any(value => ContainsMarker(value, "System.IO.Path", "Path")) &&
-                recoveredStrings.Any(value => ContainsMarker(value, "GetTempFileName")) &&
-                recoveredStrings.Any(value => ContainsMarker(value, ".cmd", ".bat")) &&
-                recoveredStrings.Any(value => ContainsMarker(value, "System.IO.File", "File")) &&
-                recoveredStrings.Any(value => ContainsMarker(value, "WriteAllText", "WriteAllBytes")))
+            if (ContainsRecoveredMarker(recoveredStrings, moduleDecodedStrings, moduleDecodedMarkerCache, "System.IO.Path", "Path") &&
+                ContainsRecoveredMarker(recoveredStrings, moduleDecodedStrings, moduleDecodedMarkerCache, "GetTempFileName") &&
+                ContainsRecoveredMarker(recoveredStrings, moduleDecodedStrings, moduleDecodedMarkerCache, ".cmd", ".bat") &&
+                ContainsRecoveredMarker(recoveredStrings, moduleDecodedStrings, moduleDecodedMarkerCache, "System.IO.File", "File") &&
+                ContainsRecoveredMarker(recoveredStrings, moduleDecodedStrings, moduleDecodedMarkerCache, "WriteAllText", "WriteAllBytes"))
             {
                 evidence.HasTempScriptStaging = true;
             }
 
-            if (recoveredStrings.Any(value => ContainsMarker(value, "System.Diagnostics.ProcessStartInfo", "ProcessStartInfo")) &&
-                recoveredStrings.Any(value => ContainsMarker(value, "System.Diagnostics.Process", "Process")) &&
-                recoveredStrings.Any(value => ContainsMarker(value, "cmd.exe")) &&
-                recoveredStrings.Any(value => ContainsMarker(value, "/c")) &&
-                recoveredStrings.Any(value => ContainsMarker(value, "WindowStyle")) &&
-                recoveredStrings.Any(value => ContainsMarker(value, "Hidden")) &&
-                recoveredStrings.Any(value => ContainsMarker(value, "UseShellExecute", "CreateNoWindow")))
+            if (ContainsRecoveredMarker(recoveredStrings, moduleDecodedStrings, moduleDecodedMarkerCache, "System.Diagnostics.ProcessStartInfo", "ProcessStartInfo") &&
+                ContainsRecoveredMarker(recoveredStrings, moduleDecodedStrings, moduleDecodedMarkerCache, "System.Diagnostics.Process", "Process") &&
+                ContainsRecoveredMarker(recoveredStrings, moduleDecodedStrings, moduleDecodedMarkerCache, "cmd.exe") &&
+                ContainsRecoveredMarker(recoveredStrings, moduleDecodedStrings, moduleDecodedMarkerCache, "/c") &&
+                ContainsRecoveredMarker(recoveredStrings, moduleDecodedStrings, moduleDecodedMarkerCache, "WindowStyle") &&
+                ContainsRecoveredMarker(recoveredStrings, moduleDecodedStrings, moduleDecodedMarkerCache, "Hidden") &&
+                ContainsRecoveredMarker(recoveredStrings, moduleDecodedStrings, moduleDecodedMarkerCache, "UseShellExecute", "CreateNoWindow"))
             {
                 evidence.HasHiddenCmdProcessLaunch = true;
             }
 
             return evidence;
+        }
+
+        private static bool ContainsRecoveredMarker(
+            IEnumerable<string> namespaceStrings,
+            IReadOnlyList<string> moduleDecodedStrings,
+            IDictionary<string, bool> moduleDecodedMarkerCache,
+            params string[] markers)
+        {
+            if (namespaceStrings.Any(value => ContainsMarker(value, markers)))
+                return true;
+
+            string cacheKey = string.Join('\0', markers);
+            if (!moduleDecodedMarkerCache.TryGetValue(cacheKey, out bool moduleContainsMarker))
+            {
+                moduleContainsMarker = moduleDecodedStrings.Any(value => ContainsMarker(value, markers));
+                moduleDecodedMarkerCache[cacheKey] = moduleContainsMarker;
+            }
+
+            return moduleContainsMarker;
         }
 
         private static IReadOnlyList<string> CollectDecodedStaticArrayStrings(ModuleDefinition module)

--- a/Models/Rules/ObfuscatedReflectiveExecutionRule.cs
+++ b/Models/Rules/ObfuscatedReflectiveExecutionRule.cs
@@ -20,6 +20,8 @@ namespace MLVScan.Models.Rules
         private const int MinimumTotalScore = 70;
         private const int ReflectionOnlyDangerFloor = 10;
         private const int ReflectionOnlyDecodeFloor = 45;
+        private const int MaximumDecodedStaticArrayStrings = 256;
+        private const int MaximumDecodedStaticArrayBytes = 256 * 1024;
 
         /// <summary>
         /// Gets the description emitted when the rule identifies an obfuscated execution chain.
@@ -491,6 +493,7 @@ namespace MLVScan.Models.Rules
         private static IReadOnlyList<string> CollectDecodedStaticArrayStrings(ModuleDefinition module)
         {
             var strings = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            int inspectedBytes = 0;
 
             foreach (TypeDefinition type in EnumerateTypes(module))
             {
@@ -501,6 +504,13 @@ namespace MLVScan.Models.Rules
                         continue;
                     }
 
+                    if (strings.Count >= MaximumDecodedStaticArrayStrings ||
+                        field.InitialValue.Length > MaximumDecodedStaticArrayBytes - inspectedBytes)
+                    {
+                        return strings.ToList();
+                    }
+
+                    inspectedBytes += field.InitialValue.Length;
                     if (TryDecodePrintableBytes(field.InitialValue, out string decoded))
                     {
                         strings.Add(decoded);

--- a/Models/Rules/ObfuscatedReflectiveExecutionRule.cs
+++ b/Models/Rules/ObfuscatedReflectiveExecutionRule.cs
@@ -22,6 +22,7 @@ namespace MLVScan.Models.Rules
         private const int ReflectionOnlyDecodeFloor = 45;
         private const int MaximumDecodedStaticArrayStrings = 256;
         private const int MaximumDecodedStaticArrayBytes = 256 * 1024;
+        private const int MaximumDecodedStaticArrayFieldBytes = 4096;
 
         /// <summary>
         /// Gets the description emitted when the rule identifies an obfuscated execution chain.
@@ -528,6 +529,13 @@ namespace MLVScan.Models.Rules
                         continue;
                     }
 
+                    // Oversized initializers cannot be decoded by this heuristic. Ignore them without
+                    // allowing attacker-controlled padding to terminate collection before later markers.
+                    if (field.InitialValue.Length > MaximumDecodedStaticArrayFieldBytes)
+                    {
+                        continue;
+                    }
+
                     if (strings.Count >= MaximumDecodedStaticArrayStrings ||
                         field.InitialValue.Length > MaximumDecodedStaticArrayBytes - inspectedBytes)
                     {
@@ -548,7 +556,7 @@ namespace MLVScan.Models.Rules
         private static bool TryDecodePrintableBytes(byte[] bytes, out string decoded)
         {
             decoded = string.Empty;
-            if (bytes.Length < 3 || bytes.Length > 4096)
+            if (bytes.Length < 3 || bytes.Length > MaximumDecodedStaticArrayFieldBytes)
             {
                 return false;
             }


### PR DESCRIPTION
### Motivation
Post-analysis collected module-wide decoded RVA strings once but copied and rehashed the entire collection for every namespace, allowing attacker-controlled namespace and static-data counts to amplify CPU and memory work.

### Fix
- Cap eligible decoded static strings at 256 and aggregate decoded bytes at 256 KiB.
- Keep module-wide strings read-only; namespace analysis no longer copies them.
- Cache module marker lookups once across all namespaces while retaining namespace-local recovered strings.
- Skip oversized (>4096-byte), non-decodable RVA fields rather than allowing padding to terminate collection before later markers.
- Add an order-sensitive regression proving a valid marker after oversized padding remains visible.

### Validation
- `dotnet test MLVScan.Core.Tests/MLVScan.Core.Tests.csproj --no-restore --filter "FullyQualifiedName~ObfuscatedReflectiveExecution|FullyQualifiedName~QuarantineMalwareScanTests" --verbosity minimal` — 68 passed, 0 failed, 0 skipped.
- The automated review thread was addressed and resolved; CodeRabbit status is successful.
- `git diff --check` passed.