### PR TITLE
Mark mock WASM scan results as incomplete

### DIFF
--- a/MLVScan.WASM/npm/src/index.ts
+++ b/MLVScan.WASM/npm/src/index.ts
@@ -54,10 +54,14 @@ const mockScanResult: ScanResult = {
     triggeredRules: [],
   },
   analysisCompleteness: {
-    status: 'Complete',
-    isComplete: true,
-    reviewRecommended: false,
-    reasons: [],
+    status: 'Incomplete',
+    isComplete: false,
+    reviewRecommended: true,
+    reasons: [{
+      reasonId: 'MockScanner',
+      summary: 'The WASM scanner did not run; this mock result must not be treated as a completed analysis.',
+      phase: 'Initialization',
+    }],
   },
   findings: []
 }


### PR DESCRIPTION
### Motivation
When the real WASM scanner did not run, explicit or fallback mock results reported `Complete` with zero findings, allowing downstream consumers to treat a non-scan as a trusted clean analysis.

### Fix
- Mark mock results `Incomplete`, `isComplete: false`, and `reviewRecommended: true`.
- Add a structured `MockScanner` initialization reason explaining that the WASM scanner did not run.
- Preserve the existing result shape and explicit/fallback mock control flow.

### Validation
- `bun x --package typescript@5.9.3 tsc` — passed.
- Bun runtime assertions validated `scanAssembly`, `scanAssemblyWithConfig`, and `scanAssemblyWithProgress` all return the fail-closed completeness contract in mock mode.
- GitHub reports no unresolved review threads; CodeRabbit status is successful.
- `git diff --check` passed.