### PR TITLE
Detect schemeless Discord webhook endpoints

### DIFF
--- a/MLVScan.Core.Tests/Unit/Rules/DataExfiltrationRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/DataExfiltrationRuleTests.cs
@@ -103,6 +103,40 @@ public class DataExfiltrationRuleTests
         findings[0].Description.Should().Contain("exfiltration");
     }
 
+    [Theory]
+    [InlineData("discord.com/api/webhooks/123456/abcdef")]
+    [InlineData("discordapp.com/api/webhooks/123456/abcdef")]
+    public void AnalyzeContextualPattern_SchemelessDiscordWebhookPost_ReturnsCriticalFinding(string endpoint)
+    {
+        var methodRef = MethodReferenceFactory.Create("System.Net.Http.HttpClient", "PostAsync");
+        var instructions = new Mono.Collections.Generic.Collection<Instruction>();
+        instructions.Add(Instruction.Create(OpCodes.Ldstr, endpoint));
+        instructions.Add(Instruction.Create(OpCodes.Call, methodRef));
+        var methodSignals = new MethodSignals();
+
+        var findings = _rule.AnalyzeContextualPattern(methodRef, instructions, 1, methodSignals).ToList();
+
+        findings.Should().ContainSingle();
+        findings[0].Severity.Should().Be(Severity.Critical);
+        findings[0].Description.Should().Contain("Discord webhook");
+    }
+
+    [Theory]
+    [InlineData("discord.com.evil.example/api/webhooks/123456/abcdef")]
+    [InlineData("notdiscord.com/api/webhooks/123456/abcdef")]
+    public void AnalyzeContextualPattern_MasqueradedSchemelessDiscordWebhookPost_ReturnsNoFinding(string endpoint)
+    {
+        var methodRef = MethodReferenceFactory.Create("System.Net.Http.HttpClient", "PostAsync");
+        var instructions = new Mono.Collections.Generic.Collection<Instruction>();
+        instructions.Add(Instruction.Create(OpCodes.Ldstr, endpoint));
+        instructions.Add(Instruction.Create(OpCodes.Call, methodRef));
+        var methodSignals = new MethodSignals();
+
+        var findings = _rule.AnalyzeContextualPattern(methodRef, instructions, 1, methodSignals).ToList();
+
+        findings.Should().BeEmpty();
+    }
+
     [Fact]
     public void AnalyzeContextualPattern_FragmentedDiscordWebhookPost_ReturnsCriticalFinding()
     {

--- a/Models/Rules/DataExfiltrationRule.cs
+++ b/Models/Rules/DataExfiltrationRule.cs
@@ -232,7 +232,8 @@ namespace MLVScan.Models.Rules
 
         private static bool IsDiscordWebhookEndpoint(string literal)
         {
-            return ExtractUrls(literal).Any(url =>
+            var urls = ExtractUrls(literal).Concat(ExtractSchemelessDiscordWebhookUrls(literal));
+            return urls.Any(url =>
             {
                 if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
                     return false;
@@ -244,6 +245,16 @@ namespace MLVScan.Models.Rules
                         host.EndsWith(".discordapp.com", StringComparison.OrdinalIgnoreCase)) &&
                        uri.AbsolutePath.StartsWith("/api/webhooks", StringComparison.OrdinalIgnoreCase);
             });
+        }
+
+        private static IEnumerable<string> ExtractSchemelessDiscordWebhookUrls(string literal)
+        {
+            foreach (Match match in Regex.Matches(literal,
+                         @"(?<![a-z0-9.-])((?:[a-z0-9-]+\.)*discord(?:app)?\.com/api/webhooks(?:/[^\s""'<>]*)?)",
+                         RegexOptions.IgnoreCase))
+            {
+                yield return "https://" + match.Groups[1].Value;
+            }
         }
 
         private static bool IsWebhookCollectionEndpoint(string literal)


### PR DESCRIPTION
### Motivation
Discord webhook literals without an `http(s)://` prefix bypassed URL extraction and could evade the exfiltration rule.

### Fix
- Extract bounded schemeless `discord.com` and `discordapp.com` webhook candidates and normalize them to HTTPS before existing URI validation.
- Retain exact/subdomain host validation and the `/api/webhooks` path gate.
- Add positive regressions for both hosts and negative regressions for masqueraded domains.

### Validation
- `dotnet test MLVScan.Core.Tests/MLVScan.Core.Tests.csproj --filter "FullyQualifiedName~DataExfiltrationRuleTests" --verbosity minimal` — 37 passed, 0 failed, 0 skipped.
- GitHub reports no unresolved review threads; CodeRabbit status is successful.
- `git diff --check` passed.