### PR TITLE
Restore exact-hash detection for known web download stagers

### DIFF
--- a/MLVScan.Core.Tests/Unit/Services/ThreatFamilyClassifierTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/ThreatFamilyClassifierTests.cs
@@ -23,6 +23,21 @@ public class ThreatFamilyClassifierTests
         matches[0].ExactHashMatch.Should().BeTrue();
     }
 
+    [Theory]
+    [InlineData("6cb8afc1bf0e504d6b95bc05a36142f81f42b200c178e0ce6988bdf1a2c6ec0e")]
+    [InlineData("b5133362b4327a1bfecd45fe651b841372a1394fcbb6f8906a6724990b50e8a4")]
+    public void Classify_WithKnownWebDownloadHashAndNoFindings_ReturnsExactHashMatch(string sha256Hash)
+    {
+        var classifier = new ThreatFamilyClassifier();
+
+        var matches = classifier.Classify([], sha256Hash);
+
+        matches.Should().ContainSingle();
+        matches[0].FamilyId.Should().Be("family-webdownload-stage-exec-v3");
+        matches[0].MatchKind.Should().Be(ThreatMatchKind.ExactSampleHash);
+        matches[0].ExactHashMatch.Should().BeTrue();
+    }
+
     [Fact]
     public void Classify_WithPowerShellDownloaderBehavior_ReturnsBehaviorMatch()
     {

--- a/MLVScan.Core.Tests/Unit/Services/ThreatFamilyClassifierTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/ThreatFamilyClassifierTests.cs
@@ -36,6 +36,10 @@ public class ThreatFamilyClassifierTests
         matches[0].FamilyId.Should().Be("family-webdownload-stage-exec-v3");
         matches[0].MatchKind.Should().Be(ThreatMatchKind.ExactSampleHash);
         matches[0].ExactHashMatch.Should().BeTrue();
+
+        var disposition = new ThreatDispositionClassifier().Classify(Array.Empty<ScanFinding>(), matches);
+        disposition.Classification.Should().Be(ThreatDispositionClassification.KnownThreat);
+        disposition.PrimaryThreatFamilyId.Should().Be("family-webdownload-stage-exec-v3");
     }
 
     [Fact]

--- a/Services/ThreatIntel/ThreatFamilyCatalog.cs
+++ b/Services/ThreatIntel/ThreatFamilyCatalog.cs
@@ -90,7 +90,11 @@ internal static partial class ThreatFamilyCatalog
                 "2026-03-malware-vortex-backuprtilizer",
                 "2026-04-malware-dynamicorders"
             ],
-            ExactSampleHashes = [],
+            ExactSampleHashes =
+            [
+                "6cb8afc1bf0e504d6b95bc05a36142f81f42b200c178e0ce6988bdf1a2c6ec0e",
+                "b5133362b4327a1bfecd45fe651b841372a1394fcbb6f8906a6724990b50e8a4"
+            ],
             Variants =
             [
                 new ThreatFamilyVariantDefinition


### PR DESCRIPTION
### Motivation
Two confirmed web-download stager hashes were removed from the threat catalog, eliminating the exact-hash fail-safe and allowing known samples with empty or incomplete behavioral findings to fall through.

### Fix
- Restore both SHA-256 indicators to `family-webdownload-stage-exec-v3`.
- Add parameterized regressions proving each hash matches with no rule findings.
- Assert the complete exact-hash-to-disposition chain returns `KnownThreat`.

### Validation
- `dotnet test MLVScan.Core.Tests/MLVScan.Core.Tests.csproj --filter "FullyQualifiedName~ThreatFamilyClassifierTests|FullyQualifiedName~ThreatDispositionClassifierTests" --verbosity minimal` — 36 passed, 0 failed, 0 skipped.
- GitHub reports no unresolved review threads.
- `git diff --check` passed.