### PR TITLE
Prevent embedded executable droppers from bypassing disposition

### DIFF
--- a/MLVScan.Core.Tests/Integration/FalsePositiveScanTests.cs
+++ b/MLVScan.Core.Tests/Integration/FalsePositiveScanTests.cs
@@ -595,12 +595,7 @@ public class FalsePositiveScanTests
         {
             // The embedded updater is benign, but its resource -> disk -> execute behavior is
             // intentionally indistinguishable from a dropper and therefore review-required.
-            ["BoneLibUpdater.dll"] = "Suspicious",
-            // These samples contain incomplete-scan warnings and must remain review-required rather
-            // than being represented as fully scanned Clean results.
-            [@"DexterTranslator\UserLibs\XUnity.AutoTranslator.Plugin.Core.dll"] = "ManualReviewRequired",
-            ["SideHustle.dll"] = "ManualReviewRequired",
-            ["XUnity.AutoTranslator.Plugin.Core.dll"] = "ManualReviewRequired"
+            ["BoneLibUpdater.dll"] = "Suspicious"
         };
 
         foreach (var path in assemblyPaths)

--- a/MLVScan.Core.Tests/Integration/FalsePositiveScanTests.cs
+++ b/MLVScan.Core.Tests/Integration/FalsePositiveScanTests.cs
@@ -586,11 +586,22 @@ public class FalsePositiveScanTests
     }
 
     [SkippableFact]
-    public void Scan_AllFalsePositiveAssemblies_ShouldRemainCleanUnderThreatDisposition()
+    public void Scan_AllFalsePositiveAssemblies_ShouldMatchExpectedThreatDispositionBaseline()
     {
         var assemblyPaths = GetAllFalsePositiveAssemblyPaths();
         var scanner = new AssemblyScanner(RuleFactory.CreateDefaultRules());
         var violations = new List<string>();
+        var expectedNonCleanDispositions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // The embedded updater is benign, but its resource -> disk -> execute behavior is
+            // intentionally indistinguishable from a dropper and therefore review-required.
+            ["BoneLibUpdater.dll"] = "Suspicious",
+            // These samples contain incomplete-scan warnings and must remain review-required rather
+            // than being represented as fully scanned Clean results.
+            [@"DexterTranslator\UserLibs\XUnity.AutoTranslator.Plugin.Core.dll"] = "ManualReviewRequired",
+            ["SideHustle.dll"] = "ManualReviewRequired",
+            ["XUnity.AutoTranslator.Plugin.Core.dll"] = "ManualReviewRequired"
+        };
 
         foreach (var path in assemblyPaths)
         {
@@ -598,19 +609,25 @@ public class FalsePositiveScanTests
             var dto = ScanResultMapper.ToDto(findings, Path.GetFileName(path), File.ReadAllBytes(path), false);
             var familyIds = dto.ThreatFamilies?.Select(match => match.FamilyId).ToList() ?? new List<string>();
             var classification = dto.Disposition?.Classification ?? "<missing>";
+            var relativePath = Path.GetRelativePath(_falsePositivesFolder!, path);
 
             _output.WriteLine(
-                $"{Path.GetRelativePath(_falsePositivesFolder!, path)} => Disposition={classification}, ThreatFamilies={(familyIds.Count == 0 ? "None" : string.Join(", ", familyIds))}, Findings={findings.Count}");
+                $"{relativePath} => Disposition={classification}, ThreatFamilies={(familyIds.Count == 0 ? "None" : string.Join(", ", familyIds))}, Findings={findings.Count}");
 
-            if (!string.Equals(classification, "Clean", StringComparison.Ordinal) || familyIds.Count > 0)
+            var expectedClassification = expectedNonCleanDispositions.TryGetValue(relativePath, out var expected)
+                ? expected
+                : "Clean";
+
+            if (!string.Equals(classification, expectedClassification, StringComparison.Ordinal) ||
+                familyIds.Count > 0)
             {
                 violations.Add(
-                    $"{Path.GetRelativePath(_falsePositivesFolder!, path)} => Disposition={classification}, ThreatFamilies={(familyIds.Count == 0 ? "None" : string.Join(", ", familyIds))}");
+                    $"{relativePath} => ExpectedDisposition={expectedClassification}, ActualDisposition={classification}, ThreatFamilies={(familyIds.Count == 0 ? "None" : string.Join(", ", familyIds))}");
             }
         }
 
         violations.Should().BeEmpty(
-            "FALSE_POSITIVES assemblies should not produce threat-family matches or non-clean dispositions.\n" +
+            "FALSE_POSITIVES assemblies should match the explicit disposition baseline and never produce threat-family matches.\n" +
             string.Join(Environment.NewLine, violations));
     }
 

--- a/MLVScan.Core.Tests/Integration/FalsePositiveScanTests.cs
+++ b/MLVScan.Core.Tests/Integration/FalsePositiveScanTests.cs
@@ -555,6 +555,9 @@ public class FalsePositiveScanTests
         var allowedHighSeveritySamples = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "Bannerlord.ButterLib.dll",
+            // Known benign sample, but its embedded resource -> disk -> execute chain is intentionally
+            // review-required because the same static behavior is indistinguishable from a dropper.
+            "BoneLibUpdater.dll",
             "CustomTV.dll",
             "IllegalRave.dll",
             "LabFusion.dll",

--- a/MLVScan.Core.Tests/Integration/FalsePositiveScanTests.cs
+++ b/MLVScan.Core.Tests/Integration/FalsePositiveScanTests.cs
@@ -272,7 +272,7 @@ public class FalsePositiveScanTests
     }
 
     [SkippableFact]
-    public void Scan_BoneLibUpdater_ShouldRemainCleanUnderThreatDisposition()
+    public void Scan_BoneLibUpdater_EmbeddedExecutableDropper_ShouldBeSuspicious()
     {
         var path = GetSamplePath("BoneLibUpdater.dll");
 
@@ -284,8 +284,9 @@ public class FalsePositiveScanTests
         var dto = ScanResultMapper.ToDto(findings, Path.GetFileName(path), File.ReadAllBytes(path), false);
 
         dto.Disposition.Should().NotBeNull();
-        dto.Disposition!.Classification.Should().Be("Clean",
-            "BoneLibUpdater stages a bundled local updater executable, but it does not stage a temp script or invoke shell32 ShellExecuteEx like the malicious family");
+        dto.Disposition!.Classification.Should().Be("Suspicious",
+            "an embedded executable drop-and-execute chain must not evade disposition based on its path or launch API");
+        dto.Disposition.BlockingRecommended.Should().BeTrue();
         dto.ThreatFamilies.Should().BeNull();
     }
 

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowAnalyzerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowAnalyzerTests.cs
@@ -260,6 +260,70 @@ public class DataFlowAnalyzerTests
     }
 
     [Fact]
+    public void AnalyzeCrossMethodFlows_EmbeddedDropperAcrossThreeMethods_MapsPayloadPath()
+    {
+        var builder = TestAssemblyBuilder.Create("CrossMethodEmbeddedDropperTest");
+        var module = builder.Module;
+        var byteArrayType = new ArrayType(module.TypeSystem.Byte);
+        var typeBuilder = builder.AddType("TestNamespace.Dropper");
+
+        typeBuilder.AddMethod("Launch", MethodAttributes.Public | MethodAttributes.Static)
+            .AddParameter("path", module.TypeSystem.String)
+            .EmitLdarg(0)
+            .EmitCallWithParams(
+                "System.Diagnostics.Process",
+                "Start",
+                module.TypeSystem.Object,
+                module.TypeSystem.String)
+            .EmitPop()
+            .EndMethod();
+        var launchMethod = typeBuilder.TypeDefinition.Methods.First(method => method.Name == "Launch");
+
+        typeBuilder.AddMethod("Stage", MethodAttributes.Public | MethodAttributes.Static)
+            .AddParameter("bytes", byteArrayType)
+            .AddLocal(module.TypeSystem.String, out var pathLocal)
+            .EmitString("payload.exe")
+            .EmitStloc(pathLocal)
+            .EmitLdloc(pathLocal)
+            .EmitLdarg(0)
+            .EmitCallWithParams(
+                "System.IO.File",
+                "WriteAllBytes",
+                module.TypeSystem.Void,
+                module.TypeSystem.String,
+                byteArrayType)
+            .EmitLdloc(pathLocal)
+            .EmitCallInternal(launchMethod)
+            .EndMethod();
+        var stageMethod = typeBuilder.TypeDefinition.Methods.First(method => method.Name == "Stage");
+
+        typeBuilder.AddMethod("Extract", MethodAttributes.Public | MethodAttributes.Static)
+            .AddLocal(byteArrayType, out var resourceLocal)
+            .EmitString("payload.bin")
+            .EmitCallWithParams(
+                "System.Reflection.Assembly",
+                "GetManifestResourceStream",
+                byteArrayType,
+                module.TypeSystem.String)
+            .EmitStloc(resourceLocal)
+            .EmitLdloc(resourceLocal)
+            .EmitCallInternal(stageMethod)
+            .EndMethod();
+        var extractMethod = typeBuilder.TypeDefinition.Methods.First(method => method.Name == "Extract");
+
+        var analyzer = new DataFlowAnalyzer(RuleFactory.CreateDefaultRules(), new CodeSnippetBuilder());
+        analyzer.AnalyzeMethod(extractMethod);
+        analyzer.AnalyzeMethod(stageMethod);
+        analyzer.AnalyzeMethod(launchMethod);
+        analyzer.AnalyzeCrossMethodFlows();
+
+        analyzer.BuildDataFlowFindings().Should().Contain(finding =>
+            finding.DataFlowChain != null &&
+            finding.DataFlowChain.IsCrossMethod &&
+            finding.DataFlowChain.Pattern == DataFlowPattern.EmbeddedResourceDropAndExecute);
+    }
+
+    [Fact]
     public void AnalyzeCrossMethodFlows_WithNoConnectedFlows_HasZeroCrossMethodChains()
     {
         // Arrange: Two methods with operations but no cross-method data flow

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowAnalyzerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowAnalyzerTests.cs
@@ -324,6 +324,72 @@ public class DataFlowAnalyzerTests
     }
 
     [Fact]
+    public void AnalyzeCrossMethodFlows_ReassignedLaunchPath_DoesNotBridgeOldWrite()
+    {
+        var builder = TestAssemblyBuilder.Create("CrossMethodReassignedPathTest");
+        var module = builder.Module;
+        var byteArrayType = new ArrayType(module.TypeSystem.Byte);
+        var typeBuilder = builder.AddType("TestNamespace.DropperLookalike");
+
+        typeBuilder.AddMethod("Launch", MethodAttributes.Public | MethodAttributes.Static)
+            .AddParameter("path", module.TypeSystem.String)
+            .EmitLdarg(0)
+            .EmitCallWithParams(
+                "System.Diagnostics.Process",
+                "Start",
+                module.TypeSystem.Object,
+                module.TypeSystem.String)
+            .EmitPop()
+            .EndMethod();
+        var launchMethod = typeBuilder.TypeDefinition.Methods.First(method => method.Name == "Launch");
+
+        typeBuilder.AddMethod("Stage", MethodAttributes.Public | MethodAttributes.Static)
+            .AddParameter("bytes", byteArrayType)
+            .AddLocal(module.TypeSystem.String, out var pathLocal)
+            .EmitString("payload.exe")
+            .EmitStloc(pathLocal)
+            .EmitLdloc(pathLocal)
+            .EmitLdarg(0)
+            .EmitCallWithParams(
+                "System.IO.File",
+                "WriteAllBytes",
+                module.TypeSystem.Void,
+                module.TypeSystem.String,
+                byteArrayType)
+            .EmitString("benign-helper.exe")
+            .EmitStloc(pathLocal)
+            .EmitLdloc(pathLocal)
+            .EmitCallInternal(launchMethod)
+            .EndMethod();
+        var stageMethod = typeBuilder.TypeDefinition.Methods.First(method => method.Name == "Stage");
+
+        typeBuilder.AddMethod("Extract", MethodAttributes.Public | MethodAttributes.Static)
+            .AddLocal(byteArrayType, out var resourceLocal)
+            .EmitString("payload.bin")
+            .EmitCallWithParams(
+                "System.Reflection.Assembly",
+                "GetManifestResourceStream",
+                byteArrayType,
+                module.TypeSystem.String)
+            .EmitStloc(resourceLocal)
+            .EmitLdloc(resourceLocal)
+            .EmitCallInternal(stageMethod)
+            .EndMethod();
+        var extractMethod = typeBuilder.TypeDefinition.Methods.First(method => method.Name == "Extract");
+
+        var analyzer = new DataFlowAnalyzer(RuleFactory.CreateDefaultRules(), new CodeSnippetBuilder());
+        analyzer.AnalyzeMethod(extractMethod);
+        analyzer.AnalyzeMethod(stageMethod);
+        analyzer.AnalyzeMethod(launchMethod);
+        analyzer.AnalyzeCrossMethodFlows();
+
+        analyzer.BuildDataFlowFindings().Should().NotContain(finding =>
+            finding.DataFlowChain != null &&
+            finding.DataFlowChain.IsCrossMethod &&
+            finding.DataFlowChain.Pattern == DataFlowPattern.EmbeddedResourceDropAndExecute);
+    }
+
+    [Fact]
     public void AnalyzeCrossMethodFlows_WithNoConnectedFlows_HasZeroCrossMethodChains()
     {
         // Arrange: Two methods with operations but no cross-method data flow

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowAnalyzerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowAnalyzerTests.cs
@@ -324,6 +324,69 @@ public class DataFlowAnalyzerTests
     }
 
     [Fact]
+    public void AnalyzeCrossMethodFlows_DirectlyForwardedPathParameter_MapsPayloadPath()
+    {
+        var builder = TestAssemblyBuilder.Create("CrossMethodForwardedPathTest");
+        var module = builder.Module;
+        var byteArrayType = new ArrayType(module.TypeSystem.Byte);
+        var typeBuilder = builder.AddType("TestNamespace.ForwardingDropper");
+
+        typeBuilder.AddMethod("Launch", MethodAttributes.Public | MethodAttributes.Static)
+            .AddParameter("path", module.TypeSystem.String)
+            .EmitLdarg(0)
+            .EmitCallWithParams(
+                "System.Diagnostics.Process",
+                "Start",
+                module.TypeSystem.Object,
+                module.TypeSystem.String)
+            .EmitPop()
+            .EndMethod();
+        var launchMethod = typeBuilder.TypeDefinition.Methods.First(method => method.Name == "Launch");
+
+        typeBuilder.AddMethod("Stage", MethodAttributes.Public | MethodAttributes.Static)
+            .AddParameter("bytes", byteArrayType)
+            .AddParameter("path", module.TypeSystem.String)
+            .EmitLdarg(1)
+            .EmitLdarg(0)
+            .EmitCallWithParams(
+                "System.IO.File",
+                "WriteAllBytes",
+                module.TypeSystem.Void,
+                module.TypeSystem.String,
+                byteArrayType)
+            .EmitLdarg(1)
+            .EmitCallInternal(launchMethod)
+            .EndMethod();
+        var stageMethod = typeBuilder.TypeDefinition.Methods.First(method => method.Name == "Stage");
+
+        typeBuilder.AddMethod("Extract", MethodAttributes.Public | MethodAttributes.Static)
+            .AddLocal(byteArrayType, out var resourceLocal)
+            .EmitString("payload.bin")
+            .EmitCallWithParams(
+                "System.Reflection.Assembly",
+                "GetManifestResourceStream",
+                byteArrayType,
+                module.TypeSystem.String)
+            .EmitStloc(resourceLocal)
+            .EmitLdloc(resourceLocal)
+            .EmitString("payload.exe")
+            .EmitCallInternal(stageMethod)
+            .EndMethod();
+        var extractMethod = typeBuilder.TypeDefinition.Methods.First(method => method.Name == "Extract");
+
+        var analyzer = new DataFlowAnalyzer(RuleFactory.CreateDefaultRules(), new CodeSnippetBuilder());
+        analyzer.AnalyzeMethod(extractMethod);
+        analyzer.AnalyzeMethod(stageMethod);
+        analyzer.AnalyzeMethod(launchMethod);
+        analyzer.AnalyzeCrossMethodFlows();
+
+        analyzer.BuildDataFlowFindings().Should().Contain(finding =>
+            finding.DataFlowChain != null &&
+            finding.DataFlowChain.IsCrossMethod &&
+            finding.DataFlowChain.Pattern == DataFlowPattern.EmbeddedResourceDropAndExecute);
+    }
+
+    [Fact]
     public void AnalyzeCrossMethodFlows_ReassignedLaunchPath_DoesNotBridgeOldWrite()
     {
         var builder = TestAssemblyBuilder.Create("CrossMethodReassignedPathTest");

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowOperationClassifierTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowOperationClassifierTests.cs
@@ -170,6 +170,52 @@ public class DataFlowOperationClassifierTests
     }
 
     [Fact]
+    public void IdentifyInterestingOperations_CreateProcessCommandWithArguments_ExtractsExecutableIdentity()
+    {
+        var method = CreateCallerMethod(out var module);
+        var pathLocal = AddLocal(method, module.TypeSystem.String);
+        var il = method.Body.GetILProcessor();
+
+        EmitStoredPayloadPath(il, pathLocal);
+        EmitFileWrite(il, module, pathLocal);
+
+        var nativeType = new TypeDefinition(
+            "Test", "NativeMethods", TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(nativeType);
+        var nativeModule = new ModuleReference("kernel32.dll");
+        module.ModuleReferences.Add(nativeModule);
+        var createProcess = new MethodDefinition(
+            "CreateProcessW",
+            MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.PInvokeImpl,
+            module.TypeSystem.Boolean);
+        createProcess.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        createProcess.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        for (var index = 2; index < 10; index++)
+        {
+            createProcess.Parameters.Add(new ParameterDefinition(module.TypeSystem.Object));
+        }
+        createProcess.PInvokeInfo = new PInvokeInfo(PInvokeAttributes.CallConvWinapi, "CreateProcessW", nativeModule);
+        nativeType.Methods.Add(createProcess);
+
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ldstr, "\"payload.exe\" /silent");
+        for (var index = 2; index < 10; index++)
+        {
+            il.Emit(OpCodes.Ldnull);
+        }
+        il.Emit(OpCodes.Call, createProcess);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
+        var createProcessOperation = operations.Single(operation =>
+            operation.Operation.Contains("PInvoke.CreateProcess", StringComparison.OrdinalIgnoreCase));
+
+        createProcessOperation.PayloadPathIdentities.Intersect(fileWrite.PayloadPathIdentities).Should().NotBeEmpty();
+    }
+
+    [Fact]
     public void IdentifyInterestingOperations_ConditionalPathReassignment_PreservesPossiblePayloadLink()
     {
         var method = CreateCallerMethod(out var module);
@@ -324,6 +370,81 @@ public class DataFlowOperationClassifierTests
         var processStart = operations.Single(operation => operation.Operation == "Process.Start");
 
         processStart.PayloadPathIdentities.Intersect(fileWrite.PayloadPathIdentities).Should().NotBeEmpty();
+        processStart.PayloadPathIdentities.Should().Contain(identity =>
+            identity.Contains("BENIGN-HELPER.EXE", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void IdentifyInterestingOperations_StoredStartInfoConstructor_ResolvesFileName()
+    {
+        var method = CreateCallerMethod(out var module);
+        var pathLocal = AddLocal(method, module.TypeSystem.String);
+        var startInfoType = CreateTypeReference(module, "System.Diagnostics", "ProcessStartInfo");
+        var startInfoLocal = AddLocal(method, startInfoType);
+        var il = method.Body.GetILProcessor();
+
+        EmitStoredPayloadPath(il, pathLocal);
+        EmitFileWrite(il, module, pathLocal);
+        var constructor = CreateMethodReference(
+            startInfoType, ".ctor", module.TypeSystem.Void, hasThis: true, module.TypeSystem.String);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stloc, startInfoLocal);
+
+        var processType = CreateTypeReference(module, "System.Diagnostics", "Process");
+        var start = CreateMethodReference(
+            processType, "Start", processType, hasThis: false, startInfoType);
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Call, start);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
+        var processStart = operations.Single(operation => operation.Operation == "Process.Start");
+
+        processStart.PayloadPathIdentities.Intersect(fileWrite.PayloadPathIdentities).Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void IdentifyInterestingOperations_ReassignedStartInfo_IgnoresSettersOnOldObject()
+    {
+        var method = CreateCallerMethod(out var module);
+        var pathLocal = AddLocal(method, module.TypeSystem.String);
+        var startInfoType = CreateTypeReference(module, "System.Diagnostics", "ProcessStartInfo");
+        var startInfoLocal = AddLocal(method, startInfoType);
+        var il = method.Body.GetILProcessor();
+
+        EmitStoredPayloadPath(il, pathLocal);
+        EmitFileWrite(il, module, pathLocal);
+        var defaultConstructor = CreateMethodReference(
+            startInfoType, ".ctor", module.TypeSystem.Void, hasThis: true);
+        il.Emit(OpCodes.Newobj, defaultConstructor);
+        il.Emit(OpCodes.Stloc, startInfoLocal);
+        var setFileName = CreateMethodReference(
+            startInfoType, "set_FileName", module.TypeSystem.Void, hasThis: true, module.TypeSystem.String);
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Callvirt, setFileName);
+
+        var fileNameConstructor = CreateMethodReference(
+            startInfoType, ".ctor", module.TypeSystem.Void, hasThis: true, module.TypeSystem.String);
+        il.Emit(OpCodes.Ldstr, "benign-helper.exe");
+        il.Emit(OpCodes.Newobj, fileNameConstructor);
+        il.Emit(OpCodes.Stloc, startInfoLocal);
+        var processType = CreateTypeReference(module, "System.Diagnostics", "Process");
+        var start = CreateMethodReference(
+            processType, "Start", processType, hasThis: false, startInfoType);
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Call, start);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
+        var processStart = operations.Single(operation => operation.Operation == "Process.Start");
+
+        processStart.PayloadPathIdentities.Intersect(fileWrite.PayloadPathIdentities).Should().BeEmpty();
         processStart.PayloadPathIdentities.Should().Contain(identity =>
             identity.Contains("BENIGN-HELPER.EXE", StringComparison.Ordinal));
     }

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowOperationClassifierTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowOperationClassifierTests.cs
@@ -121,6 +121,44 @@ public class DataFlowOperationClassifierTests
     }
 
     [Fact]
+    public void IdentifyInterestingOperations_InstanceStart_ResolvesAssignedStartInfoConstructor()
+    {
+        var method = CreateCallerMethod(out var module);
+        var pathLocal = AddLocal(method, module.TypeSystem.String);
+        var processType = CreateTypeReference(module, "System.Diagnostics", "Process");
+        var startInfoType = CreateTypeReference(module, "System.Diagnostics", "ProcessStartInfo");
+        var processLocal = AddLocal(method, processType);
+        var il = method.Body.GetILProcessor();
+
+        EmitStoredPayloadPath(il, pathLocal);
+        EmitFileWrite(il, module, pathLocal);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Stloc, processLocal);
+
+        var constructor = CreateMethodReference(
+            startInfoType, ".ctor", module.TypeSystem.Void, hasThis: true, module.TypeSystem.String);
+        var setStartInfo = CreateMethodReference(
+            processType, "set_StartInfo", module.TypeSystem.Void, hasThis: true, startInfoType);
+        il.Emit(OpCodes.Ldloc, processLocal);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Callvirt, setStartInfo);
+
+        var start = CreateMethodReference(
+            processType, "Start", module.TypeSystem.Boolean, hasThis: true);
+        il.Emit(OpCodes.Ldloc, processLocal);
+        il.Emit(OpCodes.Callvirt, start);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
+        var processStart = operations.Single(operation => operation.Operation == "Process.Start");
+
+        processStart.PayloadPathIdentities.Intersect(fileWrite.PayloadPathIdentities).Should().NotBeEmpty();
+    }
+
+    [Fact]
     public void IdentifyInterestingOperations_CreateProcessWithNullApplication_UsesCommandLineIdentity()
     {
         var method = CreateCallerMethod(out var module);

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowOperationClassifierTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowOperationClassifierTests.cs
@@ -40,7 +40,7 @@ public class DataFlowOperationClassifierTests
         var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
         var processStart = operations.Single(operation => operation.Operation == "Process.Start");
 
-        processStart.PayloadPathIdentity.Should().Be(fileWrite.PayloadPathIdentity);
+        processStart.PayloadPathIdentities.Should().BeEquivalentTo(fileWrite.PayloadPathIdentities);
     }
 
     [Fact]
@@ -87,8 +87,9 @@ public class DataFlowOperationClassifierTests
         var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
         var processStart = operations.Single(operation => operation.Operation == "Process.Start");
 
-        processStart.PayloadPathIdentity.Should().NotBe(fileWrite.PayloadPathIdentity);
-        processStart.PayloadPathIdentity.Should().Contain("BENIGN-HELPER.EXE");
+        processStart.PayloadPathIdentities.Intersect(fileWrite.PayloadPathIdentities).Should().BeEmpty();
+        processStart.PayloadPathIdentities.Should().ContainSingle(identity =>
+            identity.Contains("BENIGN-HELPER.EXE", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -137,7 +138,91 @@ public class DataFlowOperationClassifierTests
         var createProcessOperation = operations.Single(operation =>
             operation.Operation.Contains("PInvoke.CreateProcess", StringComparison.OrdinalIgnoreCase));
 
-        createProcessOperation.PayloadPathIdentity.Should().Be(fileWrite.PayloadPathIdentity);
+        createProcessOperation.PayloadPathIdentities.Should().BeEquivalentTo(fileWrite.PayloadPathIdentities);
+    }
+
+    [Fact]
+    public void IdentifyInterestingOperations_ConditionalPathReassignment_PreservesPossiblePayloadLink()
+    {
+        var method = CreateCallerMethod(out var module);
+        var pathLocal = AddLocal(method, module.TypeSystem.String);
+        var il = method.Body.GetILProcessor();
+
+        EmitStoredPayloadPath(il, pathLocal);
+        EmitFileWrite(il, module, pathLocal);
+
+        var launch = Instruction.Create(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Brfalse_S, launch);
+        il.Emit(OpCodes.Ldstr, "other.exe");
+        il.Emit(OpCodes.Stloc, pathLocal);
+        il.Append(launch);
+        var processType = CreateTypeReference(module, "System.Diagnostics", "Process");
+        var start = CreateMethodReference(
+            processType, "Start", processType, hasThis: false, module.TypeSystem.String);
+        il.Emit(OpCodes.Call, start);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
+        var processStart = operations.Single(operation => operation.Operation == "Process.Start");
+
+        processStart.PayloadPathIdentities.Intersect(fileWrite.PayloadPathIdentities).Should().NotBeEmpty();
+        processStart.PayloadPathIdentities.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void IdentifyInterestingOperations_ShellExecuteEx_IgnoresLpFileFromDifferentStruct()
+    {
+        var method = CreateCallerMethod(out var module);
+        var pathLocal = AddLocal(method, module.TypeSystem.String);
+        var shellInfoType = new TypeDefinition(
+            "Test", "SHELLEXECUTEINFO", TypeAttributes.Public | TypeAttributes.SequentialLayout |
+                                               TypeAttributes.Sealed | TypeAttributes.AnsiClass,
+            module.ImportReference(typeof(ValueType)));
+        var lpFile = new FieldDefinition("lpFile", FieldAttributes.Public, module.TypeSystem.String);
+        shellInfoType.Fields.Add(lpFile);
+        module.Types.Add(shellInfoType);
+        var launchedInfoLocal = AddLocal(method, shellInfoType);
+        var unrelatedInfoLocal = AddLocal(method, shellInfoType);
+        var il = method.Body.GetILProcessor();
+
+        EmitStoredPayloadPath(il, pathLocal);
+        EmitFileWrite(il, module, pathLocal);
+        il.Emit(OpCodes.Ldloca, launchedInfoLocal);
+        il.Emit(OpCodes.Ldstr, "benign-helper.exe");
+        il.Emit(OpCodes.Stfld, lpFile);
+        il.Emit(OpCodes.Ldloca, unrelatedInfoLocal);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Stfld, lpFile);
+
+        var nativeType = new TypeDefinition(
+            "Test", "ShellNativeMethods", TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(nativeType);
+        var nativeModule = new ModuleReference("shell32.dll");
+        module.ModuleReferences.Add(nativeModule);
+        var shellExecute = new MethodDefinition(
+            "ShellExecuteExW",
+            MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.PInvokeImpl,
+            module.TypeSystem.Boolean);
+        shellExecute.Parameters.Add(new ParameterDefinition(new ByReferenceType(shellInfoType)));
+        shellExecute.PInvokeInfo = new PInvokeInfo(
+            PInvokeAttributes.CallConvWinapi, "ShellExecuteExW", nativeModule);
+        nativeType.Methods.Add(shellExecute);
+        il.Emit(OpCodes.Ldloca, launchedInfoLocal);
+        il.Emit(OpCodes.Call, shellExecute);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
+        var shellStart = operations.Single(operation =>
+            operation.Operation.Contains("PInvoke.ShellExecuteEx", StringComparison.OrdinalIgnoreCase));
+
+        shellStart.PayloadPathIdentities.Intersect(fileWrite.PayloadPathIdentities).Should().BeEmpty();
+        shellStart.PayloadPathIdentities.Should().ContainSingle(identity =>
+            identity.Contains("BENIGN-HELPER.EXE", StringComparison.Ordinal));
     }
 
     private static MethodDefinition CreateCallerMethod(out ModuleDefinition module)

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowOperationClassifierTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowOperationClassifierTests.cs
@@ -72,6 +72,38 @@ public class DataFlowOperationClassifierTests
     }
 
     [Fact]
+    public void IdentifyInterestingOperations_InlineStartInfoInitializer_UsesFileNameIdentity()
+    {
+        var method = CreateCallerMethod(out var module);
+        var pathLocal = AddLocal(method, module.TypeSystem.String);
+        var il = method.Body.GetILProcessor();
+
+        EmitStoredPayloadPath(il, pathLocal);
+        EmitFileWrite(il, module, pathLocal);
+        var startInfoType = CreateTypeReference(module, "System.Diagnostics", "ProcessStartInfo");
+        var constructor = CreateMethodReference(
+            startInfoType, ".ctor", module.TypeSystem.Void, hasThis: true);
+        var setFileName = CreateMethodReference(
+            startInfoType, "set_FileName", module.TypeSystem.Void, hasThis: true, module.TypeSystem.String);
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Callvirt, setFileName);
+        var processType = CreateTypeReference(module, "System.Diagnostics", "Process");
+        var start = CreateMethodReference(
+            processType, "Start", processType, hasThis: false, startInfoType);
+        il.Emit(OpCodes.Call, start);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
+        var processStart = operations.Single(operation => operation.Operation == "Process.Start");
+
+        processStart.PayloadPathIdentities.Intersect(fileWrite.PayloadPathIdentities).Should().NotBeEmpty();
+    }
+
+    [Fact]
     public void IdentifyInterestingOperations_InstanceStart_IgnoresSetterForDifferentProcess()
     {
         var method = CreateCallerMethod(out var module);
@@ -483,6 +515,42 @@ public class DataFlowOperationClassifierTests
             startInfoType, ".ctor", module.TypeSystem.Void, hasThis: true, module.TypeSystem.String);
         il.Emit(OpCodes.Ldloc, pathLocal);
         il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stloc, startInfoLocal);
+
+        var processType = CreateTypeReference(module, "System.Diagnostics", "Process");
+        var start = CreateMethodReference(
+            processType, "Start", processType, hasThis: false, startInfoType);
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Call, start);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
+        var processStart = operations.Single(operation => operation.Operation == "Process.Start");
+
+        processStart.PayloadPathIdentities.Intersect(fileWrite.PayloadPathIdentities).Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void IdentifyInterestingOperations_StoredStartInfoInitializer_UsesFileNameIdentity()
+    {
+        var method = CreateCallerMethod(out var module);
+        var pathLocal = AddLocal(method, module.TypeSystem.String);
+        var startInfoType = CreateTypeReference(module, "System.Diagnostics", "ProcessStartInfo");
+        var startInfoLocal = AddLocal(method, startInfoType);
+        var il = method.Body.GetILProcessor();
+
+        EmitStoredPayloadPath(il, pathLocal);
+        EmitFileWrite(il, module, pathLocal);
+        var constructor = CreateMethodReference(
+            startInfoType, ".ctor", module.TypeSystem.Void, hasThis: true);
+        var setFileName = CreateMethodReference(
+            startInfoType, "set_FileName", module.TypeSystem.Void, hasThis: true, module.TypeSystem.String);
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Callvirt, setFileName);
         il.Emit(OpCodes.Stloc, startInfoLocal);
 
         var processType = CreateTypeReference(module, "System.Diagnostics", "Process");

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowOperationClassifierTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowOperationClassifierTests.cs
@@ -1,0 +1,208 @@
+using FluentAssertions;
+using MLVScan.Services.DataFlow;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xunit;
+
+namespace MLVScan.Core.Tests.Unit.Services;
+
+public class DataFlowOperationClassifierTests
+{
+    [Fact]
+    public void IdentifyInterestingOperations_ProcessStartInfoOverload_UsesFileNameIdentity()
+    {
+        var method = CreateCallerMethod(out var module);
+        var pathLocal = AddLocal(method, module.TypeSystem.String);
+        var startInfoType = CreateTypeReference(module, "System.Diagnostics", "ProcessStartInfo");
+        var startInfoLocal = AddLocal(method, startInfoType);
+        var il = method.Body.GetILProcessor();
+
+        EmitStoredPayloadPath(il, pathLocal);
+        EmitFileWrite(il, module, pathLocal);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Stloc, startInfoLocal);
+
+        var setFileName = CreateMethodReference(
+            startInfoType, "set_FileName", module.TypeSystem.Void, hasThis: true, module.TypeSystem.String);
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Callvirt, setFileName);
+
+        var processType = CreateTypeReference(module, "System.Diagnostics", "Process");
+        var start = CreateMethodReference(
+            processType, "Start", processType, hasThis: false, startInfoType);
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Call, start);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
+        var processStart = operations.Single(operation => operation.Operation == "Process.Start");
+
+        processStart.PayloadPathIdentity.Should().Be(fileWrite.PayloadPathIdentity);
+    }
+
+    [Fact]
+    public void IdentifyInterestingOperations_InstanceStart_IgnoresSetterForDifferentProcess()
+    {
+        var method = CreateCallerMethod(out var module);
+        var pathLocal = AddLocal(method, module.TypeSystem.String);
+        var processType = CreateTypeReference(module, "System.Diagnostics", "Process");
+        var startInfoType = CreateTypeReference(module, "System.Diagnostics", "ProcessStartInfo");
+        var configuredProcessLocal = AddLocal(method, processType);
+        var startedProcessLocal = AddLocal(method, processType);
+        var il = method.Body.GetILProcessor();
+
+        EmitStoredPayloadPath(il, pathLocal);
+        EmitFileWrite(il, module, pathLocal);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Stloc, configuredProcessLocal);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Stloc, startedProcessLocal);
+
+        var getStartInfo = CreateMethodReference(
+            processType, "get_StartInfo", startInfoType, hasThis: true);
+        var setFileName = CreateMethodReference(
+            startInfoType, "set_FileName", module.TypeSystem.Void, hasThis: true, module.TypeSystem.String);
+
+        il.Emit(OpCodes.Ldloc, configuredProcessLocal);
+        il.Emit(OpCodes.Callvirt, getStartInfo);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Callvirt, setFileName);
+
+        il.Emit(OpCodes.Ldloc, startedProcessLocal);
+        il.Emit(OpCodes.Callvirt, getStartInfo);
+        il.Emit(OpCodes.Ldstr, "benign-helper.exe");
+        il.Emit(OpCodes.Callvirt, setFileName);
+
+        var start = CreateMethodReference(
+            processType, "Start", module.TypeSystem.Boolean, hasThis: true);
+        il.Emit(OpCodes.Ldloc, startedProcessLocal);
+        il.Emit(OpCodes.Callvirt, start);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
+        var processStart = operations.Single(operation => operation.Operation == "Process.Start");
+
+        processStart.PayloadPathIdentity.Should().NotBe(fileWrite.PayloadPathIdentity);
+        processStart.PayloadPathIdentity.Should().Contain("BENIGN-HELPER.EXE");
+    }
+
+    [Fact]
+    public void IdentifyInterestingOperations_CreateProcessWithNullApplication_UsesCommandLineIdentity()
+    {
+        var method = CreateCallerMethod(out var module);
+        var pathLocal = AddLocal(method, module.TypeSystem.String);
+        var applicationNameLocal = AddLocal(method, module.TypeSystem.String);
+        var il = method.Body.GetILProcessor();
+
+        EmitStoredPayloadPath(il, pathLocal);
+        EmitFileWrite(il, module, pathLocal);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Stloc, applicationNameLocal);
+
+        var nativeType = new TypeDefinition(
+            "Test", "NativeMethods", TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(nativeType);
+        var nativeModule = new ModuleReference("kernel32.dll");
+        module.ModuleReferences.Add(nativeModule);
+        var createProcess = new MethodDefinition(
+            "CreateProcessW",
+            MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.PInvokeImpl,
+            module.TypeSystem.Boolean);
+        createProcess.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        createProcess.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        for (var index = 2; index < 10; index++)
+        {
+            createProcess.Parameters.Add(new ParameterDefinition(module.TypeSystem.Object));
+        }
+        createProcess.PInvokeInfo = new PInvokeInfo(PInvokeAttributes.CallConvWinapi, "CreateProcessW", nativeModule);
+        nativeType.Methods.Add(createProcess);
+
+        il.Emit(OpCodes.Ldloc, applicationNameLocal);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        for (var index = 2; index < 10; index++)
+        {
+            il.Emit(OpCodes.Ldnull);
+        }
+        il.Emit(OpCodes.Call, createProcess);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
+        var createProcessOperation = operations.Single(operation =>
+            operation.Operation.Contains("PInvoke.CreateProcess", StringComparison.OrdinalIgnoreCase));
+
+        createProcessOperation.PayloadPathIdentity.Should().Be(fileWrite.PayloadPathIdentity);
+    }
+
+    private static MethodDefinition CreateCallerMethod(out ModuleDefinition module)
+    {
+        var assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition("DataFlowOperationClassifierTests", new Version(1, 0)),
+            "DataFlowOperationClassifierTests",
+            ModuleKind.Dll);
+        module = assembly.MainModule;
+        var type = new TypeDefinition(
+            "Test", "Caller", TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(type);
+        var method = new MethodDefinition(
+            "Run", MethodAttributes.Public | MethodAttributes.Static, module.TypeSystem.Void);
+        method.Body = new MethodBody(method) { InitLocals = true };
+        type.Methods.Add(method);
+        return method;
+    }
+
+    private static VariableDefinition AddLocal(MethodDefinition method, TypeReference type)
+    {
+        var local = new VariableDefinition(type);
+        method.Body.Variables.Add(local);
+        return local;
+    }
+
+    private static void EmitStoredPayloadPath(ILProcessor il, VariableDefinition pathLocal)
+    {
+        il.Emit(OpCodes.Ldstr, "payload.exe");
+        il.Emit(OpCodes.Stloc, pathLocal);
+    }
+
+    private static void EmitFileWrite(ILProcessor il, ModuleDefinition module, VariableDefinition pathLocal)
+    {
+        var fileType = CreateTypeReference(module, "System.IO", "File");
+        var writeAllBytes = CreateMethodReference(
+            fileType,
+            "WriteAllBytes",
+            module.TypeSystem.Void,
+            hasThis: false,
+            module.TypeSystem.String,
+            new ArrayType(module.TypeSystem.Byte));
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Call, writeAllBytes);
+    }
+
+    private static TypeReference CreateTypeReference(ModuleDefinition module, string @namespace, string name)
+    {
+        return new TypeReference(@namespace, name, module, module.TypeSystem.CoreLibrary);
+    }
+
+    private static MethodReference CreateMethodReference(
+        TypeReference declaringType,
+        string name,
+        TypeReference returnType,
+        bool hasThis,
+        params TypeReference[] parameterTypes)
+    {
+        var method = new MethodReference(name, returnType, declaringType) { HasThis = hasThis };
+        foreach (var parameterType in parameterTypes)
+        {
+            method.Parameters.Add(new ParameterDefinition(parameterType));
+        }
+
+        return method;
+    }
+}

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowOperationClassifierTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowOperationClassifierTests.cs
@@ -197,7 +197,7 @@ public class DataFlowOperationClassifierTests
         var processStart = operations.Single(operation => operation.Operation == "Process.Start");
 
         processStart.PayloadPathIdentities.Intersect(fileWrite.PayloadPathIdentities).Should().NotBeEmpty();
-        processStart.PayloadPathIdentities.Should().HaveCount(2);
+        processStart.PayloadPathIdentities.Should().HaveCount(3);
     }
 
     [Fact]
@@ -251,6 +251,117 @@ public class DataFlowOperationClassifierTests
         shellStart.PayloadPathIdentities.Intersect(fileWrite.PayloadPathIdentities).Should().BeEmpty();
         shellStart.PayloadPathIdentities.Should().ContainSingle(identity =>
             identity.Contains("BENIGN-HELPER.EXE", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void IdentifyInterestingOperations_LocalPathAlias_PreservesConcretePayloadLink()
+    {
+        var method = CreateCallerMethod(out var module);
+        var pathLocal = AddLocal(method, module.TypeSystem.String);
+        var aliasLocal = AddLocal(method, module.TypeSystem.String);
+        var il = method.Body.GetILProcessor();
+
+        EmitStoredPayloadPath(il, pathLocal);
+        EmitFileWrite(il, module, pathLocal);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Stloc, aliasLocal);
+
+        var processType = CreateTypeReference(module, "System.Diagnostics", "Process");
+        var start = CreateMethodReference(
+            processType, "Start", processType, hasThis: false, module.TypeSystem.String);
+        il.Emit(OpCodes.Ldloc, aliasLocal);
+        il.Emit(OpCodes.Call, start);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
+        var processStart = operations.Single(operation => operation.Operation == "Process.Start");
+
+        processStart.PayloadPathIdentities.Intersect(fileWrite.PayloadPathIdentities).Should().NotBeEmpty();
+        processStart.PayloadPathIdentities.Should().Contain(identity =>
+            identity.Contains("PAYLOAD.EXE", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void IdentifyInterestingOperations_ConditionalStartInfoAssignment_TracksAllReachingPaths()
+    {
+        var method = CreateCallerMethod(out var module);
+        var pathLocal = AddLocal(method, module.TypeSystem.String);
+        var startInfoType = CreateTypeReference(module, "System.Diagnostics", "ProcessStartInfo");
+        var startInfoLocal = AddLocal(method, startInfoType);
+        var il = method.Body.GetILProcessor();
+
+        EmitStoredPayloadPath(il, pathLocal);
+        EmitFileWrite(il, module, pathLocal);
+        var constructor = CreateMethodReference(
+            startInfoType, ".ctor", module.TypeSystem.Void, hasThis: true);
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stloc, startInfoLocal);
+
+        var setFileName = CreateMethodReference(
+            startInfoType, "set_FileName", module.TypeSystem.Void, hasThis: true, module.TypeSystem.String);
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Callvirt, setFileName);
+
+        var launch = Instruction.Create(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Brfalse_S, launch);
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Ldstr, "benign-helper.exe");
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Append(launch);
+        var processType = CreateTypeReference(module, "System.Diagnostics", "Process");
+        var start = CreateMethodReference(
+            processType, "Start", processType, hasThis: false, startInfoType);
+        il.Emit(OpCodes.Call, start);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
+        var processStart = operations.Single(operation => operation.Operation == "Process.Start");
+
+        processStart.PayloadPathIdentities.Intersect(fileWrite.PayloadPathIdentities).Should().NotBeEmpty();
+        processStart.PayloadPathIdentities.Should().Contain(identity =>
+            identity.Contains("BENIGN-HELPER.EXE", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void IdentifyInterestingOperations_UnresolvedArguments_AreNotPathIdentities()
+    {
+        var method = CreateCallerMethod(out var module);
+        method.Parameters.Add(new ParameterDefinition("writePath", ParameterAttributes.None, module.TypeSystem.String));
+        method.Parameters.Add(new ParameterDefinition("launchPath", ParameterAttributes.None, module.TypeSystem.String));
+        var il = method.Body.GetILProcessor();
+
+        var fileType = CreateTypeReference(module, "System.IO", "File");
+        var writeAllBytes = CreateMethodReference(
+            fileType,
+            "WriteAllBytes",
+            module.TypeSystem.Void,
+            hasThis: false,
+            module.TypeSystem.String,
+            new ArrayType(module.TypeSystem.Byte));
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Call, writeAllBytes);
+
+        var processType = CreateTypeReference(module, "System.Diagnostics", "Process");
+        var start = CreateMethodReference(
+            processType, "Start", processType, hasThis: false, module.TypeSystem.String);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, start);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
+        var processStart = operations.Single(operation => operation.Operation == "Process.Start");
+
+        fileWrite.PayloadPathIdentities.Should().BeEmpty();
+        processStart.PayloadPathIdentities.Should().BeEmpty();
     }
 
     [Fact]

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowOperationClassifierTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowOperationClassifierTests.cs
@@ -300,6 +300,62 @@ public class DataFlowOperationClassifierTests
     }
 
     [Fact]
+    public void IdentifyInterestingOperations_ConditionalShellExecuteFile_TracksAllReachingStores()
+    {
+        var method = CreateCallerMethod(out var module);
+        var pathLocal = AddLocal(method, module.TypeSystem.String);
+        var shellInfoType = new TypeDefinition(
+            "Test", "SHELLEXECUTEINFO", TypeAttributes.Public | TypeAttributes.SequentialLayout |
+                                               TypeAttributes.Sealed | TypeAttributes.AnsiClass,
+            module.ImportReference(typeof(ValueType)));
+        var lpFile = new FieldDefinition("lpFile", FieldAttributes.Public, module.TypeSystem.String);
+        shellInfoType.Fields.Add(lpFile);
+        module.Types.Add(shellInfoType);
+        var shellInfoLocal = AddLocal(method, shellInfoType);
+        var il = method.Body.GetILProcessor();
+
+        EmitStoredPayloadPath(il, pathLocal);
+        EmitFileWrite(il, module, pathLocal);
+        il.Emit(OpCodes.Ldloca, shellInfoLocal);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Stfld, lpFile);
+
+        var launch = Instruction.Create(OpCodes.Ldloca, shellInfoLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Brfalse_S, launch);
+        il.Emit(OpCodes.Ldloca, shellInfoLocal);
+        il.Emit(OpCodes.Ldstr, "benign-helper.exe");
+        il.Emit(OpCodes.Stfld, lpFile);
+
+        var nativeType = new TypeDefinition(
+            "Test", "ShellNativeMethods", TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(nativeType);
+        var nativeModule = new ModuleReference("shell32.dll");
+        module.ModuleReferences.Add(nativeModule);
+        var shellExecute = new MethodDefinition(
+            "ShellExecuteExW",
+            MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.PInvokeImpl,
+            module.TypeSystem.Boolean);
+        shellExecute.Parameters.Add(new ParameterDefinition(new ByReferenceType(shellInfoType)));
+        shellExecute.PInvokeInfo = new PInvokeInfo(
+            PInvokeAttributes.CallConvWinapi, "ShellExecuteExW", nativeModule);
+        nativeType.Methods.Add(shellExecute);
+        il.Append(launch);
+        il.Emit(OpCodes.Call, shellExecute);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
+        var shellStart = operations.Single(operation =>
+            operation.Operation.Contains("PInvoke.ShellExecuteEx", StringComparison.OrdinalIgnoreCase));
+
+        shellStart.PayloadPathIdentities.Intersect(fileWrite.PayloadPathIdentities).Should().NotBeEmpty();
+        shellStart.PayloadPathIdentities.Should().Contain(identity =>
+            identity.Contains("BENIGN-HELPER.EXE", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void IdentifyInterestingOperations_LocalPathAlias_PreservesConcretePayloadLink()
     {
         var method = CreateCallerMethod(out var module);
@@ -486,6 +542,44 @@ public class DataFlowOperationClassifierTests
         processStart.PayloadPathIdentities.Should().ContainSingle(identity =>
             identity.EndsWith("::argument:1", StringComparison.Ordinal));
         fileWrite.PayloadPathIdentities.Intersect(processStart.PayloadPathIdentities).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void IdentifyInterestingOperations_UnresolvedArgumentAlias_PreservesSourceIdentity()
+    {
+        var method = CreateCallerMethod(out var module);
+        method.Parameters.Add(new ParameterDefinition("path", ParameterAttributes.None, module.TypeSystem.String));
+        var aliasLocal = AddLocal(method, module.TypeSystem.String);
+        var il = method.Body.GetILProcessor();
+
+        var fileType = CreateTypeReference(module, "System.IO", "File");
+        var writeAllBytes = CreateMethodReference(
+            fileType,
+            "WriteAllBytes",
+            module.TypeSystem.Void,
+            hasThis: false,
+            module.TypeSystem.String,
+            new ArrayType(module.TypeSystem.Byte));
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Call, writeAllBytes);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Stloc, aliasLocal);
+
+        var processType = CreateTypeReference(module, "System.Diagnostics", "Process");
+        var start = CreateMethodReference(
+            processType, "Start", processType, hasThis: false, module.TypeSystem.String);
+        il.Emit(OpCodes.Ldloc, aliasLocal);
+        il.Emit(OpCodes.Call, start);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
+        var processStart = operations.Single(operation => operation.Operation == "Process.Start");
+
+        processStart.PayloadPathIdentities.Intersect(fileWrite.PayloadPathIdentities).Should().ContainSingle(identity =>
+            identity.EndsWith("::argument:0", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowOperationClassifierTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowOperationClassifierTests.cs
@@ -329,7 +329,7 @@ public class DataFlowOperationClassifierTests
     }
 
     [Fact]
-    public void IdentifyInterestingOperations_UnresolvedArguments_AreNotPathIdentities()
+    public void IdentifyInterestingOperations_UnresolvedArguments_UseDistinctMethodScopedIdentities()
     {
         var method = CreateCallerMethod(out var module);
         method.Parameters.Add(new ParameterDefinition("writePath", ParameterAttributes.None, module.TypeSystem.String));
@@ -360,8 +360,11 @@ public class DataFlowOperationClassifierTests
         var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
         var processStart = operations.Single(operation => operation.Operation == "Process.Start");
 
-        fileWrite.PayloadPathIdentities.Should().BeEmpty();
-        processStart.PayloadPathIdentities.Should().BeEmpty();
+        fileWrite.PayloadPathIdentities.Should().ContainSingle(identity =>
+            identity.EndsWith("::argument:0", StringComparison.Ordinal));
+        processStart.PayloadPathIdentities.Should().ContainSingle(identity =>
+            identity.EndsWith("::argument:1", StringComparison.Ordinal));
+        fileWrite.PayloadPathIdentities.Intersect(processStart.PayloadPathIdentities).Should().BeEmpty();
     }
 
     [Fact]

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowOperationClassifierTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowOperationClassifierTests.cs
@@ -44,6 +44,34 @@ public class DataFlowOperationClassifierTests
     }
 
     [Fact]
+    public void IdentifyInterestingOperations_InlineProcessStartInfoConstructor_UsesFileNameIdentity()
+    {
+        var method = CreateCallerMethod(out var module);
+        var pathLocal = AddLocal(method, module.TypeSystem.String);
+        var il = method.Body.GetILProcessor();
+
+        EmitStoredPayloadPath(il, pathLocal);
+        EmitFileWrite(il, module, pathLocal);
+        var startInfoType = CreateTypeReference(module, "System.Diagnostics", "ProcessStartInfo");
+        var constructor = CreateMethodReference(
+            startInfoType, ".ctor", module.TypeSystem.Void, hasThis: true, module.TypeSystem.String);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Newobj, constructor);
+        var processType = CreateTypeReference(module, "System.Diagnostics", "Process");
+        var start = CreateMethodReference(
+            processType, "Start", processType, hasThis: false, startInfoType);
+        il.Emit(OpCodes.Call, start);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
+        var processStart = operations.Single(operation => operation.Operation == "Process.Start");
+
+        processStart.PayloadPathIdentities.Should().BeEquivalentTo(fileWrite.PayloadPathIdentities);
+    }
+
+    [Fact]
     public void IdentifyInterestingOperations_InstanceStart_IgnoresSetterForDifferentProcess()
     {
         var method = CreateCallerMethod(out var module);
@@ -223,6 +251,37 @@ public class DataFlowOperationClassifierTests
         shellStart.PayloadPathIdentities.Intersect(fileWrite.PayloadPathIdentities).Should().BeEmpty();
         shellStart.PayloadPathIdentities.Should().ContainSingle(identity =>
             identity.Contains("BENIGN-HELPER.EXE", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void IdentifyInterestingOperations_ReadOnlyFileStream_IsNotAWriteSink()
+    {
+        var method = CreateCallerMethod(out var module);
+        var pathLocal = AddLocal(method, module.TypeSystem.String);
+        var il = method.Body.GetILProcessor();
+        EmitStoredPayloadPath(il, pathLocal);
+
+        var fileStreamType = CreateTypeReference(module, "System.IO", "FileStream");
+        var fileModeType = CreateTypeReference(module, "System.IO", "FileMode");
+        var fileAccessType = CreateTypeReference(module, "System.IO", "FileAccess");
+        var constructor = CreateMethodReference(
+            fileStreamType,
+            ".ctor",
+            module.TypeSystem.Void,
+            hasThis: true,
+            module.TypeSystem.String,
+            fileModeType,
+            fileAccessType);
+        il.Emit(OpCodes.Ldloc, pathLocal);
+        il.Emit(OpCodes.Ldc_I4_3); // FileMode.Open
+        il.Emit(OpCodes.Ldc_I4_1); // FileAccess.Read
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+
+        operations.Should().NotContain(operation => operation.Operation.Contains("FileStream"));
     }
 
     private static MethodDefinition CreateCallerMethod(out ModuleDefinition module)

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowPatternEvaluatorTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowPatternEvaluatorTests.cs
@@ -77,14 +77,14 @@ public class DataFlowPatternEvaluatorTests
                 NodeType = DataFlowNodeType.Sink,
                 Operation = "File.Create",
                 DataDescription = "Writes to file",
-                PayloadPathIdentity = writtenPath
+                PayloadPathIdentities = new HashSet<string>(StringComparer.Ordinal) { writtenPath }
             },
             new()
             {
                 NodeType = DataFlowNodeType.Sink,
                 Operation = "Process.Start",
                 DataDescription = "Executes process",
-                PayloadPathIdentity = executedPath
+                PayloadPathIdentities = new HashSet<string>(StringComparer.Ordinal) { executedPath }
             }
         };
     }

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowPatternEvaluatorTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowPatternEvaluatorTests.cs
@@ -9,6 +9,25 @@ namespace MLVScan.Core.Tests.Unit.Services;
 public class DataFlowPatternEvaluatorTests
 {
     [Fact]
+    public void RecognizePattern_WithLinkedFileWriteAndProcessTarget_ReturnsEmbeddedDropper()
+    {
+        var operations = CreateEmbeddedResourceOperations("method::local:4", "method::local:4");
+
+        new DataFlowPatternEvaluator().RecognizePattern(operations)
+            .Should().Be(DataFlowPattern.EmbeddedResourceDropAndExecute);
+    }
+
+    [Fact]
+    public void RecognizePattern_WithUnrelatedFileWriteAndProcessTarget_DoesNotReturnEmbeddedDropper()
+    {
+        var operations = CreateEmbeddedResourceOperations("method::local:4", "method::local:7");
+
+        new DataFlowPatternEvaluator().RecognizePattern(operations)
+            .Should().Be(DataFlowPattern.Unknown,
+                "nearby resource handling and process execution are not a linked payload flow");
+    }
+
+    [Fact]
     public void CreateFinding_WithEmbeddedExecutableDropperWithoutScriptMarkers_PreservesSeverity()
     {
         var chain = new DataFlowChain(
@@ -39,5 +58,34 @@ public class DataFlowPatternEvaluatorTests
         var finding = new DataFlowPatternEvaluator().CreateFinding(chain);
 
         finding.Severity.Should().Be(Severity.Critical);
+    }
+
+    private static List<DataFlowInterestingOperation> CreateEmbeddedResourceOperations(
+        string writtenPath,
+        string executedPath)
+    {
+        return new List<DataFlowInterestingOperation>
+        {
+            new()
+            {
+                NodeType = DataFlowNodeType.Source,
+                Operation = "Assembly.GetManifestResourceStream",
+                DataDescription = "embedded resource"
+            },
+            new()
+            {
+                NodeType = DataFlowNodeType.Sink,
+                Operation = "File.Create",
+                DataDescription = "Writes to file",
+                PayloadPathIdentity = writtenPath
+            },
+            new()
+            {
+                NodeType = DataFlowNodeType.Sink,
+                Operation = "Process.Start",
+                DataDescription = "Executes process",
+                PayloadPathIdentity = executedPath
+            }
+        };
     }
 }

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowPatternEvaluatorTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowPatternEvaluatorTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using MLVScan.Models;
+using MLVScan.Models.DataFlow;
+using MLVScan.Services.DataFlow;
+using Xunit;
+
+namespace MLVScan.Core.Tests.Unit.Services;
+
+public class DataFlowPatternEvaluatorTests
+{
+    [Fact]
+    public void CreateFinding_WithEmbeddedExecutableDropperWithoutScriptMarkers_PreservesSeverity()
+    {
+        var chain = new DataFlowChain(
+            "df-embedded-executable",
+            DataFlowPattern.EmbeddedResourceDropAndExecute,
+            Severity.Critical,
+            "Extracts and launches an embedded executable",
+            "Malware.Loader.Run");
+        chain.AppendNode(new DataFlowNode(
+            "Malware.Loader.Run:12",
+            "GetManifestResourceStream",
+            DataFlowNodeType.Source,
+            "embedded executable",
+            12));
+        chain.AppendNode(new DataFlowNode(
+            "Malware.Loader.Run:24",
+            "File.Create",
+            DataFlowNodeType.Sink,
+            "C:/AppData/Vendor/updater.exe",
+            24));
+        chain.AppendNode(new DataFlowNode(
+            "Malware.Loader.Run:36",
+            "Process.Start",
+            DataFlowNodeType.Sink,
+            "launch updater executable",
+            36));
+
+        var finding = new DataFlowPatternEvaluator().CreateFinding(chain);
+
+        finding.Severity.Should().Be(Severity.Critical);
+    }
+}

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowPatternEvaluatorTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowPatternEvaluatorTests.cs
@@ -28,6 +28,17 @@ public class DataFlowPatternEvaluatorTests
     }
 
     [Fact]
+    public void RecognizePattern_WithExecutionBeforeMatchingWrite_DoesNotReturnEmbeddedDropper()
+    {
+        var operations = CreateEmbeddedResourceOperations("method::local:4", "method::local:4");
+        (operations[1], operations[2]) = (operations[2], operations[1]);
+
+        new DataFlowPatternEvaluator().RecognizePattern(operations)
+            .Should().Be(DataFlowPattern.Unknown,
+                "a payload written only after execution was not dropped and executed");
+    }
+
+    [Fact]
     public void CreateFinding_WithEmbeddedExecutableDropperWithoutScriptMarkers_PreservesSeverity()
     {
         var chain = new DataFlowChain(

--- a/MLVScan.Core.Tests/Unit/Services/Helpers/InstructionExtensionsTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/Helpers/InstructionExtensionsTests.cs
@@ -224,6 +224,7 @@ public class InstructionExtensionsTests
         Instruction.Create(OpCodes.Ldstr, "value").IsSimpleConstantLoad().Should().BeTrue();
         Instruction.Create(OpCodes.Ldc_I4, 5).IsSimpleConstantLoad().Should().BeTrue();
         Instruction.Create(OpCodes.Ldc_I4_S, (sbyte)2).IsSimpleConstantLoad().Should().BeTrue();
+        Instruction.Create(OpCodes.Ldc_I4_2).IsSimpleConstantLoad().Should().BeTrue();
         Instruction.Create(OpCodes.Ldnull).IsSimpleConstantLoad().Should().BeTrue();
         Instruction.Create(OpCodes.Ldc_I8, 5L).IsSimpleConstantLoad().Should().BeFalse();
     }

--- a/MLVScan.Core.Tests/Unit/Services/ThreatDispositionClassifierTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/ThreatDispositionClassifierTests.cs
@@ -182,10 +182,10 @@ public class ThreatDispositionClassifierTests
 
         var finding = new ScanFinding(
             "Benign.Updater.Run",
-            "Embedded updater executable extracted and launched with Process.Start",
+            "Detected Process.Start for an embedded updater executable with correlated data flow",
             Severity.Critical)
         {
-            RuleId = "DataFlowAnalysis",
+            RuleId = "ProcessStartRule",
             DataFlowChain = dataFlow
         };
 

--- a/MLVScan.Core.Tests/Unit/Services/ThreatDispositionClassifierTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/ThreatDispositionClassifierTests.cs
@@ -152,7 +152,7 @@ public class ThreatDispositionClassifierTests
     }
 
     [Fact]
-    public void Classify_WithEmbeddedUpdaterExeDataFlowAndNoDropperMarkers_ReturnsClean()
+    public void Classify_WithEmbeddedUpdaterExeDataFlowAndNoDropperMarkers_ReturnsSuspicious()
     {
         var classifier = new ThreatDispositionClassifier();
         var dataFlow = new DataFlowChain(
@@ -191,9 +191,9 @@ public class ThreatDispositionClassifierTests
 
         var result = classifier.Classify(new[] { finding }, threatFamilies: null);
 
-        result.Classification.Should().Be(ThreatDispositionClassification.Clean);
-        result.RelatedFindings.Should().BeEmpty();
-        result.BlockingRecommended.Should().BeFalse();
+        result.Classification.Should().Be(ThreatDispositionClassification.Suspicious);
+        result.RelatedFindings.Should().ContainSingle().Which.Should().BeSameAs(finding);
+        result.BlockingRecommended.Should().BeTrue();
     }
 
     [Fact]

--- a/Models/DataFlow/DataFlowInterestingOperation.cs
+++ b/Models/DataFlow/DataFlowInterestingOperation.cs
@@ -19,5 +19,12 @@ namespace MLVScan.Models.DataFlow
         public string DataDescription { get; set; } = string.Empty;
 
         public int? LocalVariableIndex { get; set; }
+
+        /// <summary>
+        /// Stable identity for the file path consumed by a file-write or process-execution operation.
+        /// Local identities include the containing method so unrelated locals in cross-method chains
+        /// cannot be mistaken for the same payload.
+        /// </summary>
+        public string? PayloadPathIdentity { get; set; }
     }
 }

--- a/Models/DataFlow/DataFlowInterestingOperation.cs
+++ b/Models/DataFlow/DataFlowInterestingOperation.cs
@@ -25,6 +25,6 @@ namespace MLVScan.Models.DataFlow
         /// Local identities include the containing method so unrelated locals in cross-method chains
         /// cannot be mistaken for the same payload.
         /// </summary>
-        public string? PayloadPathIdentity { get; set; }
+        public HashSet<string> PayloadPathIdentities { get; set; } = new(StringComparer.Ordinal);
     }
 }

--- a/Models/DataFlow/DataFlowMethodCallSite.cs
+++ b/Models/DataFlow/DataFlowMethodCallSite.cs
@@ -12,6 +12,8 @@ namespace MLVScan.Models.DataFlow
 
         public Dictionary<int, int> ParameterMapping { get; set; } = new();
 
+        public Dictionary<int, HashSet<int>> ParameterReachingStoreIndexes { get; set; } = new();
+
         public bool ReturnValueUsed { get; set; }
 
         public bool CalledMethodReturnsData { get; set; }

--- a/Models/DataFlow/DataFlowMethodCallSite.cs
+++ b/Models/DataFlow/DataFlowMethodCallSite.cs
@@ -14,6 +14,8 @@ namespace MLVScan.Models.DataFlow
 
         public Dictionary<int, HashSet<int>> ParameterReachingStoreIndexes { get; set; } = new();
 
+        public Dictionary<int, int> ForwardedParameterMapping { get; set; } = new();
+
         public bool ReturnValueUsed { get; set; }
 
         public bool CalledMethodReturnsData { get; set; }

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -106,6 +106,35 @@ namespace MLVScan.Models.Rules.Helpers
         }
 
         /// <summary>
+        /// Tries to resolve one argument passed to a call site. This is used by data-flow analysis to
+        /// compare file-write destinations with later process targets without relying on nearby calls.
+        /// </summary>
+        public static bool TryResolveCallArgumentDisplay(
+            MethodDefinition? containingMethod,
+            MethodReference calledMethod,
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            int callIndex,
+            int argumentIndex,
+            out string valueDisplay)
+        {
+            valueDisplay = "<unknown/non-literal>";
+            if (argumentIndex < 0 || argumentIndex >= calledMethod.Parameters.Count)
+            {
+                return false;
+            }
+
+            var context = new ResolverContext(containingMethod?.Module);
+            if (!TryResolveCallArguments(context, containingMethod, instructions, callIndex,
+                    calledMethod.Parameters.Count, null, 0, out var arguments))
+            {
+                return false;
+            }
+
+            valueDisplay = arguments[argumentIndex].Display;
+            return true;
+        }
+
+        /// <summary>
         /// Tries to recover a constant value assigned to <c>ProcessStartInfo.UseShellExecute</c>.
         /// </summary>
         /// <param name="containingMethod">The method containing the process launch.</param>

--- a/Services/DataFlow/DataFlowInstructionHelper.cs
+++ b/Services/DataFlow/DataFlowInstructionHelper.cs
@@ -123,7 +123,19 @@ namespace MLVScan.Services.DataFlow
             int localLoadIndex,
             int localIndex)
         {
-            if (localLoadIndex < 0 || localLoadIndex >= instructions.Count)
+            return GetReachingInstructionIndexes(
+                instructions,
+                localLoadIndex,
+                index => instructions[index].TryGetStoredLocalIndex(out var storedLocalIndex) &&
+                         storedLocalIndex == localIndex);
+        }
+
+        public static IReadOnlyCollection<int> GetReachingInstructionIndexes(
+            Collection<Instruction> instructions,
+            int consumerIndex,
+            Func<int, bool> isDefinition)
+        {
+            if (consumerIndex < 0 || consumerIndex >= instructions.Count)
             {
                 return Array.Empty<int>();
             }
@@ -143,8 +155,8 @@ namespace MLVScan.Services.DataFlow
                 }
             }
 
-            var offsets = new HashSet<int>();
-            var pending = new Stack<int>(predecessors[localLoadIndex]);
+            var definitions = new HashSet<int>();
+            var pending = new Stack<int>(predecessors[consumerIndex]);
             var visited = new HashSet<int>();
             while (pending.Count > 0)
             {
@@ -154,10 +166,9 @@ namespace MLVScan.Services.DataFlow
                     continue;
                 }
 
-                if (instructions[index].TryGetStoredLocalIndex(out var storedLocalIndex) &&
-                    storedLocalIndex == localIndex)
+                if (isDefinition(index))
                 {
-                    offsets.Add(index);
+                    definitions.Add(index);
                     continue;
                 }
 
@@ -167,7 +178,7 @@ namespace MLVScan.Services.DataFlow
                 }
             }
 
-            return offsets;
+            return definitions;
         }
 
         public static bool TryGetCallReceiverProducerIndex(

--- a/Services/DataFlow/DataFlowInstructionHelper.cs
+++ b/Services/DataFlow/DataFlowInstructionHelper.cs
@@ -72,10 +72,23 @@ namespace MLVScan.Services.DataFlow
             int argumentIndex,
             out int localIndex)
         {
+            return TryGetCallArgumentLocalVariable(
+                instructions, callIndex, calledMethod, argumentIndex, out localIndex, out _);
+        }
+
+        public static bool TryGetCallArgumentLocalVariable(
+            Collection<Instruction> instructions,
+            int callIndex,
+            MethodReference calledMethod,
+            int argumentIndex,
+            out int localIndex,
+            out int producerIndex)
+        {
             localIndex = -1;
+            producerIndex = -1;
             return TryGetCallArgumentProducerIndex(
-                       instructions, callIndex, calledMethod, argumentIndex, out var producerIndex) &&
-                   instructions[producerIndex].TryGetLocalIndex(out localIndex);
+                       instructions, callIndex, calledMethod, argumentIndex, out producerIndex) &&
+                   TryGetLocalOrAddressedLocalIndex(instructions[producerIndex], out localIndex);
         }
 
         public static bool TryGetCallReceiverLocalVariable(
@@ -86,7 +99,75 @@ namespace MLVScan.Services.DataFlow
         {
             localIndex = -1;
             return TryGetCallReceiverProducerIndex(instructions, callIndex, calledMethod, out var producerIndex) &&
-                   instructions[producerIndex].TryGetLocalIndex(out localIndex);
+                   TryGetLocalOrAddressedLocalIndex(instructions[producerIndex], out localIndex);
+        }
+
+        public static bool TryGetFieldStoreReceiverLocalVariable(
+            Collection<Instruction> instructions,
+            int fieldStoreIndex,
+            out int localIndex)
+        {
+            localIndex = -1;
+            if (fieldStoreIndex <= 0 ||
+                !TryFindTopValueProducer(instructions, fieldStoreIndex - 1, out var valueProducerIndex) ||
+                !TryFindTopValueProducer(instructions, valueProducerIndex - 1, out var receiverProducerIndex))
+            {
+                return false;
+            }
+
+            return TryGetLocalOrAddressedLocalIndex(instructions[receiverProducerIndex], out localIndex);
+        }
+
+        public static IReadOnlyCollection<int> GetReachingLocalStoreIndexes(
+            Collection<Instruction> instructions,
+            int localLoadIndex,
+            int localIndex)
+        {
+            if (localLoadIndex < 0 || localLoadIndex >= instructions.Count)
+            {
+                return Array.Empty<int>();
+            }
+
+            var instructionIndexes = instructions
+                .Select((instruction, index) => (instruction, index))
+                .ToDictionary(static entry => entry.instruction, static entry => entry.index);
+            var predecessors = Enumerable.Range(0, instructions.Count)
+                .Select(_ => new List<int>())
+                .ToArray();
+
+            for (var index = 0; index < instructions.Count; index++)
+            {
+                foreach (var successor in GetSuccessorIndexes(instructions, instructionIndexes, index))
+                {
+                    predecessors[successor].Add(index);
+                }
+            }
+
+            var offsets = new HashSet<int>();
+            var pending = new Stack<int>(predecessors[localLoadIndex]);
+            var visited = new HashSet<int>();
+            while (pending.Count > 0)
+            {
+                var index = pending.Pop();
+                if (!visited.Add(index))
+                {
+                    continue;
+                }
+
+                if (instructions[index].TryGetStoredLocalIndex(out var storedLocalIndex) &&
+                    storedLocalIndex == localIndex)
+                {
+                    offsets.Add(index);
+                    continue;
+                }
+
+                foreach (var predecessor in predecessors[index])
+                {
+                    pending.Push(predecessor);
+                }
+            }
+
+            return offsets;
         }
 
         public static bool TryGetCallReceiverProducerIndex(
@@ -169,6 +250,51 @@ namespace MLVScan.Services.DataFlow
                 needed += instruction.GetPopCount();
             }
 
+            return false;
+        }
+
+        private static IEnumerable<int> GetSuccessorIndexes(
+            Collection<Instruction> instructions,
+            IReadOnlyDictionary<Instruction, int> instructionIndexes,
+            int index)
+        {
+            var instruction = instructions[index];
+            if (instruction.Operand is Instruction target)
+            {
+                yield return instructionIndexes[target];
+            }
+            else if (instruction.Operand is Instruction[] targets)
+            {
+                foreach (var switchTarget in targets)
+                {
+                    yield return instructionIndexes[switchTarget];
+                }
+            }
+
+            if (index + 1 >= instructions.Count ||
+                instruction.OpCode.FlowControl is FlowControl.Branch or FlowControl.Return or FlowControl.Throw)
+            {
+                yield break;
+            }
+
+            yield return index + 1;
+        }
+
+        private static bool TryGetLocalOrAddressedLocalIndex(Instruction instruction, out int localIndex)
+        {
+            if (instruction.TryGetLocalIndex(out localIndex))
+            {
+                return true;
+            }
+
+            if ((instruction.OpCode == OpCodes.Ldloca || instruction.OpCode == OpCodes.Ldloca_S) &&
+                instruction.Operand is VariableDefinition local)
+            {
+                localIndex = local.Index;
+                return true;
+            }
+
+            localIndex = -1;
             return false;
         }
 

--- a/Services/DataFlow/DataFlowInstructionHelper.cs
+++ b/Services/DataFlow/DataFlowInstructionHelper.cs
@@ -197,6 +197,16 @@ namespace MLVScan.Services.DataFlow
             return TryFindTopValueProducer(instructions, cursor, out producerIndex);
         }
 
+        public static bool TryGetConsumedValueProducerIndex(
+            Collection<Instruction> instructions,
+            int consumerIndex,
+            out int producerIndex)
+        {
+            producerIndex = -1;
+            return consumerIndex > 0 &&
+                   TryFindTopValueProducer(instructions, consumerIndex - 1, out producerIndex);
+        }
+
         public static bool TryGetCallArgumentProducerIndex(
             Collection<Instruction> instructions,
             int callIndex,

--- a/Services/DataFlow/DataFlowInstructionHelper.cs
+++ b/Services/DataFlow/DataFlowInstructionHelper.cs
@@ -196,7 +196,7 @@ namespace MLVScan.Services.DataFlow
             return TryFindTopValueProducer(instructions, cursor, out producerIndex);
         }
 
-        private static bool TryGetCallArgumentProducerIndex(
+        public static bool TryGetCallArgumentProducerIndex(
             Collection<Instruction> instructions,
             int callIndex,
             MethodReference calledMethod,

--- a/Services/DataFlow/DataFlowInstructionHelper.cs
+++ b/Services/DataFlow/DataFlowInstructionHelper.cs
@@ -186,12 +186,13 @@ namespace MLVScan.Services.DataFlow
             var cursor = callIndex - 1;
             for (var argumentIndex = calledMethod.Parameters.Count - 1; argumentIndex >= 0; argumentIndex--)
             {
-                if (!TryFindTopValueProducer(instructions, cursor, out var argumentProducer))
+                if (!TryFindTopValueProducer(instructions, cursor, out var argumentProducer) ||
+                    !TryFindValueExpressionStart(instructions, argumentProducer, out var argumentStart))
                 {
                     return false;
                 }
 
-                cursor = argumentProducer - 1;
+                cursor = argumentStart - 1;
             }
 
             return TryFindTopValueProducer(instructions, cursor, out producerIndex);
@@ -234,7 +235,12 @@ namespace MLVScan.Services.DataFlow
                     return true;
                 }
 
-                cursor = currentProducer - 1;
+                if (!TryFindValueExpressionStart(instructions, currentProducer, out var expressionStart))
+                {
+                    return false;
+                }
+
+                cursor = expressionStart - 1;
             }
 
             return false;
@@ -259,6 +265,27 @@ namespace MLVScan.Services.DataFlow
                 }
 
                 needed += instruction.GetPopCount();
+            }
+
+            return false;
+        }
+
+        private static bool TryFindValueExpressionStart(
+            Collection<Instruction> instructions,
+            int producerIndex,
+            out int expressionStart)
+        {
+            expressionStart = -1;
+            var needed = 1;
+            for (var index = producerIndex; index >= 0; index--)
+            {
+                needed -= instructions[index].GetPushCount();
+                needed += instructions[index].GetPopCount();
+                if (needed <= 0)
+                {
+                    expressionStart = index;
+                    return true;
+                }
             }
 
             return false;

--- a/Services/DataFlow/DataFlowInstructionHelper.cs
+++ b/Services/DataFlow/DataFlowInstructionHelper.cs
@@ -23,22 +23,12 @@ namespace MLVScan.Services.DataFlow
             MethodReference calledMethod)
         {
             var mapping = new Dictionary<int, int>();
-            var paramCount = calledMethod.Parameters.Count;
-            var foundParams = 0;
-
-            for (var index = callIndex - 1; index >= 0 && foundParams < paramCount; index--)
+            for (var parameterIndex = 0; parameterIndex < calledMethod.Parameters.Count; parameterIndex++)
             {
-                var instruction = instructions[index];
-                if (instruction.TryGetLocalIndex(out var localIndex))
+                if (TryGetCallArgumentLocalVariable(
+                        instructions, callIndex, calledMethod, parameterIndex, out var localIndex))
                 {
-                    mapping[paramCount - 1 - foundParams] = localIndex;
-                    foundParams++;
-                    continue;
-                }
-
-                if (instruction.IsArgumentLoad() || instruction.IsSimpleConstantLoad())
-                {
-                    foundParams++;
+                    mapping[parameterIndex] = localIndex;
                 }
             }
 

--- a/Services/DataFlow/DataFlowInstructionHelper.cs
+++ b/Services/DataFlow/DataFlowInstructionHelper.cs
@@ -81,6 +81,23 @@ namespace MLVScan.Services.DataFlow
                    TryGetLocalOrAddressedLocalIndex(instructions[producerIndex], out localIndex);
         }
 
+        public static bool TryGetMethodParameterIndex(
+            MethodDefinition method,
+            Instruction instruction,
+            out int parameterIndex)
+        {
+            parameterIndex = -1;
+            if (!instruction.TryGetArgumentIndex(out var rawIndex))
+            {
+                return false;
+            }
+
+            parameterIndex = instruction.Operand is ParameterDefinition parameter
+                ? parameter.Index
+                : rawIndex - (method.HasThis ? 1 : 0);
+            return parameterIndex >= 0 && parameterIndex < method.Parameters.Count;
+        }
+
         public static bool TryGetCallReceiverLocalVariable(
             Collection<Instruction> instructions,
             int callIndex,

--- a/Services/DataFlow/DataFlowInstructionHelper.cs
+++ b/Services/DataFlow/DataFlowInstructionHelper.cs
@@ -65,5 +65,112 @@ namespace MLVScan.Services.DataFlow
                    nextInstruction.OpCode == OpCodes.Stsfld;
         }
 
+        public static bool TryGetCallArgumentLocalVariable(
+            Collection<Instruction> instructions,
+            int callIndex,
+            MethodReference calledMethod,
+            int argumentIndex,
+            out int localIndex)
+        {
+            localIndex = -1;
+            return TryGetCallArgumentProducerIndex(
+                       instructions, callIndex, calledMethod, argumentIndex, out var producerIndex) &&
+                   instructions[producerIndex].TryGetLocalIndex(out localIndex);
+        }
+
+        public static bool TryGetCallReceiverLocalVariable(
+            Collection<Instruction> instructions,
+            int callIndex,
+            MethodReference calledMethod,
+            out int localIndex)
+        {
+            localIndex = -1;
+            return TryGetCallReceiverProducerIndex(instructions, callIndex, calledMethod, out var producerIndex) &&
+                   instructions[producerIndex].TryGetLocalIndex(out localIndex);
+        }
+
+        public static bool TryGetCallReceiverProducerIndex(
+            Collection<Instruction> instructions,
+            int callIndex,
+            MethodReference calledMethod,
+            out int producerIndex)
+        {
+            producerIndex = -1;
+            if (!calledMethod.HasThis || callIndex <= 0)
+            {
+                return false;
+            }
+
+            var cursor = callIndex - 1;
+            for (var argumentIndex = calledMethod.Parameters.Count - 1; argumentIndex >= 0; argumentIndex--)
+            {
+                if (!TryFindTopValueProducer(instructions, cursor, out var argumentProducer))
+                {
+                    return false;
+                }
+
+                cursor = argumentProducer - 1;
+            }
+
+            return TryFindTopValueProducer(instructions, cursor, out producerIndex);
+        }
+
+        private static bool TryGetCallArgumentProducerIndex(
+            Collection<Instruction> instructions,
+            int callIndex,
+            MethodReference calledMethod,
+            int argumentIndex,
+            out int producerIndex)
+        {
+            producerIndex = -1;
+            if (argumentIndex < 0 || argumentIndex >= calledMethod.Parameters.Count || callIndex <= 0)
+            {
+                return false;
+            }
+
+            var cursor = callIndex - 1;
+            for (var currentArgument = calledMethod.Parameters.Count - 1; currentArgument >= 0; currentArgument--)
+            {
+                if (!TryFindTopValueProducer(instructions, cursor, out var currentProducer))
+                {
+                    return false;
+                }
+
+                if (currentArgument == argumentIndex)
+                {
+                    producerIndex = currentProducer;
+                    return true;
+                }
+
+                cursor = currentProducer - 1;
+            }
+
+            return false;
+        }
+
+        private static bool TryFindTopValueProducer(
+            Collection<Instruction> instructions,
+            int beforeIndex,
+            out int producerIndex)
+        {
+            producerIndex = -1;
+            var needed = 1;
+
+            for (var index = beforeIndex; index >= 0; index--)
+            {
+                var instruction = instructions[index];
+                needed -= instruction.GetPushCount();
+                if (needed <= 0)
+                {
+                    producerIndex = index;
+                    return true;
+                }
+
+                needed += instruction.GetPopCount();
+            }
+
+            return false;
+        }
+
     }
 }

--- a/Services/DataFlow/DataFlowMethodAnalyzer.cs
+++ b/Services/DataFlow/DataFlowMethodAnalyzer.cs
@@ -75,6 +75,7 @@ namespace MLVScan.Services.DataFlow
                 var parameterMapping = DataFlowInstructionHelper.TryGetParameterMapping(
                     instructions, index, calledMethod);
                 var parameterReachingStoreIndexes = new Dictionary<int, HashSet<int>>();
+                var forwardedParameterMapping = new Dictionary<int, int>();
                 foreach (var (parameterIndex, localIndex) in parameterMapping)
                 {
                     if (!DataFlowInstructionHelper.TryGetCallArgumentProducerIndex(
@@ -87,6 +88,16 @@ namespace MLVScan.Services.DataFlow
                         .GetReachingLocalStoreIndexes(instructions, producerIndex, localIndex)
                         .ToHashSet();
                 }
+                for (var parameterIndex = 0; parameterIndex < calledMethod.Parameters.Count; parameterIndex++)
+                {
+                    if (DataFlowInstructionHelper.TryGetCallArgumentProducerIndex(
+                            instructions, index, calledMethod, parameterIndex, out var producerIndex) &&
+                        DataFlowInstructionHelper.TryGetMethodParameterIndex(
+                            method, instructions[producerIndex], out var callerParameterIndex))
+                    {
+                        forwardedParameterMapping[parameterIndex] = callerParameterIndex;
+                    }
+                }
 
                 info.OutgoingCalls.Add(new DataFlowMethodCallSite
                 {
@@ -96,6 +107,7 @@ namespace MLVScan.Services.DataFlow
                     InstructionIndex = index,
                     ParameterMapping = parameterMapping,
                     ParameterReachingStoreIndexes = parameterReachingStoreIndexes,
+                    ForwardedParameterMapping = forwardedParameterMapping,
                     ReturnValueUsed = DataFlowInstructionHelper.IsReturnValueUsed(instructions, index),
                     CalledMethodReturnsData = calledMethod.ReturnType.FullName != "System.Void"
                 });

--- a/Services/DataFlow/DataFlowMethodAnalyzer.cs
+++ b/Services/DataFlow/DataFlowMethodAnalyzer.cs
@@ -72,13 +72,30 @@ namespace MLVScan.Services.DataFlow
                     continue;
                 }
 
+                var parameterMapping = DataFlowInstructionHelper.TryGetParameterMapping(
+                    instructions, index, calledMethod);
+                var parameterReachingStoreIndexes = new Dictionary<int, HashSet<int>>();
+                foreach (var (parameterIndex, localIndex) in parameterMapping)
+                {
+                    if (!DataFlowInstructionHelper.TryGetCallArgumentProducerIndex(
+                            instructions, index, calledMethod, parameterIndex, out var producerIndex))
+                    {
+                        continue;
+                    }
+
+                    parameterReachingStoreIndexes[parameterIndex] = DataFlowInstructionHelper
+                        .GetReachingLocalStoreIndexes(instructions, producerIndex, localIndex)
+                        .ToHashSet();
+                }
+
                 info.OutgoingCalls.Add(new DataFlowMethodCallSite
                 {
                     TargetMethodKey = calledMethod.GetMethodKey(),
                     TargetDisplayName = calledMethod.GetDisplayName(),
                     InstructionOffset = instruction.Offset,
                     InstructionIndex = index,
-                    ParameterMapping = DataFlowInstructionHelper.TryGetParameterMapping(instructions, index, calledMethod),
+                    ParameterMapping = parameterMapping,
+                    ParameterReachingStoreIndexes = parameterReachingStoreIndexes,
                     ReturnValueUsed = DataFlowInstructionHelper.IsReturnValueUsed(instructions, index),
                     CalledMethodReturnsData = calledMethod.ReturnType.FullName != "System.Void"
                 });

--- a/Services/DataFlow/DataFlowOperationClassifier.cs
+++ b/Services/DataFlow/DataFlowOperationClassifier.cs
@@ -159,13 +159,10 @@ namespace MLVScan.Services.DataFlow
                     startInfoLocal = resolvedStartInfoLocal;
                 }
                 else if (DataFlowInstructionHelper.TryGetCallArgumentProducerIndex(
-                             instructions, processStartIndex, processStartMethod, 0, out var producerIndex) &&
-                         instructions[producerIndex].OpCode == OpCodes.Newobj &&
-                         instructions[producerIndex].Operand is MethodReference constructor &&
-                         constructor.DeclaringType?.FullName == "System.Diagnostics.ProcessStartInfo" &&
-                         constructor.Parameters.Count > 0)
+                             instructions, processStartIndex, processStartMethod, 0, out var producerIndex))
                 {
-                    return TryGetCallArgumentIdentities(method, instructions, producerIndex, constructor, 0);
+                    return TryGetStartInfoProducerIdentities(
+                        method, instructions, producerIndex, processStartIndex);
                 }
                 else
                 {
@@ -265,12 +262,11 @@ namespace MLVScan.Services.DataFlow
                 return EmptyIdentities();
             }
 
-            if (instructions[producerIndex].OpCode == OpCodes.Newobj &&
-                instructions[producerIndex].Operand is MethodReference constructor &&
-                constructor.DeclaringType?.FullName == "System.Diagnostics.ProcessStartInfo" &&
-                constructor.Parameters.Count > 0)
+            var producerIdentities = TryGetStartInfoProducerIdentities(
+                method, instructions, producerIndex, setterIndex);
+            if (producerIdentities.Count > 0)
             {
-                return TryGetCallArgumentIdentities(method, instructions, producerIndex, constructor, 0);
+                return producerIdentities;
             }
 
             if (!instructions[producerIndex].TryGetLocalIndex(out var startInfoLocal))
@@ -309,22 +305,67 @@ namespace MLVScan.Services.DataFlow
             return identities;
         }
 
+        private static HashSet<string> TryGetStartInfoProducerIdentities(
+            MethodDefinition method,
+            Collection<Instruction> instructions,
+            int producerIndex,
+            int consumerIndex)
+        {
+            var initializerStartIndex = producerIndex;
+            var constructorIndex = producerIndex;
+            if (instructions[producerIndex].OpCode == OpCodes.Dup)
+            {
+                if (!DataFlowInstructionHelper.TryGetConsumedValueProducerIndex(
+                        instructions, producerIndex, out constructorIndex))
+                {
+                    return EmptyIdentities();
+                }
+            }
+
+            if (instructions[constructorIndex].OpCode != OpCodes.Newobj ||
+                instructions[constructorIndex].Operand is not MethodReference constructor ||
+                constructor.DeclaringType?.FullName != "System.Diagnostics.ProcessStartInfo")
+            {
+                return EmptyIdentities();
+            }
+
+            var identities = constructor.Parameters.Count > 0
+                ? TryGetCallArgumentIdentities(method, instructions, constructorIndex, constructor, 0)
+                : EmptyIdentities();
+            if (instructions[producerIndex].OpCode != OpCodes.Dup)
+            {
+                return identities;
+            }
+
+            for (var index = initializerStartIndex + 1; index < consumerIndex; index++)
+            {
+                if (!TryGetStartInfoFileNameSetter(instructions[index], out var fileNameSetter) ||
+                    !DataFlowInstructionHelper.TryGetCallReceiverProducerIndex(
+                        instructions, index, fileNameSetter, out var receiverProducerIndex) ||
+                    receiverProducerIndex != initializerStartIndex)
+                {
+                    continue;
+                }
+
+                identities.UnionWith(TryGetCallArgumentIdentities(
+                    method, instructions, index, fileNameSetter, 0));
+            }
+
+            return identities;
+        }
+
         private static HashSet<string> TryGetStoredStartInfoConstructorIdentities(
             MethodDefinition method,
             Collection<Instruction> instructions,
             int storeIndex)
         {
             if (!DataFlowInstructionHelper.TryGetConsumedValueProducerIndex(
-                    instructions, storeIndex, out var producerIndex) ||
-                instructions[producerIndex].OpCode != OpCodes.Newobj ||
-                instructions[producerIndex].Operand is not MethodReference constructor ||
-                constructor.DeclaringType?.FullName != "System.Diagnostics.ProcessStartInfo" ||
-                constructor.Parameters.Count == 0)
+                    instructions, storeIndex, out var producerIndex))
             {
                 return EmptyIdentities();
             }
 
-            return TryGetCallArgumentIdentities(method, instructions, producerIndex, constructor, 0);
+            return TryGetStartInfoProducerIdentities(method, instructions, producerIndex, storeIndex);
         }
 
         private static bool TryGetStartInfoFileNameSetter(
@@ -614,7 +655,8 @@ namespace MLVScan.Services.DataFlow
             }
             else if (DataFlowInstructionHelper.TryGetCallArgumentProducerIndex(
                          instructions, callIndex, calledMethod, argumentIndex, out producerIndex) &&
-                     TryGetMethodParameterIndex(method, instructions[producerIndex], out var parameterIndex))
+                     DataFlowInstructionHelper.TryGetMethodParameterIndex(
+                         method, instructions[producerIndex], out var parameterIndex))
             {
                 identities.Add(BuildArgumentPathIdentity(method, parameterIndex));
             }
@@ -625,23 +667,6 @@ namespace MLVScan.Services.DataFlow
             }
 
             return identities;
-        }
-
-        private static bool TryGetMethodParameterIndex(
-            MethodDefinition method,
-            Instruction instruction,
-            out int parameterIndex)
-        {
-            parameterIndex = -1;
-            if (!instruction.TryGetArgumentIndex(out var rawIndex))
-            {
-                return false;
-            }
-
-            parameterIndex = instruction.Operand is ParameterDefinition parameter
-                ? parameter.Index
-                : rawIndex - (method.HasThis ? 1 : 0);
-            return parameterIndex >= 0 && parameterIndex < method.Parameters.Count;
         }
 
         private static string BuildArgumentPathIdentity(MethodDefinition method, int parameterIndex)
@@ -700,7 +725,8 @@ namespace MLVScan.Services.DataFlow
                     continue;
                 }
 
-                if (TryGetMethodParameterIndex(method, instructions[producerIndex], out var parameterIndex))
+                if (DataFlowInstructionHelper.TryGetMethodParameterIndex(
+                        method, instructions[producerIndex], out var parameterIndex))
                 {
                     identities.Add(BuildArgumentPathIdentity(method, parameterIndex));
                 }

--- a/Services/DataFlow/DataFlowOperationClassifier.cs
+++ b/Services/DataFlow/DataFlowOperationClassifier.cs
@@ -31,7 +31,7 @@ namespace MLVScan.Services.DataFlow
                 var operationInfo = ClassifyOperation(calledMethod);
                 if (operationInfo != null)
                 {
-                    var payloadPathIdentity = TryGetPayloadPathIdentity(
+                    var payloadPathIdentities = TryGetPayloadPathIdentities(
                         method,
                         instructions,
                         index,
@@ -47,7 +47,7 @@ namespace MLVScan.Services.DataFlow
                         Operation = operationInfo.Value.Operation,
                         DataDescription = operationInfo.Value.DataDescription,
                         LocalVariableIndex = DataFlowInstructionHelper.TryGetTargetLocalVariable(instructions, index),
-                        PayloadPathIdentity = payloadPathIdentity
+                        PayloadPathIdentities = payloadPathIdentities
                     });
                 }
 
@@ -70,7 +70,7 @@ namespace MLVScan.Services.DataFlow
             return operations;
         }
 
-        private static string? TryGetPayloadPathIdentity(
+        private static HashSet<string> TryGetPayloadPathIdentities(
             MethodDefinition method,
             Collection<Instruction> instructions,
             int callIndex,
@@ -80,20 +80,20 @@ namespace MLVScan.Services.DataFlow
         {
             if (nodeType != DataFlowNodeType.Sink)
             {
-                return null;
+                return EmptyIdentities();
             }
 
             if (IsFilePathSink(operation))
             {
-                return TryGetCallArgumentIdentity(method, instructions, callIndex, calledMethod, 0);
+                return TryGetCallArgumentIdentities(method, instructions, callIndex, calledMethod, 0);
             }
 
             if (operation.Equals("Process.Start", StringComparison.OrdinalIgnoreCase))
             {
-                return TryGetProcessStartPathIdentity(method, instructions, callIndex, calledMethod);
+                return TryGetProcessStartPathIdentities(method, instructions, callIndex, calledMethod);
             }
 
-            return TryGetNativeExecutionPathIdentity(method, instructions, callIndex, calledMethod, operation);
+            return TryGetNativeExecutionPathIdentities(method, instructions, callIndex, calledMethod, operation);
         }
 
         private static bool IsFilePathSink(string operation)
@@ -102,7 +102,7 @@ namespace MLVScan.Services.DataFlow
                    operation.Contains("FileStream", StringComparison.OrdinalIgnoreCase);
         }
 
-        private static string? TryGetProcessStartPathIdentity(
+        private static HashSet<string> TryGetProcessStartPathIdentities(
             MethodDefinition method,
             Collection<Instruction> instructions,
             int processStartIndex,
@@ -118,7 +118,7 @@ namespace MLVScan.Services.DataFlow
                 if (!DataFlowInstructionHelper.TryGetCallArgumentLocalVariable(
                         instructions, processStartIndex, processStartMethod, 0, out var resolvedStartInfoLocal))
                 {
-                    return null;
+                    return EmptyIdentities();
                 }
 
                 startInfoLocal = resolvedStartInfoLocal;
@@ -128,14 +128,14 @@ namespace MLVScan.Services.DataFlow
                 if (!DataFlowInstructionHelper.TryGetCallReceiverLocalVariable(
                         instructions, processStartIndex, processStartMethod, out var resolvedProcessLocal))
                 {
-                    return null;
+                    return EmptyIdentities();
                 }
 
                 processLocal = resolvedProcessLocal;
             }
             else if (processStartMethod.Parameters.Count > 0)
             {
-                return TryGetCallArgumentIdentity(method, instructions, processStartIndex, processStartMethod, 0);
+                return TryGetCallArgumentIdentities(method, instructions, processStartIndex, processStartMethod, 0);
             }
 
             var searchStart = Math.Max(0, processStartIndex - 400);
@@ -155,10 +155,10 @@ namespace MLVScan.Services.DataFlow
                     continue;
                 }
 
-                return TryGetCallArgumentIdentity(method, instructions, index, setter, 0);
+                return TryGetCallArgumentIdentities(method, instructions, index, setter, 0);
             }
 
-            return null;
+            return EmptyIdentities();
         }
 
         private static bool StartInfoSetterBelongsToStartedProcess(
@@ -196,7 +196,7 @@ namespace MLVScan.Services.DataFlow
                    setterProcessLocal == processLocal.Value;
         }
 
-        private static string? TryGetNativeExecutionPathIdentity(
+        private static HashSet<string> TryGetNativeExecutionPathIdentities(
             MethodDefinition method,
             Collection<Instruction> instructions,
             int callIndex,
@@ -205,12 +205,12 @@ namespace MLVScan.Services.DataFlow
         {
             if (operation.Contains("ShellExecuteEx", StringComparison.OrdinalIgnoreCase))
             {
-                return TryGetShellExecuteExFileIdentity(method, instructions, callIndex);
+                return TryGetShellExecuteExFileIdentities(method, instructions, callIndex, calledMethod);
             }
 
             if (operation.Contains("CreateProcess", StringComparison.OrdinalIgnoreCase))
             {
-                return TryGetCreateProcessPathIdentity(method, instructions, callIndex, calledMethod, operation);
+                return TryGetCreateProcessPathIdentities(method, instructions, callIndex, calledMethod, operation);
             }
 
             var argumentIndex = operation switch
@@ -222,11 +222,11 @@ namespace MLVScan.Services.DataFlow
             };
 
             return argumentIndex >= 0
-                ? TryGetCallArgumentIdentity(method, instructions, callIndex, calledMethod, argumentIndex)
-                : null;
+                ? TryGetCallArgumentIdentities(method, instructions, callIndex, calledMethod, argumentIndex)
+                : EmptyIdentities();
         }
 
-        private static string? TryGetCreateProcessPathIdentity(
+        private static HashSet<string> TryGetCreateProcessPathIdentities(
             MethodDefinition method,
             Collection<Instruction> instructions,
             int callIndex,
@@ -241,17 +241,25 @@ namespace MLVScan.Services.DataFlow
                 _ => (0, 1)
             };
 
-            var applicationIdentity = TryGetCallArgumentIdentity(
+            var applicationIdentities = TryGetCallArgumentIdentities(
                 method, instructions, callIndex, calledMethod, applicationNameIndex);
-            return applicationIdentity ?? TryGetCallArgumentIdentity(
-                method, instructions, callIndex, calledMethod, commandLineIndex);
+            return applicationIdentities.Count > 0
+                ? applicationIdentities
+                : TryGetCallArgumentIdentities(method, instructions, callIndex, calledMethod, commandLineIndex);
         }
 
-        private static string? TryGetShellExecuteExFileIdentity(
+        private static HashSet<string> TryGetShellExecuteExFileIdentities(
             MethodDefinition method,
             Collection<Instruction> instructions,
-            int callIndex)
+            int callIndex,
+            MethodReference calledMethod)
         {
+            if (!DataFlowInstructionHelper.TryGetCallArgumentLocalVariable(
+                    instructions, callIndex, calledMethod, 0, out var shellExecuteInfoLocal))
+            {
+                return EmptyIdentities();
+            }
+
             var searchStart = Math.Max(0, callIndex - 400);
             for (var index = callIndex - 1; index >= searchStart; index--)
             {
@@ -262,9 +270,16 @@ namespace MLVScan.Services.DataFlow
                     continue;
                 }
 
+                if (!DataFlowInstructionHelper.TryGetFieldStoreReceiverLocalVariable(
+                        instructions, index, out var fieldReceiverLocal) ||
+                    fieldReceiverLocal != shellExecuteInfoLocal)
+                {
+                    continue;
+                }
+
                 if (index > 0 && instructions[index - 1].TryGetLocalIndex(out var localIndex))
                 {
-                    return BuildLocalPathIdentity(method, instructions, index, localIndex);
+                    return BuildLocalPathIdentities(method, instructions, index - 1, localIndex);
                 }
 
                 if (InstructionValueResolver.TryResolveStackValueDisplay(
@@ -272,14 +287,14 @@ namespace MLVScan.Services.DataFlow
                     !string.IsNullOrWhiteSpace(display) &&
                     !display.Contains("<unknown", StringComparison.OrdinalIgnoreCase))
                 {
-                    return NormalizeResolvedPathIdentity(display);
+                    return SingleIdentity(NormalizeResolvedPathIdentity(display));
                 }
             }
 
-            return null;
+            return EmptyIdentities();
         }
 
-        private static string? TryGetCallArgumentIdentity(
+        private static HashSet<string> TryGetCallArgumentIdentities(
             MethodDefinition method,
             Collection<Instruction> instructions,
             int callIndex,
@@ -290,13 +305,13 @@ namespace MLVScan.Services.DataFlow
                 method, calledMethod, instructions, callIndex, argumentIndex, out var display);
             if (resolved && display.Contains("<null>", StringComparison.OrdinalIgnoreCase))
             {
-                return null;
+                return EmptyIdentities();
             }
 
             if (DataFlowInstructionHelper.TryGetCallArgumentLocalVariable(
-                    instructions, callIndex, calledMethod, argumentIndex, out var localIndex))
+                    instructions, callIndex, calledMethod, argumentIndex, out var localIndex, out var producerIndex))
             {
-                return BuildLocalPathIdentity(method, instructions, callIndex, localIndex);
+                return BuildLocalPathIdentities(method, instructions, producerIndex, localIndex);
             }
 
             if (resolved &&
@@ -305,29 +320,34 @@ namespace MLVScan.Services.DataFlow
                 !display.Contains("<local:", StringComparison.OrdinalIgnoreCase) &&
                 !display.Contains("<argument:", StringComparison.OrdinalIgnoreCase))
             {
-                return NormalizeResolvedPathIdentity(display);
+                return SingleIdentity(NormalizeResolvedPathIdentity(display));
             }
 
-            return null;
+            return EmptyIdentities();
         }
 
-        private static string BuildLocalPathIdentity(
+        private static HashSet<string> BuildLocalPathIdentities(
             MethodDefinition method,
             Collection<Instruction> instructions,
-            int consumerIndex,
+            int localLoadIndex,
             int localIndex)
         {
-            for (var index = consumerIndex - 1; index >= 0; index--)
+            var storeIndexes = DataFlowInstructionHelper.GetReachingLocalStoreIndexes(
+                instructions, localLoadIndex, localIndex);
+            if (storeIndexes.Count == 0)
             {
-                if (instructions[index].TryGetStoredLocalIndex(out var storedLocalIndex) &&
-                    storedLocalIndex == localIndex)
-                {
-                    return $"{method.GetMethodKey()}::local:{localIndex}@{instructions[index].Offset}";
-                }
+                return SingleIdentity($"{method.GetMethodKey()}::local:{localIndex}@parameter");
             }
 
-            return $"{method.GetMethodKey()}::local:{localIndex}@parameter";
+            return storeIndexes
+                .Select(index => $"{method.GetMethodKey()}::local:{localIndex}@instruction:{index}")
+                .ToHashSet(StringComparer.Ordinal);
         }
+
+        private static HashSet<string> EmptyIdentities() => new(StringComparer.Ordinal);
+
+        private static HashSet<string> SingleIdentity(string identity) =>
+            new(StringComparer.Ordinal) { identity };
 
         private static string NormalizeResolvedPathIdentity(string display)
         {

--- a/Services/DataFlow/DataFlowOperationClassifier.cs
+++ b/Services/DataFlow/DataFlowOperationClassifier.cs
@@ -20,10 +20,20 @@ namespace MLVScan.Services.DataFlow
             {
                 var instruction = instructions[index];
 
-                if (instruction.Operand is not MethodReference calledMethod ||
-                    (!instruction.IsCallOrCallvirt() &&
-                     !(instruction.OpCode == OpCodes.Newobj &&
-                       IsFileStreamSink(calledMethod.DeclaringType?.FullName ?? string.Empty, calledMethod.Name))))
+                if (instruction.Operand is not MethodReference calledMethod)
+                {
+                    continue;
+                }
+
+                var isFileStreamConstructor = instruction.OpCode == OpCodes.Newobj &&
+                    IsFileStreamSink(calledMethod.DeclaringType?.FullName ?? string.Empty, calledMethod.Name);
+                if (!instruction.IsCallOrCallvirt() && !isFileStreamConstructor)
+                {
+                    continue;
+                }
+
+                if (isFileStreamConstructor &&
+                    !IsWritableFileStreamConstructor(method, instructions, index, calledMethod))
                 {
                     continue;
                 }
@@ -102,6 +112,33 @@ namespace MLVScan.Services.DataFlow
                    operation.Contains("FileStream", StringComparison.OrdinalIgnoreCase);
         }
 
+        private static bool IsWritableFileStreamConstructor(
+            MethodDefinition method,
+            Collection<Instruction> instructions,
+            int constructorIndex,
+            MethodReference constructor)
+        {
+            var accessParameterIndex = constructor.Parameters
+                .Select((parameter, index) => (parameter, index))
+                .Where(static entry => entry.parameter.ParameterType.FullName == "System.IO.FileAccess")
+                .Select(static entry => (int?)entry.index)
+                .FirstOrDefault();
+            if (!accessParameterIndex.HasValue)
+            {
+                return true;
+            }
+
+            return !InstructionValueResolver.TryResolveCallArgumentDisplay(
+                       method,
+                       constructor,
+                       instructions,
+                       constructorIndex,
+                       accessParameterIndex.Value,
+                       out var accessDisplay) ||
+                   !int.TryParse(accessDisplay, out var accessValue) ||
+                   accessValue != 1;
+        }
+
         private static HashSet<string> TryGetProcessStartPathIdentities(
             MethodDefinition method,
             Collection<Instruction> instructions,
@@ -115,13 +152,24 @@ namespace MLVScan.Services.DataFlow
                 processStartMethod.Parameters.Count == 1 &&
                 processStartMethod.Parameters[0].ParameterType.FullName == "System.Diagnostics.ProcessStartInfo")
             {
-                if (!DataFlowInstructionHelper.TryGetCallArgumentLocalVariable(
+                if (DataFlowInstructionHelper.TryGetCallArgumentLocalVariable(
                         instructions, processStartIndex, processStartMethod, 0, out var resolvedStartInfoLocal))
+                {
+                    startInfoLocal = resolvedStartInfoLocal;
+                }
+                else if (DataFlowInstructionHelper.TryGetCallArgumentProducerIndex(
+                             instructions, processStartIndex, processStartMethod, 0, out var producerIndex) &&
+                         instructions[producerIndex].OpCode == OpCodes.Newobj &&
+                         instructions[producerIndex].Operand is MethodReference constructor &&
+                         constructor.DeclaringType?.FullName == "System.Diagnostics.ProcessStartInfo" &&
+                         constructor.Parameters.Count > 0)
+                {
+                    return TryGetCallArgumentIdentities(method, instructions, producerIndex, constructor, 0);
+                }
+                else
                 {
                     return EmptyIdentities();
                 }
-
-                startInfoLocal = resolvedStartInfoLocal;
             }
             else if (processStartMethod.HasThis)
             {

--- a/Services/DataFlow/DataFlowOperationClassifier.cs
+++ b/Services/DataFlow/DataFlowOperationClassifier.cs
@@ -415,37 +415,49 @@ namespace MLVScan.Services.DataFlow
                 return EmptyIdentities();
             }
 
-            var searchStart = Math.Max(0, callIndex - 400);
-            for (var index = callIndex - 1; index >= searchStart; index--)
+            var fieldStoreIndexes = DataFlowInstructionHelper.GetReachingInstructionIndexes(
+                instructions,
+                callIndex,
+                index => IsShellExecuteFileStoreForLocal(
+                    instructions, index, shellExecuteInfoLocal));
+            var identities = EmptyIdentities();
+            foreach (var index in fieldStoreIndexes)
             {
-                if (instructions[index].OpCode != OpCodes.Stfld ||
-                    instructions[index].Operand is not FieldReference field ||
-                    !field.Name.Equals("lpFile", StringComparison.OrdinalIgnoreCase))
+                if (!DataFlowInstructionHelper.TryGetConsumedValueProducerIndex(
+                        instructions, index, out var valueProducerIndex))
                 {
                     continue;
                 }
 
-                if (!DataFlowInstructionHelper.TryGetFieldStoreReceiverLocalVariable(
-                        instructions, index, out var fieldReceiverLocal) ||
-                    fieldReceiverLocal != shellExecuteInfoLocal)
+                if (instructions[valueProducerIndex].TryGetLocalIndex(out var localIndex))
                 {
+                    identities.UnionWith(
+                        BuildLocalPathIdentities(method, instructions, valueProducerIndex, localIndex));
                     continue;
-                }
-
-                if (index > 0 && instructions[index - 1].TryGetLocalIndex(out var localIndex))
-                {
-                    return BuildLocalPathIdentities(method, instructions, index - 1, localIndex);
                 }
 
                 if (InstructionValueResolver.TryResolveStackValueDisplay(
                         method, instructions, index - 1, out var display) &&
                     IsConcreteResolvedPath(display))
                 {
-                    return SingleIdentity(NormalizeResolvedPathIdentity(display));
+                    identities.Add(NormalizeResolvedPathIdentity(display));
                 }
             }
 
-            return EmptyIdentities();
+            return identities;
+        }
+
+        private static bool IsShellExecuteFileStoreForLocal(
+            Collection<Instruction> instructions,
+            int index,
+            int shellExecuteInfoLocal)
+        {
+            return instructions[index].OpCode == OpCodes.Stfld &&
+                   instructions[index].Operand is FieldReference field &&
+                   field.Name.Equals("lpFile", StringComparison.OrdinalIgnoreCase) &&
+                   DataFlowInstructionHelper.TryGetFieldStoreReceiverLocalVariable(
+                       instructions, index, out var fieldReceiverLocal) &&
+                   fieldReceiverLocal == shellExecuteInfoLocal;
         }
 
         private static HashSet<string> TryGetCallArgumentIdentities(
@@ -518,6 +530,26 @@ namespace MLVScan.Services.DataFlow
             int localLoadIndex,
             int localIndex)
         {
+            return BuildLocalPathIdentities(
+                method,
+                instructions,
+                localLoadIndex,
+                localIndex,
+                new HashSet<(int LoadIndex, int LocalIndex)>());
+        }
+
+        private static HashSet<string> BuildLocalPathIdentities(
+            MethodDefinition method,
+            Collection<Instruction> instructions,
+            int localLoadIndex,
+            int localIndex,
+            HashSet<(int LoadIndex, int LocalIndex)> visited)
+        {
+            if (!visited.Add((localLoadIndex, localIndex)))
+            {
+                return EmptyIdentities();
+            }
+
             var storeIndexes = DataFlowInstructionHelper.GetReachingLocalStoreIndexes(
                 instructions, localLoadIndex, localIndex);
             if (storeIndexes.Count == 0)
@@ -525,9 +557,33 @@ namespace MLVScan.Services.DataFlow
                 return SingleIdentity($"{method.GetMethodKey()}::local:{localIndex}@parameter");
             }
 
-            return storeIndexes
+            var identities = storeIndexes
                 .Select(index => $"{method.GetMethodKey()}::local:{localIndex}@instruction:{index}")
                 .ToHashSet(StringComparer.Ordinal);
+            foreach (var storeIndex in storeIndexes)
+            {
+                if (!DataFlowInstructionHelper.TryGetConsumedValueProducerIndex(
+                        instructions, storeIndex, out var producerIndex))
+                {
+                    continue;
+                }
+
+                if (TryGetMethodParameterIndex(method, instructions[producerIndex], out var parameterIndex))
+                {
+                    identities.Add(BuildArgumentPathIdentity(method, parameterIndex));
+                }
+                else if (instructions[producerIndex].TryGetLocalIndex(out var sourceLocalIndex))
+                {
+                    identities.UnionWith(BuildLocalPathIdentities(
+                        method,
+                        instructions,
+                        producerIndex,
+                        sourceLocalIndex,
+                        visited));
+                }
+            }
+
+            return identities;
         }
 
         private static HashSet<string> EmptyIdentities() => new(StringComparer.Ordinal);

--- a/Services/DataFlow/DataFlowOperationClassifier.cs
+++ b/Services/DataFlow/DataFlowOperationClassifier.cs
@@ -186,27 +186,38 @@ namespace MLVScan.Services.DataFlow
                 return TryGetCallArgumentIdentities(method, instructions, processStartIndex, processStartMethod, 0);
             }
 
-            var searchStart = Math.Max(0, processStartIndex - 400);
-            for (var index = processStartIndex - 1; index >= searchStart; index--)
+            var setterIndexes = DataFlowInstructionHelper.GetReachingInstructionIndexes(
+                instructions,
+                processStartIndex,
+                index => TryGetStartInfoFileNameSetter(instructions[index], out var setter) &&
+                         StartInfoSetterBelongsToStartedProcess(
+                             instructions, index, setter, startInfoLocal, processLocal));
+            var identities = EmptyIdentities();
+            foreach (var setterIndex in setterIndexes)
             {
-                if (!instructions[index].IsCallOrCallvirt() ||
-                    instructions[index].Operand is not MethodReference setter ||
-                    setter.DeclaringType?.FullName != "System.Diagnostics.ProcessStartInfo" ||
-                    setter.Name != "set_FileName")
-                {
-                    continue;
-                }
-
-                if (!StartInfoSetterBelongsToStartedProcess(
-                        instructions, index, setter, startInfoLocal, processLocal))
-                {
-                    continue;
-                }
-
-                return TryGetCallArgumentIdentities(method, instructions, index, setter, 0);
+                var setter = (MethodReference)instructions[setterIndex].Operand;
+                identities.UnionWith(
+                    TryGetCallArgumentIdentities(method, instructions, setterIndex, setter, 0));
             }
 
-            return EmptyIdentities();
+            return identities;
+        }
+
+        private static bool TryGetStartInfoFileNameSetter(
+            Instruction instruction,
+            out MethodReference setter)
+        {
+            setter = null!;
+            if (!instruction.IsCallOrCallvirt() ||
+                instruction.Operand is not MethodReference candidate ||
+                candidate.DeclaringType?.FullName != "System.Diagnostics.ProcessStartInfo" ||
+                candidate.Name != "set_FileName")
+            {
+                return false;
+            }
+
+            setter = candidate;
+            return true;
         }
 
         private static bool StartInfoSetterBelongsToStartedProcess(
@@ -332,8 +343,7 @@ namespace MLVScan.Services.DataFlow
 
                 if (InstructionValueResolver.TryResolveStackValueDisplay(
                         method, instructions, index - 1, out var display) &&
-                    !string.IsNullOrWhiteSpace(display) &&
-                    !display.Contains("<unknown", StringComparison.OrdinalIgnoreCase))
+                    IsConcreteResolvedPath(display))
                 {
                     return SingleIdentity(NormalizeResolvedPathIdentity(display));
                 }
@@ -356,22 +366,26 @@ namespace MLVScan.Services.DataFlow
                 return EmptyIdentities();
             }
 
+            var identities = EmptyIdentities();
             if (DataFlowInstructionHelper.TryGetCallArgumentLocalVariable(
                     instructions, callIndex, calledMethod, argumentIndex, out var localIndex, out var producerIndex))
             {
-                return BuildLocalPathIdentities(method, instructions, producerIndex, localIndex);
+                identities.UnionWith(BuildLocalPathIdentities(method, instructions, producerIndex, localIndex));
             }
 
-            if (resolved &&
-                !string.IsNullOrWhiteSpace(display) &&
-                !display.Contains("<unknown", StringComparison.OrdinalIgnoreCase) &&
-                !display.Contains("<local:", StringComparison.OrdinalIgnoreCase) &&
-                !display.Contains("<argument:", StringComparison.OrdinalIgnoreCase))
+            if (resolved && IsConcreteResolvedPath(display))
             {
-                return SingleIdentity(NormalizeResolvedPathIdentity(display));
+                identities.Add(NormalizeResolvedPathIdentity(display));
             }
 
-            return EmptyIdentities();
+            return identities;
+        }
+
+        private static bool IsConcreteResolvedPath(string display)
+        {
+            return !string.IsNullOrWhiteSpace(display) &&
+                   !display.Contains('<') &&
+                   !display.Contains('>');
         }
 
         private static HashSet<string> BuildLocalPathIdentities(

--- a/Services/DataFlow/DataFlowOperationClassifier.cs
+++ b/Services/DataFlow/DataFlowOperationClassifier.cs
@@ -1,5 +1,6 @@
 using MLVScan.Models;
 using MLVScan.Models.DataFlow;
+using MLVScan.Models.Rules.Helpers;
 using MLVScan.Services.Helpers;
 using Mono.Collections.Generic;
 using Mono.Cecil;
@@ -19,8 +20,10 @@ namespace MLVScan.Services.DataFlow
             {
                 var instruction = instructions[index];
 
-                if (!instruction.IsCallOrCallvirt() ||
-                    instruction.Operand is not MethodReference calledMethod)
+                if (instruction.Operand is not MethodReference calledMethod ||
+                    (!instruction.IsCallOrCallvirt() &&
+                     !(instruction.OpCode == OpCodes.Newobj &&
+                       IsFileStreamSink(calledMethod.DeclaringType?.FullName ?? string.Empty, calledMethod.Name))))
                 {
                     continue;
                 }
@@ -28,6 +31,13 @@ namespace MLVScan.Services.DataFlow
                 var operationInfo = ClassifyOperation(calledMethod);
                 if (operationInfo != null)
                 {
+                    var payloadPathIdentity = TryGetPayloadPathIdentity(
+                        method,
+                        instructions,
+                        index,
+                        calledMethod,
+                        operationInfo.Value.Operation,
+                        operationInfo.Value.NodeType);
                     operations.Add(new DataFlowInterestingOperation
                     {
                         Instruction = instruction,
@@ -36,7 +46,8 @@ namespace MLVScan.Services.DataFlow
                         NodeType = operationInfo.Value.NodeType,
                         Operation = operationInfo.Value.Operation,
                         DataDescription = operationInfo.Value.DataDescription,
-                        LocalVariableIndex = DataFlowInstructionHelper.TryGetTargetLocalVariable(instructions, index)
+                        LocalVariableIndex = DataFlowInstructionHelper.TryGetTargetLocalVariable(instructions, index),
+                        PayloadPathIdentity = payloadPathIdentity
                     });
                 }
 
@@ -57,6 +68,172 @@ namespace MLVScan.Services.DataFlow
             }
 
             return operations;
+        }
+
+        private static string? TryGetPayloadPathIdentity(
+            MethodDefinition method,
+            Collection<Instruction> instructions,
+            int callIndex,
+            MethodReference calledMethod,
+            string operation,
+            DataFlowNodeType nodeType)
+        {
+            if (nodeType != DataFlowNodeType.Sink)
+            {
+                return null;
+            }
+
+            if (IsFilePathSink(operation))
+            {
+                return TryGetCallArgumentIdentity(method, instructions, callIndex, calledMethod, 0);
+            }
+
+            if (operation.Equals("Process.Start", StringComparison.OrdinalIgnoreCase))
+            {
+                if (calledMethod.Parameters.Count > 0)
+                {
+                    return TryGetCallArgumentIdentity(method, instructions, callIndex, calledMethod, 0);
+                }
+
+                return TryGetStartInfoFileNameIdentity(method, instructions, callIndex);
+            }
+
+            return TryGetNativeExecutionPathIdentity(method, instructions, callIndex, calledMethod, operation);
+        }
+
+        private static bool IsFilePathSink(string operation)
+        {
+            return operation.Contains("File.", StringComparison.OrdinalIgnoreCase) ||
+                   operation.Contains("FileStream", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string? TryGetStartInfoFileNameIdentity(
+            MethodDefinition method,
+            Collection<Instruction> instructions,
+            int processStartIndex)
+        {
+            var searchStart = Math.Max(0, processStartIndex - 400);
+            for (var index = processStartIndex - 1; index >= searchStart; index--)
+            {
+                if (!instructions[index].IsCallOrCallvirt() ||
+                    instructions[index].Operand is not MethodReference setter ||
+                    setter.DeclaringType?.FullName != "System.Diagnostics.ProcessStartInfo" ||
+                    setter.Name != "set_FileName")
+                {
+                    continue;
+                }
+
+                return TryGetCallArgumentIdentity(method, instructions, index, setter, 0);
+            }
+
+            return null;
+        }
+
+        private static string? TryGetNativeExecutionPathIdentity(
+            MethodDefinition method,
+            Collection<Instruction> instructions,
+            int callIndex,
+            MethodReference calledMethod,
+            string operation)
+        {
+            if (operation.Contains("ShellExecuteEx", StringComparison.OrdinalIgnoreCase))
+            {
+                return TryGetShellExecuteExFileIdentity(method, instructions, callIndex);
+            }
+
+            var argumentIndex = operation switch
+            {
+                var value when value.Contains("WinExec", StringComparison.OrdinalIgnoreCase) => 0,
+                var value when value.Contains("CreateProcess", StringComparison.OrdinalIgnoreCase) => 0,
+                var value when value.Contains("ShellExecute", StringComparison.OrdinalIgnoreCase) &&
+                                   !value.Contains("ShellExecuteEx", StringComparison.OrdinalIgnoreCase) => 2,
+                _ => -1
+            };
+
+            return argumentIndex >= 0
+                ? TryGetCallArgumentIdentity(method, instructions, callIndex, calledMethod, argumentIndex)
+                : null;
+        }
+
+        private static string? TryGetShellExecuteExFileIdentity(
+            MethodDefinition method,
+            Collection<Instruction> instructions,
+            int callIndex)
+        {
+            var searchStart = Math.Max(0, callIndex - 400);
+            for (var index = callIndex - 1; index >= searchStart; index--)
+            {
+                if (instructions[index].OpCode != OpCodes.Stfld ||
+                    instructions[index].Operand is not FieldReference field ||
+                    !field.Name.Equals("lpFile", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (index > 0 && instructions[index - 1].TryGetLocalIndex(out var localIndex))
+                {
+                    return BuildLocalPathIdentity(method, instructions, index, localIndex);
+                }
+
+                if (InstructionValueResolver.TryResolveStackValueDisplay(
+                        method, instructions, index - 1, out var display) &&
+                    !string.IsNullOrWhiteSpace(display) &&
+                    !display.Contains("<unknown", StringComparison.OrdinalIgnoreCase))
+                {
+                    return NormalizeResolvedPathIdentity(display);
+                }
+            }
+
+            return null;
+        }
+
+        private static string? TryGetCallArgumentIdentity(
+            MethodDefinition method,
+            Collection<Instruction> instructions,
+            int callIndex,
+            MethodReference calledMethod,
+            int argumentIndex)
+        {
+            var mapping = DataFlowInstructionHelper.TryGetParameterMapping(instructions, callIndex, calledMethod);
+            if (mapping.TryGetValue(argumentIndex, out var localIndex))
+            {
+                return BuildLocalPathIdentity(method, instructions, callIndex, localIndex);
+            }
+
+            if (!InstructionValueResolver.TryResolveCallArgumentDisplay(
+                    method, calledMethod, instructions, callIndex, argumentIndex, out var display) ||
+                string.IsNullOrWhiteSpace(display) ||
+                display.Contains("<unknown", StringComparison.OrdinalIgnoreCase) ||
+                display.Contains("<local:", StringComparison.OrdinalIgnoreCase) ||
+                display.Contains("<argument:", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            return NormalizeResolvedPathIdentity(display);
+        }
+
+        private static string BuildLocalPathIdentity(
+            MethodDefinition method,
+            Collection<Instruction> instructions,
+            int consumerIndex,
+            int localIndex)
+        {
+            for (var index = consumerIndex - 1; index >= 0; index--)
+            {
+                if (instructions[index].TryGetStoredLocalIndex(out var storedLocalIndex) &&
+                    storedLocalIndex == localIndex)
+                {
+                    return $"{method.GetMethodKey()}::local:{localIndex}@{instructions[index].Offset}";
+                }
+            }
+
+            return $"{method.GetMethodKey()}::local:{localIndex}@parameter";
+        }
+
+        private static string NormalizeResolvedPathIdentity(string display)
+        {
+            return $"value:{display.Trim().Trim('"').Replace('\\', '/').ToUpperInvariant()}";
         }
 
         private (DataFlowNodeType NodeType, string Operation, string DataDescription)? ClassifyOperation(MethodReference method)

--- a/Services/DataFlow/DataFlowOperationClassifier.cs
+++ b/Services/DataFlow/DataFlowOperationClassifier.cs
@@ -90,12 +90,7 @@ namespace MLVScan.Services.DataFlow
 
             if (operation.Equals("Process.Start", StringComparison.OrdinalIgnoreCase))
             {
-                if (calledMethod.Parameters.Count > 0)
-                {
-                    return TryGetCallArgumentIdentity(method, instructions, callIndex, calledMethod, 0);
-                }
-
-                return TryGetStartInfoFileNameIdentity(method, instructions, callIndex);
+                return TryGetProcessStartPathIdentity(method, instructions, callIndex, calledMethod);
             }
 
             return TryGetNativeExecutionPathIdentity(method, instructions, callIndex, calledMethod, operation);
@@ -107,11 +102,42 @@ namespace MLVScan.Services.DataFlow
                    operation.Contains("FileStream", StringComparison.OrdinalIgnoreCase);
         }
 
-        private static string? TryGetStartInfoFileNameIdentity(
+        private static string? TryGetProcessStartPathIdentity(
             MethodDefinition method,
             Collection<Instruction> instructions,
-            int processStartIndex)
+            int processStartIndex,
+            MethodReference processStartMethod)
         {
+            int? startInfoLocal = null;
+            int? processLocal = null;
+
+            if (!processStartMethod.HasThis &&
+                processStartMethod.Parameters.Count == 1 &&
+                processStartMethod.Parameters[0].ParameterType.FullName == "System.Diagnostics.ProcessStartInfo")
+            {
+                if (!DataFlowInstructionHelper.TryGetCallArgumentLocalVariable(
+                        instructions, processStartIndex, processStartMethod, 0, out var resolvedStartInfoLocal))
+                {
+                    return null;
+                }
+
+                startInfoLocal = resolvedStartInfoLocal;
+            }
+            else if (processStartMethod.HasThis)
+            {
+                if (!DataFlowInstructionHelper.TryGetCallReceiverLocalVariable(
+                        instructions, processStartIndex, processStartMethod, out var resolvedProcessLocal))
+                {
+                    return null;
+                }
+
+                processLocal = resolvedProcessLocal;
+            }
+            else if (processStartMethod.Parameters.Count > 0)
+            {
+                return TryGetCallArgumentIdentity(method, instructions, processStartIndex, processStartMethod, 0);
+            }
+
             var searchStart = Math.Max(0, processStartIndex - 400);
             for (var index = processStartIndex - 1; index >= searchStart; index--)
             {
@@ -123,10 +149,51 @@ namespace MLVScan.Services.DataFlow
                     continue;
                 }
 
+                if (!StartInfoSetterBelongsToStartedProcess(
+                        instructions, index, setter, startInfoLocal, processLocal))
+                {
+                    continue;
+                }
+
                 return TryGetCallArgumentIdentity(method, instructions, index, setter, 0);
             }
 
             return null;
+        }
+
+        private static bool StartInfoSetterBelongsToStartedProcess(
+            Collection<Instruction> instructions,
+            int setterIndex,
+            MethodReference setter,
+            int? startInfoLocal,
+            int? processLocal)
+        {
+            if (startInfoLocal.HasValue)
+            {
+                return DataFlowInstructionHelper.TryGetCallReceiverLocalVariable(
+                           instructions, setterIndex, setter, out var setterStartInfoLocal) &&
+                       setterStartInfoLocal == startInfoLocal.Value;
+            }
+
+            if (!processLocal.HasValue ||
+                !DataFlowInstructionHelper.TryGetCallReceiverProducerIndex(
+                    instructions, setterIndex, setter, out var setterReceiverProducerIndex))
+            {
+                return false;
+            }
+
+            var setterReceiverProducer = instructions[setterReceiverProducerIndex];
+            if (!setterReceiverProducer.IsCallOrCallvirt() ||
+                setterReceiverProducer.Operand is not MethodReference getter ||
+                getter.DeclaringType?.FullName != "System.Diagnostics.Process" ||
+                getter.Name != "get_StartInfo")
+            {
+                return false;
+            }
+
+            return DataFlowInstructionHelper.TryGetCallReceiverLocalVariable(
+                       instructions, setterReceiverProducerIndex, getter, out var setterProcessLocal) &&
+                   setterProcessLocal == processLocal.Value;
         }
 
         private static string? TryGetNativeExecutionPathIdentity(
@@ -141,10 +208,14 @@ namespace MLVScan.Services.DataFlow
                 return TryGetShellExecuteExFileIdentity(method, instructions, callIndex);
             }
 
+            if (operation.Contains("CreateProcess", StringComparison.OrdinalIgnoreCase))
+            {
+                return TryGetCreateProcessPathIdentity(method, instructions, callIndex, calledMethod, operation);
+            }
+
             var argumentIndex = operation switch
             {
                 var value when value.Contains("WinExec", StringComparison.OrdinalIgnoreCase) => 0,
-                var value when value.Contains("CreateProcess", StringComparison.OrdinalIgnoreCase) => 0,
                 var value when value.Contains("ShellExecute", StringComparison.OrdinalIgnoreCase) &&
                                    !value.Contains("ShellExecuteEx", StringComparison.OrdinalIgnoreCase) => 2,
                 _ => -1
@@ -153,6 +224,27 @@ namespace MLVScan.Services.DataFlow
             return argumentIndex >= 0
                 ? TryGetCallArgumentIdentity(method, instructions, callIndex, calledMethod, argumentIndex)
                 : null;
+        }
+
+        private static string? TryGetCreateProcessPathIdentity(
+            MethodDefinition method,
+            Collection<Instruction> instructions,
+            int callIndex,
+            MethodReference calledMethod,
+            string operation)
+        {
+            var (applicationNameIndex, commandLineIndex) = operation switch
+            {
+                var value when value.Contains("CreateProcessWithLogon", StringComparison.OrdinalIgnoreCase) => (4, 5),
+                var value when value.Contains("CreateProcessWithToken", StringComparison.OrdinalIgnoreCase) => (2, 3),
+                var value when value.Contains("CreateProcessAsUser", StringComparison.OrdinalIgnoreCase) => (1, 2),
+                _ => (0, 1)
+            };
+
+            var applicationIdentity = TryGetCallArgumentIdentity(
+                method, instructions, callIndex, calledMethod, applicationNameIndex);
+            return applicationIdentity ?? TryGetCallArgumentIdentity(
+                method, instructions, callIndex, calledMethod, commandLineIndex);
         }
 
         private static string? TryGetShellExecuteExFileIdentity(
@@ -194,23 +286,29 @@ namespace MLVScan.Services.DataFlow
             MethodReference calledMethod,
             int argumentIndex)
         {
-            var mapping = DataFlowInstructionHelper.TryGetParameterMapping(instructions, callIndex, calledMethod);
-            if (mapping.TryGetValue(argumentIndex, out var localIndex))
-            {
-                return BuildLocalPathIdentity(method, instructions, callIndex, localIndex);
-            }
-
-            if (!InstructionValueResolver.TryResolveCallArgumentDisplay(
-                    method, calledMethod, instructions, callIndex, argumentIndex, out var display) ||
-                string.IsNullOrWhiteSpace(display) ||
-                display.Contains("<unknown", StringComparison.OrdinalIgnoreCase) ||
-                display.Contains("<local:", StringComparison.OrdinalIgnoreCase) ||
-                display.Contains("<argument:", StringComparison.OrdinalIgnoreCase))
+            var resolved = InstructionValueResolver.TryResolveCallArgumentDisplay(
+                method, calledMethod, instructions, callIndex, argumentIndex, out var display);
+            if (resolved && display.Contains("<null>", StringComparison.OrdinalIgnoreCase))
             {
                 return null;
             }
 
-            return NormalizeResolvedPathIdentity(display);
+            if (DataFlowInstructionHelper.TryGetCallArgumentLocalVariable(
+                    instructions, callIndex, calledMethod, argumentIndex, out var localIndex))
+            {
+                return BuildLocalPathIdentity(method, instructions, callIndex, localIndex);
+            }
+
+            if (resolved &&
+                !string.IsNullOrWhiteSpace(display) &&
+                !display.Contains("<unknown", StringComparison.OrdinalIgnoreCase) &&
+                !display.Contains("<local:", StringComparison.OrdinalIgnoreCase) &&
+                !display.Contains("<argument:", StringComparison.OrdinalIgnoreCase))
+            {
+                return NormalizeResolvedPathIdentity(display);
+            }
+
+            return null;
         }
 
         private static string BuildLocalPathIdentity(

--- a/Services/DataFlow/DataFlowOperationClassifier.cs
+++ b/Services/DataFlow/DataFlowOperationClassifier.cs
@@ -372,6 +372,12 @@ namespace MLVScan.Services.DataFlow
             {
                 identities.UnionWith(BuildLocalPathIdentities(method, instructions, producerIndex, localIndex));
             }
+            else if (DataFlowInstructionHelper.TryGetCallArgumentProducerIndex(
+                         instructions, callIndex, calledMethod, argumentIndex, out producerIndex) &&
+                     TryGetMethodParameterIndex(method, instructions[producerIndex], out var parameterIndex))
+            {
+                identities.Add(BuildArgumentPathIdentity(method, parameterIndex));
+            }
 
             if (resolved && IsConcreteResolvedPath(display))
             {
@@ -379,6 +385,28 @@ namespace MLVScan.Services.DataFlow
             }
 
             return identities;
+        }
+
+        private static bool TryGetMethodParameterIndex(
+            MethodDefinition method,
+            Instruction instruction,
+            out int parameterIndex)
+        {
+            parameterIndex = -1;
+            if (!instruction.TryGetArgumentIndex(out var rawIndex))
+            {
+                return false;
+            }
+
+            parameterIndex = instruction.Operand is ParameterDefinition parameter
+                ? parameter.Index
+                : rawIndex - (method.HasThis ? 1 : 0);
+            return parameterIndex >= 0 && parameterIndex < method.Parameters.Count;
+        }
+
+        private static string BuildArgumentPathIdentity(MethodDefinition method, int parameterIndex)
+        {
+            return $"{method.GetMethodKey()}::argument:{parameterIndex}";
         }
 
         private static bool IsConcreteResolvedPath(string display)

--- a/Services/DataFlow/DataFlowOperationClassifier.cs
+++ b/Services/DataFlow/DataFlowOperationClassifier.cs
@@ -186,13 +186,33 @@ namespace MLVScan.Services.DataFlow
                 return TryGetCallArgumentIdentities(method, instructions, processStartIndex, processStartMethod, 0);
             }
 
+            IReadOnlyCollection<int> startInfoDefinitionIndexes = Array.Empty<int>();
+            if (startInfoLocal.HasValue &&
+                DataFlowInstructionHelper.TryGetCallArgumentProducerIndex(
+                    instructions, processStartIndex, processStartMethod, 0, out var startInfoLoadIndex))
+            {
+                startInfoDefinitionIndexes = DataFlowInstructionHelper.GetReachingLocalStoreIndexes(
+                    instructions, startInfoLoadIndex, startInfoLocal.Value);
+            }
+
             var setterIndexes = DataFlowInstructionHelper.GetReachingInstructionIndexes(
                 instructions,
                 processStartIndex,
                 index => TryGetStartInfoFileNameSetter(instructions[index], out var setter) &&
                          StartInfoSetterBelongsToStartedProcess(
-                             instructions, index, setter, startInfoLocal, processLocal));
+                             instructions,
+                             index,
+                             setter,
+                             startInfoLocal,
+                             processLocal,
+                             startInfoDefinitionIndexes));
             var identities = EmptyIdentities();
+            foreach (var definitionIndex in startInfoDefinitionIndexes)
+            {
+                identities.UnionWith(TryGetStoredStartInfoConstructorIdentities(
+                    method, instructions, definitionIndex));
+            }
+
             foreach (var setterIndex in setterIndexes)
             {
                 var setter = (MethodReference)instructions[setterIndex].Operand;
@@ -201,6 +221,24 @@ namespace MLVScan.Services.DataFlow
             }
 
             return identities;
+        }
+
+        private static HashSet<string> TryGetStoredStartInfoConstructorIdentities(
+            MethodDefinition method,
+            Collection<Instruction> instructions,
+            int storeIndex)
+        {
+            if (!DataFlowInstructionHelper.TryGetConsumedValueProducerIndex(
+                    instructions, storeIndex, out var producerIndex) ||
+                instructions[producerIndex].OpCode != OpCodes.Newobj ||
+                instructions[producerIndex].Operand is not MethodReference constructor ||
+                constructor.DeclaringType?.FullName != "System.Diagnostics.ProcessStartInfo" ||
+                constructor.Parameters.Count == 0)
+            {
+                return EmptyIdentities();
+            }
+
+            return TryGetCallArgumentIdentities(method, instructions, producerIndex, constructor, 0);
         }
 
         private static bool TryGetStartInfoFileNameSetter(
@@ -225,13 +263,27 @@ namespace MLVScan.Services.DataFlow
             int setterIndex,
             MethodReference setter,
             int? startInfoLocal,
-            int? processLocal)
+            int? processLocal,
+            IReadOnlyCollection<int> startedStartInfoDefinitions)
         {
             if (startInfoLocal.HasValue)
             {
-                return DataFlowInstructionHelper.TryGetCallReceiverLocalVariable(
-                           instructions, setterIndex, setter, out var setterStartInfoLocal) &&
-                       setterStartInfoLocal == startInfoLocal.Value;
+                if (!DataFlowInstructionHelper.TryGetCallReceiverProducerIndex(
+                        instructions, setterIndex, setter, out var receiverProducerIndex) ||
+                    !instructions[receiverProducerIndex].TryGetLocalIndex(out var setterStartInfoLocal) ||
+                    setterStartInfoLocal != startInfoLocal.Value)
+                {
+                    return false;
+                }
+
+                if (startedStartInfoDefinitions.Count == 0)
+                {
+                    return true;
+                }
+
+                var setterStartInfoDefinitions = DataFlowInstructionHelper.GetReachingLocalStoreIndexes(
+                    instructions, receiverProducerIndex, setterStartInfoLocal);
+                return setterStartInfoDefinitions.Intersect(startedStartInfoDefinitions).Any();
             }
 
             if (!processLocal.HasValue ||
@@ -302,9 +354,53 @@ namespace MLVScan.Services.DataFlow
 
             var applicationIdentities = TryGetCallArgumentIdentities(
                 method, instructions, callIndex, calledMethod, applicationNameIndex);
-            return applicationIdentities.Count > 0
-                ? applicationIdentities
-                : TryGetCallArgumentIdentities(method, instructions, callIndex, calledMethod, commandLineIndex);
+            if (applicationIdentities.Count > 0)
+            {
+                return applicationIdentities;
+            }
+
+            var commandLineIdentities = TryGetCallArgumentIdentities(
+                method, instructions, callIndex, calledMethod, commandLineIndex);
+            if (InstructionValueResolver.TryResolveCallArgumentDisplay(
+                    method,
+                    calledMethod,
+                    instructions,
+                    callIndex,
+                    commandLineIndex,
+                    out var commandLine) &&
+                IsConcreteResolvedPath(commandLine) &&
+                TryExtractCommandExecutable(commandLine, out var executable))
+            {
+                commandLineIdentities.Add(NormalizeResolvedPathIdentity(executable));
+            }
+
+            return commandLineIdentities;
+        }
+
+        private static bool TryExtractCommandExecutable(string commandLine, out string executable)
+        {
+            executable = string.Empty;
+            var trimmed = commandLine.Trim();
+            if (trimmed.Length == 0)
+            {
+                return false;
+            }
+
+            if (trimmed[0] == '"')
+            {
+                var closingQuote = trimmed.IndexOf('"', 1);
+                if (closingQuote <= 1)
+                {
+                    return false;
+                }
+
+                executable = trimmed[1..closingQuote];
+                return true;
+            }
+
+            var separatorIndex = trimmed.IndexOfAny(new[] { ' ', '\t', '\r', '\n' });
+            executable = separatorIndex < 0 ? trimmed : trimmed[..separatorIndex];
+            return executable.Length > 0;
         }
 
         private static HashSet<string> TryGetShellExecuteExFileIdentities(

--- a/Services/DataFlow/DataFlowOperationClassifier.cs
+++ b/Services/DataFlow/DataFlowOperationClassifier.cs
@@ -147,6 +147,7 @@ namespace MLVScan.Services.DataFlow
         {
             int? startInfoLocal = null;
             int? processLocal = null;
+            int? processReceiverLoadIndex = null;
 
             if (!processStartMethod.HasThis &&
                 processStartMethod.Parameters.Count == 1 &&
@@ -173,13 +174,15 @@ namespace MLVScan.Services.DataFlow
             }
             else if (processStartMethod.HasThis)
             {
-                if (!DataFlowInstructionHelper.TryGetCallReceiverLocalVariable(
-                        instructions, processStartIndex, processStartMethod, out var resolvedProcessLocal))
+                if (!DataFlowInstructionHelper.TryGetCallReceiverProducerIndex(
+                        instructions, processStartIndex, processStartMethod, out var receiverLoadIndex) ||
+                    !instructions[receiverLoadIndex].TryGetLocalIndex(out var resolvedProcessLocal))
                 {
                     return EmptyIdentities();
                 }
 
                 processLocal = resolvedProcessLocal;
+                processReceiverLoadIndex = receiverLoadIndex;
             }
             else if (processStartMethod.Parameters.Count > 0)
             {
@@ -187,12 +190,18 @@ namespace MLVScan.Services.DataFlow
             }
 
             IReadOnlyCollection<int> startInfoDefinitionIndexes = Array.Empty<int>();
+            IReadOnlyCollection<int> processDefinitionIndexes = Array.Empty<int>();
             if (startInfoLocal.HasValue &&
                 DataFlowInstructionHelper.TryGetCallArgumentProducerIndex(
                     instructions, processStartIndex, processStartMethod, 0, out var startInfoLoadIndex))
             {
                 startInfoDefinitionIndexes = DataFlowInstructionHelper.GetReachingLocalStoreIndexes(
                     instructions, startInfoLoadIndex, startInfoLocal.Value);
+            }
+            else if (processLocal.HasValue && processReceiverLoadIndex.HasValue)
+            {
+                processDefinitionIndexes = DataFlowInstructionHelper.GetReachingLocalStoreIndexes(
+                    instructions, processReceiverLoadIndex.Value, processLocal.Value);
             }
 
             var setterIndexes = DataFlowInstructionHelper.GetReachingInstructionIndexes(
@@ -205,7 +214,8 @@ namespace MLVScan.Services.DataFlow
                              setter,
                              startInfoLocal,
                              processLocal,
-                             startInfoDefinitionIndexes));
+                             startInfoDefinitionIndexes,
+                             processDefinitionIndexes));
             var identities = EmptyIdentities();
             foreach (var definitionIndex in startInfoDefinitionIndexes)
             {
@@ -218,6 +228,82 @@ namespace MLVScan.Services.DataFlow
                 var setter = (MethodReference)instructions[setterIndex].Operand;
                 identities.UnionWith(
                     TryGetCallArgumentIdentities(method, instructions, setterIndex, setter, 0));
+            }
+
+            if (processLocal.HasValue)
+            {
+                var startInfoAssignmentIndexes = DataFlowInstructionHelper.GetReachingInstructionIndexes(
+                    instructions,
+                    processStartIndex,
+                    index => TryGetProcessStartInfoSetter(instructions[index], out var setter) &&
+                             ProcessReceiverMatchesStartedProcess(
+                                 instructions,
+                                 index,
+                                 setter,
+                                 processLocal.Value,
+                                 processDefinitionIndexes));
+                foreach (var assignmentIndex in startInfoAssignmentIndexes)
+                {
+                    var setter = (MethodReference)instructions[assignmentIndex].Operand;
+                    identities.UnionWith(TryGetAssignedStartInfoIdentities(
+                        method, instructions, assignmentIndex, setter));
+                }
+            }
+
+            return identities;
+        }
+
+        private static HashSet<string> TryGetAssignedStartInfoIdentities(
+            MethodDefinition method,
+            Collection<Instruction> instructions,
+            int setterIndex,
+            MethodReference setter)
+        {
+            if (!DataFlowInstructionHelper.TryGetCallArgumentProducerIndex(
+                    instructions, setterIndex, setter, 0, out var producerIndex))
+            {
+                return EmptyIdentities();
+            }
+
+            if (instructions[producerIndex].OpCode == OpCodes.Newobj &&
+                instructions[producerIndex].Operand is MethodReference constructor &&
+                constructor.DeclaringType?.FullName == "System.Diagnostics.ProcessStartInfo" &&
+                constructor.Parameters.Count > 0)
+            {
+                return TryGetCallArgumentIdentities(method, instructions, producerIndex, constructor, 0);
+            }
+
+            if (!instructions[producerIndex].TryGetLocalIndex(out var startInfoLocal))
+            {
+                return EmptyIdentities();
+            }
+
+            var definitions = DataFlowInstructionHelper.GetReachingLocalStoreIndexes(
+                instructions, producerIndex, startInfoLocal);
+            var identities = EmptyIdentities();
+            foreach (var definitionIndex in definitions)
+            {
+                identities.UnionWith(TryGetStoredStartInfoConstructorIdentities(
+                    method, instructions, definitionIndex));
+            }
+
+            var fileNameSetterIndexes = DataFlowInstructionHelper.GetReachingInstructionIndexes(
+                instructions,
+                setterIndex,
+                index => TryGetStartInfoFileNameSetter(instructions[index], out var fileNameSetter) &&
+                         StartInfoSetterBelongsToStartedProcess(
+                             instructions,
+                             index,
+                             fileNameSetter,
+                             startInfoLocal,
+                             null,
+                             definitions,
+                             Array.Empty<int>()));
+            foreach (var fileNameSetterIndex in fileNameSetterIndexes)
+            {
+                var fileNameSetter = (MethodReference)instructions[fileNameSetterIndex].Operand;
+                identities.UnionWith(TryGetCallArgumentIdentities(
+                    method, instructions, fileNameSetterIndex, fileNameSetter, 0));
             }
 
             return identities;
@@ -258,13 +344,31 @@ namespace MLVScan.Services.DataFlow
             return true;
         }
 
+        private static bool TryGetProcessStartInfoSetter(
+            Instruction instruction,
+            out MethodReference setter)
+        {
+            setter = null!;
+            if (!instruction.IsCallOrCallvirt() ||
+                instruction.Operand is not MethodReference candidate ||
+                candidate.DeclaringType?.FullName != "System.Diagnostics.Process" ||
+                candidate.Name != "set_StartInfo")
+            {
+                return false;
+            }
+
+            setter = candidate;
+            return true;
+        }
+
         private static bool StartInfoSetterBelongsToStartedProcess(
             Collection<Instruction> instructions,
             int setterIndex,
             MethodReference setter,
             int? startInfoLocal,
             int? processLocal,
-            IReadOnlyCollection<int> startedStartInfoDefinitions)
+            IReadOnlyCollection<int> startedStartInfoDefinitions,
+            IReadOnlyCollection<int> startedProcessDefinitions)
         {
             if (startInfoLocal.HasValue)
             {
@@ -302,9 +406,37 @@ namespace MLVScan.Services.DataFlow
                 return false;
             }
 
-            return DataFlowInstructionHelper.TryGetCallReceiverLocalVariable(
-                       instructions, setterReceiverProducerIndex, getter, out var setterProcessLocal) &&
-                   setterProcessLocal == processLocal.Value;
+            return ProcessReceiverMatchesStartedProcess(
+                instructions,
+                setterReceiverProducerIndex,
+                getter,
+                processLocal.Value,
+                startedProcessDefinitions);
+        }
+
+        private static bool ProcessReceiverMatchesStartedProcess(
+            Collection<Instruction> instructions,
+            int callIndex,
+            MethodReference calledMethod,
+            int processLocal,
+            IReadOnlyCollection<int> startedProcessDefinitions)
+        {
+            if (!DataFlowInstructionHelper.TryGetCallReceiverProducerIndex(
+                    instructions, callIndex, calledMethod, out var receiverProducerIndex) ||
+                !instructions[receiverProducerIndex].TryGetLocalIndex(out var receiverProcessLocal) ||
+                receiverProcessLocal != processLocal)
+            {
+                return false;
+            }
+
+            if (startedProcessDefinitions.Count == 0)
+            {
+                return true;
+            }
+
+            var receiverDefinitions = DataFlowInstructionHelper.GetReachingLocalStoreIndexes(
+                instructions, receiverProducerIndex, receiverProcessLocal);
+            return receiverDefinitions.Intersect(startedProcessDefinitions).Any();
         }
 
         private static HashSet<string> TryGetNativeExecutionPathIdentities(

--- a/Services/DataFlow/DataFlowPatternEvaluator.cs
+++ b/Services/DataFlow/DataFlowPatternEvaluator.cs
@@ -85,11 +85,10 @@ namespace MLVScan.Services.DataFlow
 
         public ScanFinding CreateFinding(DataFlowChain chain)
         {
-            var findingSeverity = DetermineFindingSeverity(chain);
             return new ScanFinding(
                 chain.MethodLocation,
                 chain.ToDetailedDescription(),
-                findingSeverity,
+                chain.Severity,
                 chain.ToCombinedCodeSnippet())
             {
                 RuleId = "DataFlowAnalysis",
@@ -103,53 +102,6 @@ namespace MLVScan.Services.DataFlow
                    pattern == DataFlowPattern.DownloadAndExecute ||
                    pattern == DataFlowPattern.DynamicCodeLoading ||
                    pattern == DataFlowPattern.ObfuscatedPersistence;
-        }
-
-        private static Severity DetermineFindingSeverity(DataFlowChain chain)
-        {
-            if (chain.Pattern != DataFlowPattern.EmbeddedResourceDropAndExecute)
-            {
-                return chain.Severity;
-            }
-
-            return HasEmbeddedDropperMarkers(chain)
-                ? chain.Severity
-                : Severity.Medium;
-        }
-
-        private static bool HasEmbeddedDropperMarkers(DataFlowChain chain)
-        {
-            var texts = EnumerateChainTexts(chain).Where(value => !string.IsNullOrWhiteSpace(value)).ToList();
-            return texts.Any(value =>
-                value.Contains(".cmd", StringComparison.OrdinalIgnoreCase) ||
-                value.Contains(".bat", StringComparison.OrdinalIgnoreCase) ||
-                value.Contains("%TEMP%", StringComparison.OrdinalIgnoreCase) ||
-                value.Contains("ShellExecuteEx", StringComparison.OrdinalIgnoreCase) ||
-                value.Contains("PInvoke.ShellExecute", StringComparison.OrdinalIgnoreCase) ||
-                value.Contains("PInvoke.CreateProcess", StringComparison.OrdinalIgnoreCase) ||
-                value.Contains("PInvoke.WinExec", StringComparison.OrdinalIgnoreCase) ||
-                value.Contains("temp script dropper pattern", StringComparison.OrdinalIgnoreCase) ||
-                value.Contains("nShow=0", StringComparison.OrdinalIgnoreCase) ||
-                value.Contains("WindowStyle=Hidden", StringComparison.OrdinalIgnoreCase) ||
-                value.Contains("CreateNoWindow=true", StringComparison.OrdinalIgnoreCase));
-        }
-
-        private static IEnumerable<string> EnumerateChainTexts(DataFlowChain chain)
-        {
-            yield return chain.Summary;
-            yield return chain.MethodLocation;
-
-            foreach (var node in chain.Nodes)
-            {
-                yield return node.Location;
-                yield return node.Operation;
-                yield return node.DataDescription;
-
-                if (!string.IsNullOrWhiteSpace(node.CodeSnippet))
-                {
-                    yield return node.CodeSnippet;
-                }
-            }
         }
 
         private static bool HasNetworkSource(IEnumerable<DataFlowInterestingOperation> operations)

--- a/Services/DataFlow/DataFlowPatternEvaluator.cs
+++ b/Services/DataFlow/DataFlowPatternEvaluator.cs
@@ -168,19 +168,22 @@ namespace MLVScan.Services.DataFlow
         private static bool HasLinkedEmbeddedPayloadExecution(
             IReadOnlyList<DataFlowInterestingOperation> operations)
         {
-            var writtenPaths = operations
-                .Where(static operation => HasFileWrite(new[] { operation }))
-                .SelectMany(static operation => operation.PayloadPathIdentities)
-                .ToHashSet(StringComparer.Ordinal);
-
-            if (writtenPaths.Count == 0)
+            var writtenPaths = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var operation in operations)
             {
-                return false;
+                if (HasProcessStart(new[] { operation }) &&
+                    operation.PayloadPathIdentities.Overlaps(writtenPaths))
+                {
+                    return true;
+                }
+
+                if (HasFileWrite(new[] { operation }))
+                {
+                    writtenPaths.UnionWith(operation.PayloadPathIdentities);
+                }
             }
 
-            return operations.Any(operation =>
-                HasProcessStart(new[] { operation }) &&
-                operation.PayloadPathIdentities.Overlaps(writtenPaths));
+            return false;
         }
 
         private static bool HasNetworkSink(IEnumerable<DataFlowInterestingOperation> operations)

--- a/Services/DataFlow/DataFlowPatternEvaluator.cs
+++ b/Services/DataFlow/DataFlowPatternEvaluator.cs
@@ -7,7 +7,7 @@ namespace MLVScan.Services.DataFlow
     {
         public DataFlowPattern RecognizePattern(IReadOnlyList<DataFlowInterestingOperation> operations)
         {
-            if (HasResourceSource(operations) && HasProcessStart(operations) && (HasFileWrite(operations) || HasTransform(operations)))
+            if (HasResourceSource(operations) && HasLinkedEmbeddedPayloadExecution(operations))
             {
                 return DataFlowPattern.EmbeddedResourceDropAndExecute;
             }
@@ -163,6 +163,26 @@ namespace MLVScan.Services.DataFlow
                  operation.Operation.Contains("PInvoke.ShellExecute", StringComparison.OrdinalIgnoreCase) ||
                  operation.Operation.Contains("PInvoke.CreateProcess", StringComparison.OrdinalIgnoreCase) ||
                  operation.Operation.Contains("PInvoke.WinExec", StringComparison.OrdinalIgnoreCase)));
+        }
+
+        private static bool HasLinkedEmbeddedPayloadExecution(
+            IReadOnlyList<DataFlowInterestingOperation> operations)
+        {
+            var writtenPaths = operations
+                .Where(static operation => HasFileWrite(new[] { operation }))
+                .Select(static operation => operation.PayloadPathIdentity)
+                .Where(static identity => !string.IsNullOrWhiteSpace(identity))
+                .ToHashSet(StringComparer.Ordinal);
+
+            if (writtenPaths.Count == 0)
+            {
+                return false;
+            }
+
+            return operations.Any(operation =>
+                HasProcessStart(new[] { operation }) &&
+                operation.PayloadPathIdentity != null &&
+                writtenPaths.Contains(operation.PayloadPathIdentity));
         }
 
         private static bool HasNetworkSink(IEnumerable<DataFlowInterestingOperation> operations)

--- a/Services/DataFlow/DataFlowPatternEvaluator.cs
+++ b/Services/DataFlow/DataFlowPatternEvaluator.cs
@@ -170,8 +170,7 @@ namespace MLVScan.Services.DataFlow
         {
             var writtenPaths = operations
                 .Where(static operation => HasFileWrite(new[] { operation }))
-                .Select(static operation => operation.PayloadPathIdentity)
-                .Where(static identity => !string.IsNullOrWhiteSpace(identity))
+                .SelectMany(static operation => operation.PayloadPathIdentities)
                 .ToHashSet(StringComparer.Ordinal);
 
             if (writtenPaths.Count == 0)
@@ -181,8 +180,7 @@ namespace MLVScan.Services.DataFlow
 
             return operations.Any(operation =>
                 HasProcessStart(new[] { operation }) &&
-                operation.PayloadPathIdentity != null &&
-                writtenPaths.Contains(operation.PayloadPathIdentity));
+                operation.PayloadPathIdentities.Overlaps(writtenPaths));
         }
 
         private static bool HasNetworkSink(IEnumerable<DataFlowInterestingOperation> operations)

--- a/Services/DataFlow/DeepCallChainAnalyzer.cs
+++ b/Services/DataFlow/DeepCallChainAnalyzer.cs
@@ -132,8 +132,9 @@ namespace MLVScan.Services.DataFlow
             combinedOperations.AddRange(rootFlowOperations);
             combinedOperations.AddRange(transforms.Select(static entry => entry.Operation));
             combinedOperations.AddRange(sinks.Select(static entry => entry.Operation));
+            var identityMappedOperations = CloneOperationsWithCallSitePathMappings(rootNode, combinedOperations);
 
-            var pattern = _patternEvaluator.RecognizePattern(combinedOperations);
+            var pattern = _patternEvaluator.RecognizePattern(identityMappedOperations);
             if (pattern == DataFlowPattern.Legitimate || pattern == DataFlowPattern.Unknown)
             {
                 return null;
@@ -188,6 +189,67 @@ namespace MLVScan.Services.DataFlow
             }
 
             return chain;
+        }
+
+        private static List<DataFlowInterestingOperation> CloneOperationsWithCallSitePathMappings(
+            DataFlowCallChainNode rootNode,
+            IEnumerable<DataFlowInterestingOperation> operations)
+        {
+            var clones = operations.Select(static operation => new DataFlowInterestingOperation
+            {
+                Instruction = operation.Instruction,
+                InstructionIndex = operation.InstructionIndex,
+                MethodReference = operation.MethodReference,
+                NodeType = operation.NodeType,
+                Operation = operation.Operation,
+                DataDescription = operation.DataDescription,
+                LocalVariableIndex = operation.LocalVariableIndex,
+                PayloadPathIdentities = new HashSet<string>(
+                    operation.PayloadPathIdentities, StringComparer.Ordinal)
+            }).ToList();
+
+            ApplyCallSitePathMappings(rootNode, clones);
+            return clones;
+        }
+
+        private static void ApplyCallSitePathMappings(
+            DataFlowCallChainNode callerNode,
+            IReadOnlyCollection<DataFlowInterestingOperation> operations)
+        {
+            foreach (var calleeNode in callerNode.ChildNodes)
+            {
+                var callSite = calleeNode.IncomingCallSite;
+                if (callSite != null)
+                {
+                    foreach (var (parameterIndex, localIndex) in callSite.ParameterMapping)
+                    {
+                        var callerLocalPrefix =
+                            $"{callerNode.MethodInfo.MethodKey}::local:{localIndex}@";
+                        var calleeArgumentIdentity =
+                            $"{calleeNode.MethodInfo.MethodKey}::argument:{parameterIndex}";
+                        var callerOperations = operations
+                            .Where(operation => operation.PayloadPathIdentities.Any(identity =>
+                                identity.StartsWith(callerLocalPrefix, StringComparison.Ordinal)))
+                            .ToList();
+                        var calleeOperations = operations
+                            .Where(operation => operation.PayloadPathIdentities.Contains(calleeArgumentIdentity))
+                            .ToList();
+                        if (callerOperations.Count == 0 || calleeOperations.Count == 0)
+                        {
+                            continue;
+                        }
+
+                        var bridgeIdentity =
+                            $"call:{callerNode.MethodInfo.MethodKey}@{callSite.InstructionIndex}:argument:{parameterIndex}";
+                        foreach (var operation in callerOperations.Concat(calleeOperations))
+                        {
+                            operation.PayloadPathIdentities.Add(bridgeIdentity);
+                        }
+                    }
+                }
+
+                ApplyCallSitePathMappings(calleeNode, operations);
+            }
         }
 
         private static void CollectChainOperations(

--- a/Services/DataFlow/DeepCallChainAnalyzer.cs
+++ b/Services/DataFlow/DeepCallChainAnalyzer.cs
@@ -225,11 +225,22 @@ namespace MLVScan.Services.DataFlow
                     {
                         var callerLocalPrefix =
                             $"{callerNode.MethodInfo.MethodKey}::local:{localIndex}@";
+                        var reachingStores = callSite.ParameterReachingStoreIndexes.TryGetValue(
+                            parameterIndex, out var mappedStores)
+                            ? mappedStores
+                            : new HashSet<int>();
+                        var callerPathIdentities = reachingStores.Count == 0
+                            ? new HashSet<string>(StringComparer.Ordinal)
+                            {
+                                $"{callerLocalPrefix}parameter"
+                            }
+                            : reachingStores
+                                .Select(index => $"{callerLocalPrefix}instruction:{index}")
+                                .ToHashSet(StringComparer.Ordinal);
                         var calleeArgumentIdentity =
                             $"{calleeNode.MethodInfo.MethodKey}::argument:{parameterIndex}";
                         var callerOperations = operations
-                            .Where(operation => operation.PayloadPathIdentities.Any(identity =>
-                                identity.StartsWith(callerLocalPrefix, StringComparison.Ordinal)))
+                            .Where(operation => operation.PayloadPathIdentities.Overlaps(callerPathIdentities))
                             .ToList();
                         var calleeOperations = operations
                             .Where(operation => operation.PayloadPathIdentities.Contains(calleeArgumentIdentity))

--- a/Services/DataFlow/DeepCallChainAnalyzer.cs
+++ b/Services/DataFlow/DeepCallChainAnalyzer.cs
@@ -257,6 +257,31 @@ namespace MLVScan.Services.DataFlow
                             operation.PayloadPathIdentities.Add(bridgeIdentity);
                         }
                     }
+
+                    foreach (var (parameterIndex, callerParameterIndex) in callSite.ForwardedParameterMapping)
+                    {
+                        var callerArgumentIdentity =
+                            $"{callerNode.MethodInfo.MethodKey}::argument:{callerParameterIndex}";
+                        var calleeArgumentIdentity =
+                            $"{calleeNode.MethodInfo.MethodKey}::argument:{parameterIndex}";
+                        var callerOperations = operations
+                            .Where(operation => operation.PayloadPathIdentities.Contains(callerArgumentIdentity))
+                            .ToList();
+                        var calleeOperations = operations
+                            .Where(operation => operation.PayloadPathIdentities.Contains(calleeArgumentIdentity))
+                            .ToList();
+                        if (callerOperations.Count == 0 || calleeOperations.Count == 0)
+                        {
+                            continue;
+                        }
+
+                        var bridgeIdentity =
+                            $"call:{callerNode.MethodInfo.MethodKey}@{callSite.InstructionIndex}:argument:{parameterIndex}";
+                        foreach (var operation in callerOperations.Concat(calleeOperations))
+                        {
+                            operation.PayloadPathIdentities.Add(bridgeIdentity);
+                        }
+                    }
                 }
 
                 ApplyCallSitePathMappings(calleeNode, operations);

--- a/Services/Helpers/InstructionExtensions.cs
+++ b/Services/Helpers/InstructionExtensions.cs
@@ -298,8 +298,7 @@ namespace MLVScan.Services.Helpers
         public static bool IsSimpleConstantLoad(this Instruction instruction)
         {
             return instruction.OpCode == OpCodes.Ldstr ||
-                   instruction.OpCode == OpCodes.Ldc_I4 ||
-                   instruction.OpCode == OpCodes.Ldc_I4_S ||
+                   instruction.TryResolveInt32Literal(out _) ||
                    instruction.OpCode == OpCodes.Ldnull;
         }
     }

--- a/Services/ThreatIntel/ThreatDispositionClassifier.cs
+++ b/Services/ThreatIntel/ThreatDispositionClassifier.cs
@@ -239,10 +239,14 @@ public sealed class ThreatDispositionClassifier
             return false;
         }
 
+        if (finding.HasDataFlow && IsSuspiciousDataFlowSeed(finding))
+        {
+            return true;
+        }
+
         if (string.Equals(finding.RuleId, "DataFlowAnalysis", StringComparison.Ordinal))
         {
-            return finding.HasDataFlow &&
-                   IsSuspiciousDataFlowSeed(finding);
+            return false;
         }
 
         if (StrongStandaloneRuleIds.Contains(finding.RuleId ?? string.Empty))

--- a/Services/ThreatIntel/ThreatDispositionClassifier.cs
+++ b/Services/ThreatIntel/ThreatDispositionClassifier.cs
@@ -295,30 +295,7 @@ public sealed class ThreatDispositionClassifier
 
     private static bool IsSuspiciousDataFlowSeed(ScanFinding finding)
     {
-        var pattern = finding.DataFlowChain!.Pattern;
-        if (pattern == DataFlowPattern.EmbeddedResourceDropAndExecute)
-        {
-            return HasEmbeddedDropperExecutionMarkers(finding);
-        }
-
-        return SuspiciousDataFlowPatterns.Contains(pattern);
-    }
-
-    private static bool HasEmbeddedDropperExecutionMarkers(ScanFinding finding)
-    {
-        var texts = EnumerateEmbeddedDataFlowTexts(finding).ToList();
-        return ContainsAny(texts,
-            ".cmd",
-            ".bat",
-            "%TEMP%",
-            "ShellExecuteEx",
-            "PInvoke.ShellExecute",
-            "PInvoke.CreateProcess",
-            "PInvoke.WinExec",
-            "temp script dropper pattern",
-            "nShow=0",
-            "WindowStyle=Hidden",
-            "CreateNoWindow=true");
+        return SuspiciousDataFlowPatterns.Contains(finding.DataFlowChain!.Pattern);
     }
 
     private static IEnumerable<string> EnumerateEmbeddedDataFlowTexts(ScanFinding finding)


### PR DESCRIPTION
### Motivation
An `EmbeddedResourceDropAndExecute` finding was downgraded unless narrow script/temp/hidden markers were present, allowing embedded PE payloads launched with process APIs to fall through to a Clean disposition.

### Fix
- Preserve emitted embedded-dropper severity and seed a Suspicious disposition from validated linked drop-and-execute data flow.
- Require a real, write-before-execute path link instead of proximity.
- Track concrete, local reaching-definition, formal-argument, alias, conditional, and cross-method path identities without accepting unresolved resolver placeholders.
- Resolve direct and indirect targets for `Process.Start`, `ProcessStartInfo` constructors/setters/object initializers, `Process.StartInfo` assignment, `CreateProcess*`, `ShellExecuteEx.lpFile`, `WinExec`, and related shell APIs.
- Make Process/ProcessStartInfo object ownership and reassignment branch-aware.
- Treat only writable `FileStream` constructors as write sinks.
- Reclassify BoneLibUpdater as review-required Suspicious because its embedded-resource -> disk -> execute behavior is statically indistinguishable from a dropper.
- Add positive and false-positive regressions for every reviewed execution/path variant.

### Validation
- 227 focused resolver, data-flow, disposition, BoneLibUpdater, quarantine, and cross-method tests passed.
- The full 100+ assembly false-positive disposition sweep passed against explicit expected baselines, including BoneLibUpdater as Suspicious and existing incomplete samples as ManualReviewRequired.
- The separate High-signal corpus summary retains only the existing unrelated AngleSharp, SideHustle, and Sideload baseline failures.
- `git diff --check` passed.
- All actionable Codex and CodeRabbit review threads were addressed and resolved.