### PR TITLE
Enforce complete clean false-positive corpus coverage

### DIFF
--- a/MLVScan.Core.Tests/Integration/FalsePositiveScanTests.cs
+++ b/MLVScan.Core.Tests/Integration/FalsePositiveScanTests.cs
@@ -273,7 +273,7 @@ public class FalsePositiveScanTests
     }
 
     [SkippableFact]
-    public void Scan_BoneLibUpdater_EmbeddedExecutableDropper_ShouldBeSuspicious()
+    public void Scan_BoneLibUpdater_ExactReviewedSample_ShouldBeClean()
     {
         var path = GetSamplePath("BoneLibUpdater.dll");
 
@@ -285,9 +285,9 @@ public class FalsePositiveScanTests
         var dto = ScanResultMapper.ToDto(findings, Path.GetFileName(path), File.ReadAllBytes(path), false);
 
         dto.Disposition.Should().NotBeNull();
-        dto.Disposition!.Classification.Should().Be("Suspicious",
-            "an embedded executable drop-and-execute chain must not evade disposition based on its path or launch API");
-        dto.Disposition.BlockingRecommended.Should().BeTrue();
+        dto.Disposition!.Classification.Should().Be("Clean",
+            "the exact reviewed BoneLib updater bytes are a known benign exception to the otherwise suspicious behavior");
+        dto.Disposition.BlockingRecommended.Should().BeFalse();
         dto.ThreatFamilies.Should().BeNull();
     }
 
@@ -557,8 +557,8 @@ public class FalsePositiveScanTests
         {
             "AngleSharp.dll",
             "Bannerlord.ButterLib.dll",
-            // Known benign sample, but its embedded resource -> disk -> execute chain is intentionally
-            // review-required because the same static behavior is indistinguishable from a dropper.
+            // Known benign exact sample. Its High findings remain visible even though the reviewed bytes
+            // receive a Clean disposition.
             "BoneLibUpdater.dll",
             "CustomTV.dll",
             "IllegalRave.dll",
@@ -595,13 +595,6 @@ public class FalsePositiveScanTests
         var assemblyPaths = GetAllFalsePositiveAssemblyPaths();
         var scanner = new AssemblyScanner(RuleFactory.CreateDefaultRules());
         var violations = new List<string>();
-        var expectedNonCleanDispositions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-        {
-            // The embedded updater is benign, but its resource -> disk -> execute behavior is
-            // intentionally indistinguishable from a dropper and therefore review-required.
-            ["BoneLibUpdater.dll"] = "Suspicious"
-        };
-
         foreach (var path in assemblyPaths)
         {
             var findings = scanner.Scan(path).ToList();
@@ -613,20 +606,16 @@ public class FalsePositiveScanTests
             _output.WriteLine(
                 $"{relativePath} => Disposition={classification}, ThreatFamilies={(familyIds.Count == 0 ? "None" : string.Join(", ", familyIds))}, Findings={findings.Count}");
 
-            var expectedClassification = expectedNonCleanDispositions.TryGetValue(relativePath, out var expected)
-                ? expected
-                : "Clean";
-
-            if (!string.Equals(classification, expectedClassification, StringComparison.Ordinal) ||
+            if (!string.Equals(classification, "Clean", StringComparison.Ordinal) ||
                 familyIds.Count > 0)
             {
                 violations.Add(
-                    $"{relativePath} => ExpectedDisposition={expectedClassification}, ActualDisposition={classification}, ThreatFamilies={(familyIds.Count == 0 ? "None" : string.Join(", ", familyIds))}");
+                    $"{relativePath} => ExpectedDisposition=Clean, ActualDisposition={classification}, ThreatFamilies={(familyIds.Count == 0 ? "None" : string.Join(", ", familyIds))}");
             }
         }
 
         violations.Should().BeEmpty(
-            "FALSE_POSITIVES assemblies should match the explicit disposition baseline and never produce threat-family matches.\n" +
+            "every FALSE_POSITIVES assembly should be Clean and never produce threat-family matches.\n" +
             string.Join(Environment.NewLine, violations));
     }
 

--- a/MLVScan.Core.Tests/Integration/FalsePositiveScanTests.cs
+++ b/MLVScan.Core.Tests/Integration/FalsePositiveScanTests.cs
@@ -38,6 +38,7 @@ public class FalsePositiveScanTests
         "LabFusion.dll",
         "LecPowerTranslator15.dll",
         "LethalLizard.ModManager.dll",
+        "ModHub.Core.dll",
         "ModsApp.dll",
         "Muse_Dash.dll",
         "Musicfy.dll",
@@ -554,6 +555,7 @@ public class FalsePositiveScanTests
 
         var allowedHighSeveritySamples = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
+            "AngleSharp.dll",
             "Bannerlord.ButterLib.dll",
             // Known benign sample, but its embedded resource -> disk -> execute chain is intentionally
             // review-required because the same static behavior is indistinguishable from a dropper.
@@ -563,6 +565,8 @@ public class FalsePositiveScanTests
             "LabFusion.dll",
             "Muse_Dash.dll",
             "Personify.dll",
+            "SideHustle.dll",
+            "Sideload.dll",
             "SimpleSingleplayerRespawn.dll",
             "UnityExplorer.ML.IL2CPP.CoreCLR.dll",
             "UnityExplorer.ML.Mono.dll",

--- a/MLVScan.Core.Tests/Integration/ThreatFamilyQuarantineTests.cs
+++ b/MLVScan.Core.Tests/Integration/ThreatFamilyQuarantineTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using System.Text;
 using MLVScan.Models.Dto;
 using MLVScan.Services;
+using MLVScan.Services.ThreatIntel;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -105,9 +106,24 @@ public class ThreatFamilyQuarantineTests
         var dto = ScanResultMapper.ToDto(findings, Path.GetFileName(path), assemblyBytes, false);
 
         dto.ThreatFamilies.Should().NotBeNullOrEmpty();
-        dto.ThreatFamilies!.Should().Contain(match =>
+        var mappedVariant = dto.ThreatFamilies!.FirstOrDefault(match =>
             match.FamilyId == "family-webdownload-stage-exec-v3" &&
             match.VariantId == expectedVariantId);
+
+        if (mappedVariant == null)
+        {
+            dto.ThreatFamilies.Should().Contain(match =>
+                    match.FamilyId == "family-webdownload-stage-exec-v3" &&
+                    match.ExactHashMatch,
+                "an exact known-sample match may take precedence in the production result");
+
+            var behaviorMatches = new ThreatFamilyClassifier().Classify(findings, sha256Hash: null);
+            behaviorMatches.Should().Contain(match =>
+                    match.FamilyId == "family-webdownload-stage-exec-v3" &&
+                    match.VariantId == expectedVariantId &&
+                    !match.ExactHashMatch,
+                "the sample should retain its behavior-based variant when exact-hash evidence is unavailable");
+        }
 
         WriteThreatFamilyLog(filename, dto.ThreatFamilies!, dto.Findings);
     }

--- a/MLVScan.Core.Tests/Unit/Services/ThreatDispositionClassifierTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/ThreatDispositionClassifierTests.cs
@@ -8,6 +8,9 @@ namespace MLVScan.Core.Tests.Unit.Services;
 
 public class ThreatDispositionClassifierTests
 {
+    private const string ReviewedBoneLibUpdaterSha256 =
+        "BAE327FACB187856E98F4A7997630762BAF0FE73962AAA0EEDB19F8235A9EA81";
+
     [Fact]
     public void Classify_WithFamilyMatch_ReturnsKnownThreat()
     {
@@ -155,44 +158,103 @@ public class ThreatDispositionClassifierTests
     public void Classify_WithEmbeddedUpdaterExeDataFlowAndNoDropperMarkers_ReturnsSuspicious()
     {
         var classifier = new ThreatDispositionClassifier();
-        var dataFlow = new DataFlowChain(
-            "df-local-updater",
-            DataFlowPattern.EmbeddedResourceDropAndExecute,
-            Severity.Critical,
-            "Extracts embedded updater executable and launches it from a local data directory",
-            "Benign.Updater.Run");
-        dataFlow.AppendNode(new DataFlowNode(
-            "Benign.Updater.Run:12",
-            "GetManifestResourceStream",
-            DataFlowNodeType.Source,
-            "embedded updater resource",
-            12));
-        dataFlow.AppendNode(new DataFlowNode(
-            "Benign.Updater.Run:24",
-            "File.Create",
-            DataFlowNodeType.Sink,
-            "C:/AppData/Vendor/updater.exe",
-            24));
-        dataFlow.AppendNode(new DataFlowNode(
-            "Benign.Updater.Run:36",
-            "Process.Start",
-            DataFlowNodeType.Sink,
-            "run local updater executable",
-            36));
-
-        var finding = new ScanFinding(
-            "Benign.Updater.Run",
-            "Detected Process.Start for an embedded updater executable with correlated data flow",
-            Severity.Critical)
-        {
-            RuleId = "ProcessStartRule",
-            DataFlowChain = dataFlow
-        };
+        var finding = CreateEmbeddedUpdaterFinding();
 
         var result = classifier.Classify(new[] { finding }, threatFamilies: null);
 
         result.Classification.Should().Be(ThreatDispositionClassification.Suspicious);
         result.RelatedFindings.Should().ContainSingle().Which.Should().BeSameAs(finding);
+        result.BlockingRecommended.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Classify_WithReviewedBoneLibUpdaterHashAndExpectedBehavior_ReturnsClean()
+    {
+        var classifier = new ThreatDispositionClassifier();
+        var finding = CreateEmbeddedUpdaterFinding();
+
+        var result = classifier.Classify(
+            new[] { finding },
+            threatFamilies: null,
+            analysisCompleteness: null,
+            ReviewedBoneLibUpdaterSha256);
+
+        result.Classification.Should().Be(ThreatDispositionClassification.Clean);
+        result.RelatedFindings.Should().BeEmpty();
+        result.BlockingRecommended.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Classify_WithReviewedBoneLibUpdaterHashAndUnexpectedHighEvidence_ReturnsSuspicious()
+    {
+        var classifier = new ThreatDispositionClassifier();
+        var finding = new ScanFinding(
+            "Embedded resource: stage.ps1",
+            "Embedded script stages and executes a payload",
+            Severity.High)
+        {
+            RuleId = "EmbeddedResourceScriptRule"
+        };
+
+        var result = classifier.Classify(
+            new[] { finding },
+            threatFamilies: null,
+            analysisCompleteness: null,
+            ReviewedBoneLibUpdaterSha256);
+
+        result.Classification.Should().Be(ThreatDispositionClassification.Suspicious);
+        result.BlockingRecommended.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Classify_WithReviewedBoneLibUpdaterHashAndIncompleteAnalysis_ReturnsManualReview()
+    {
+        var classifier = new ThreatDispositionClassifier();
+        var completenessFinding = new ScanFinding(
+            "Assembly",
+            "Data-flow analysis did not complete",
+            Severity.Low)
+        {
+            RuleId = "DataFlowScanWarning"
+        };
+        var completeness = new AnalysisCompletenessResult
+        {
+            IsComplete = false,
+            ReviewRecommended = true,
+            RelatedFindings = { completenessFinding }
+        };
+
+        var result = classifier.Classify(
+            new[] { completenessFinding },
+            threatFamilies: null,
+            completeness,
+            ReviewedBoneLibUpdaterSha256);
+
+        result.Classification.Should().Be(ThreatDispositionClassification.ManualReviewRequired);
+        result.BlockingRecommended.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Classify_WithReviewedBoneLibUpdaterHashAndKnownThreatFamily_ReturnsKnownThreat()
+    {
+        var classifier = new ThreatDispositionClassifier();
+        var family = new ThreatFamilyMatch
+        {
+            FamilyId = "known-malware",
+            DisplayName = "Known Malware",
+            MatchKind = ThreatMatchKind.ExactSampleHash,
+            ExactHashMatch = true,
+            Confidence = 1.0
+        };
+
+        var result = classifier.Classify(
+            Array.Empty<ScanFinding>(),
+            new[] { family },
+            analysisCompleteness: null,
+            ReviewedBoneLibUpdaterSha256);
+
+        result.Classification.Should().Be(ThreatDispositionClassification.KnownThreat);
+        result.PrimaryThreatFamilyId.Should().Be("known-malware");
         result.BlockingRecommended.Should().BeTrue();
     }
 
@@ -358,5 +420,42 @@ public class ThreatDispositionClassifierTests
         result.RelatedFindings.Should().Contain(finding => finding.RuleId == "DataInfiltrationRule");
         result.RelatedFindings.Should().Contain(finding => finding.RuleId == "ProcessStartRule");
         result.BlockingRecommended.Should().BeTrue();
+    }
+
+    private static ScanFinding CreateEmbeddedUpdaterFinding()
+    {
+        var dataFlow = new DataFlowChain(
+            "df-local-updater",
+            DataFlowPattern.EmbeddedResourceDropAndExecute,
+            Severity.Critical,
+            "Extracts embedded updater executable and launches it from a local data directory",
+            "Benign.Updater.Run");
+        dataFlow.AppendNode(new DataFlowNode(
+            "Benign.Updater.Run:12",
+            "GetManifestResourceStream",
+            DataFlowNodeType.Source,
+            "embedded updater resource",
+            12));
+        dataFlow.AppendNode(new DataFlowNode(
+            "Benign.Updater.Run:24",
+            "File.Create",
+            DataFlowNodeType.Sink,
+            "C:/AppData/Vendor/updater.exe",
+            24));
+        dataFlow.AppendNode(new DataFlowNode(
+            "Benign.Updater.Run:36",
+            "Process.Start",
+            DataFlowNodeType.Sink,
+            "run local updater executable",
+            36));
+
+        return new ScanFinding(
+            "Benign.Updater.Run",
+            "Detected Process.Start for an embedded updater executable with correlated data flow",
+            Severity.Critical)
+        {
+            RuleId = "ProcessStartRule",
+            DataFlowChain = dataFlow
+        };
     }
 }

--- a/Services/ScanResultMapper.cs
+++ b/Services/ScanResultMapper.cs
@@ -56,7 +56,7 @@ public static class ScanResultMapper
         var sha256Hash = ComputeSha256(assemblyBytes);
         var analysisCompleteness = BuildAnalysisCompleteness(findingsList);
         var threatFamilies = ThreatFamilyClassifier.Classify(findingsList, callChains, dataFlows, sha256Hash);
-        var disposition = ThreatDispositionClassifier.Classify(findingsList, threatFamilies, analysisCompleteness);
+        var disposition = ThreatDispositionClassifier.Classify(findingsList, threatFamilies, analysisCompleteness, sha256Hash);
         var relatedFindings = disposition.RelatedFindings.ToHashSet();
         var findingDtos = findingsList
             .Select(finding => ToFindingDto(

--- a/Services/ThreatIntel/KnownBenignSampleCatalog.cs
+++ b/Services/ThreatIntel/KnownBenignSampleCatalog.cs
@@ -1,0 +1,31 @@
+using MLVScan.Models;
+
+namespace MLVScan.Services.ThreatIntel;
+
+/// <summary>
+/// Records exact, manually reviewed benign samples whose static behavior would otherwise require review.
+/// </summary>
+internal static class KnownBenignSampleCatalog
+{
+    private const string BoneLibUpdaterSha256 =
+        "BAE327FACB187856E98F4A7997630762BAF0FE73962AAA0EEDB19F8235A9EA81";
+
+    /// <summary>
+    /// Returns whether the exact sample and all of its retained High+ evidence match a reviewed benign profile.
+    /// </summary>
+    public static bool MatchesReviewedBehavior(string? sha256Hash, IReadOnlyList<ScanFinding> findings)
+    {
+        if (!string.Equals(sha256Hash, BoneLibUpdaterSha256, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        // BoneLibUpdater embeds its own updater executable, writes it locally, and launches it. Trust only
+        // these exact bytes and only while every disposition-relevant finding remains that reviewed flow.
+        return findings
+            .Where(finding => finding.Severity >= Severity.High)
+            .All(finding =>
+                string.Equals(finding.RuleId, "ProcessStartRule", StringComparison.Ordinal) &&
+                finding.DataFlowChain?.Pattern == DataFlowPattern.EmbeddedResourceDropAndExecute);
+    }
+}

--- a/Services/ThreatIntel/ThreatDispositionClassifier.cs
+++ b/Services/ThreatIntel/ThreatDispositionClassifier.cs
@@ -51,13 +51,22 @@ public sealed class ThreatDispositionClassifier
         IEnumerable<ScanFinding> findings,
         IEnumerable<ThreatFamilyMatch>? threatFamilies)
     {
-        return Classify(findings, threatFamilies, null);
+        return Classify(findings, threatFamilies, null, null);
     }
 
     public ThreatDispositionResult Classify(
         IEnumerable<ScanFinding> findings,
         IEnumerable<ThreatFamilyMatch>? threatFamilies,
         AnalysisCompletenessResult? analysisCompleteness)
+    {
+        return Classify(findings, threatFamilies, analysisCompleteness, null);
+    }
+
+    public ThreatDispositionResult Classify(
+        IEnumerable<ScanFinding> findings,
+        IEnumerable<ThreatFamilyMatch>? threatFamilies,
+        AnalysisCompletenessResult? analysisCompleteness,
+        string? sha256Hash)
     {
         var findingsList = findings?.ToList() ?? new List<ScanFinding>();
         var threatFamilyList = threatFamilies?.ToList() ?? new List<ThreatFamilyMatch>();
@@ -70,6 +79,12 @@ public sealed class ThreatDispositionClassifier
         if (primaryFamily != null)
         {
             return BuildKnownThreatDisposition(findingsList, primaryFamily);
+        }
+
+        if (analysisCompleteness?.ReviewRecommended != true &&
+            KnownBenignSampleCatalog.MatchesReviewedBehavior(sha256Hash, findingsList))
+        {
+            return BuildCleanDisposition();
         }
 
         var suspiciousSeeds = findingsList
@@ -86,6 +101,11 @@ public sealed class ThreatDispositionClassifier
             return BuildManualReviewDisposition(analysisCompleteness);
         }
 
+        return BuildCleanDisposition();
+    }
+
+    private static ThreatDispositionResult BuildCleanDisposition()
+    {
         return new ThreatDispositionResult
         {
             Classification = ThreatDispositionClassification.Clean,


### PR DESCRIPTION
## What changed

- tracks every current managed assembly in `FALSE_POSITIVES`, including `ModHub.Core.dll`
- requires every recursively discovered false-positive assembly to map to `Clean` with no threat-family match
- records the exact reviewed SHA-256 of `BoneLibUpdater.dll` as benign only when its retained High+ evidence is the reviewed embedded-updater drop-and-launch flow
- preserves `KnownThreat` precedence, incomplete-analysis review, and suspicious disposition for changed bytes or unexpected High+ evidence
- keeps high-severity finding summaries explicit for the reviewed AngleSharp, SideHustle, Sideload, and BoneLib samples
- verifies behavior-family classification independently when an exact malicious quarantine hash correctly takes precedence

## Why

The false-positive corpus had drifted from its tracked inventory, and BoneLib's legitimate embedded updater behavior could only be represented as `Suspicious`. This made it impossible to enforce the ecosystem requirement that approved false-positive samples have a clean final disposition.

The override is content-addressed and behavior-constrained rather than filename- or path-based, so it does not weaken the generic embedded executable drop-and-execute detection.

## Impact

All 113 managed assemblies currently present under `FALSE_POSITIVES` now receive `Clean` with no threat family. All 48 managed quarantine samples remain required to resolve to `KnownThreat`.

## Validation

- focused BoneLib and disposition guardrails: 17 passed
- false-positive suite: 43 passed, 6 optional-fixture skips
- quarantine suite: 180 passed, 1 optional-fixture skip
- full solution: 1,527 passed, 18 fixture-dependent skips
- `git diff --check`
- repository-wide `dotnet format --verify-no-changes` remains unusable due to pre-existing CRLF/whitespace diagnostics across untouched files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Enforces complete tracking and clean dispositions for all 113 false-positive assemblies.
- Trusts the reviewed `BoneLibUpdater.dll` hash only for the expected embedded-updater behavior.
- Preserves `KnownThreat` precedence and review handling for incomplete or unexpected analysis.
- Requires all 48 managed quarantine samples to resolve to `KnownThreat`.
- Adds focused, corpus, quarantine, and full-solution test coverage.

| Author | Lines added | Lines removed |
|---|---:|---:|
| Not available | — | — |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->