### PR TITLE
Bound and cache data-flow CFG analysis work

### DIFF
--- a/MLVScan.Core.Tests/Unit/Services/DataFlowAnalyzerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowAnalyzerTests.cs
@@ -927,6 +927,76 @@ public class DataFlowAnalyzerTests
     }
 
     #endregion
+
+    #region Bounded Analysis Tests
+
+    [Fact]
+    public void AnalyzeMethod_WithRepresentativeCallHeavyMethod_CompletesAnalysis()
+    {
+        using var module = ModuleDefinition.CreateModule("DataFlowCallHeavyTest", ModuleKind.Dll);
+        var method = CreateCallHeavyMethod(module, 400);
+        var analyzer = new DataFlowAnalyzer(RuleFactory.CreateDefaultRules(), new CodeSnippetBuilder());
+
+        analyzer.AnalyzeMethod(method);
+        var findings = analyzer.BuildDataFlowFindings().ToList();
+
+        findings.Should().NotContain(finding => finding.RuleId == "DataFlowScanWarning");
+    }
+
+    [Fact]
+    public void AnalyzeMethod_WhenReachingDefinitionWorkIsExhausted_FailsClosedForManualReview()
+    {
+        using var module = ModuleDefinition.CreateModule("DataFlowBudgetTest", ModuleKind.Dll);
+        // Keep this above the representative 400-call case so it exceeds the current 256x linear budget.
+        var stress = CreateCallHeavyMethod(module, 800);
+        var analyzer = new DataFlowAnalyzer(RuleFactory.CreateDefaultRules(), new CodeSnippetBuilder());
+
+        analyzer.AnalyzeMethod(stress);
+        var findings = analyzer.BuildDataFlowFindings().ToList();
+        var dto = ScanResultMapper.ToDto(findings, "budget-stress.dll", [0x4d, 0x5a], false);
+
+        findings.Should().ContainSingle(finding => finding.RuleId == "DataFlowScanWarning");
+        dto.AnalysisCompleteness.IsComplete.Should().BeFalse();
+        dto.AnalysisCompleteness.ReviewRecommended.Should().BeTrue();
+        dto.Disposition.Should().NotBeNull();
+        dto.Disposition!.Classification.Should().Be("ManualReviewRequired");
+        dto.Disposition.BlockingRecommended.Should().BeTrue();
+    }
+
+    private static MethodDefinition CreateCallHeavyMethod(ModuleDefinition module, int callCount)
+    {
+        var type = new TypeDefinition("TestNamespace", $"CallHeavy{callCount}",
+            TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(type);
+
+        var consume = new MethodDefinition("Consume",
+            MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Void);
+        consume.Parameters.Add(new ParameterDefinition("value", ParameterAttributes.None, module.TypeSystem.Int32));
+        consume.Body.GetILProcessor().Emit(OpCodes.Ret);
+        type.Methods.Add(consume);
+
+        var method = new MethodDefinition("Stress",
+            MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Void);
+        var local = new VariableDefinition(module.TypeSystem.Int32);
+        method.Body.Variables.Add(local);
+        method.Body.InitLocals = true;
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, local);
+        for (var index = 0; index < callCount; index++)
+        {
+            il.Emit(OpCodes.Ldloc, local);
+            il.Emit(OpCodes.Call, consume);
+        }
+
+        il.Emit(OpCodes.Ret);
+        type.Methods.Add(method);
+        return method;
+    }
+
+    #endregion
 }
 
 #pragma warning restore CS0618

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowOperationClassifierTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowOperationClassifierTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using MLVScan.Models.DataFlow;
 using MLVScan.Services.DataFlow;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -36,7 +37,7 @@ public class DataFlowOperationClassifierTests
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
-        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var operations = Classify(method);
         var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
         var processStart = operations.Single(operation => operation.Operation == "Process.Start");
 
@@ -64,7 +65,7 @@ public class DataFlowOperationClassifierTests
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
-        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var operations = Classify(method);
         var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
         var processStart = operations.Single(operation => operation.Operation == "Process.Start");
 
@@ -96,7 +97,7 @@ public class DataFlowOperationClassifierTests
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
-        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var operations = Classify(method);
         var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
         var processStart = operations.Single(operation => operation.Operation == "Process.Start");
 
@@ -143,7 +144,7 @@ public class DataFlowOperationClassifierTests
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
-        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var operations = Classify(method);
         var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
         var processStart = operations.Single(operation => operation.Operation == "Process.Start");
 
@@ -183,7 +184,7 @@ public class DataFlowOperationClassifierTests
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
-        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var operations = Classify(method);
         var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
         var processStart = operations.Single(operation => operation.Operation == "Process.Start");
 
@@ -231,7 +232,7 @@ public class DataFlowOperationClassifierTests
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
-        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var operations = Classify(method);
         var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
         var createProcessOperation = operations.Single(operation =>
             operation.Operation.Contains("PInvoke.CreateProcess", StringComparison.OrdinalIgnoreCase));
@@ -277,7 +278,7 @@ public class DataFlowOperationClassifierTests
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
-        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var operations = Classify(method);
         var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
         var createProcessOperation = operations.Single(operation =>
             operation.Operation.Contains("PInvoke.CreateProcess", StringComparison.OrdinalIgnoreCase));
@@ -308,7 +309,7 @@ public class DataFlowOperationClassifierTests
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
-        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var operations = Classify(method);
         var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
         var processStart = operations.Single(operation => operation.Operation == "Process.Start");
 
@@ -359,7 +360,7 @@ public class DataFlowOperationClassifierTests
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
-        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var operations = Classify(method);
         var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
         var shellStart = operations.Single(operation =>
             operation.Operation.Contains("PInvoke.ShellExecuteEx", StringComparison.OrdinalIgnoreCase));
@@ -415,7 +416,7 @@ public class DataFlowOperationClassifierTests
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
-        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var operations = Classify(method);
         var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
         var shellStart = operations.Single(operation =>
             operation.Operation.Contains("PInvoke.ShellExecuteEx", StringComparison.OrdinalIgnoreCase));
@@ -446,7 +447,7 @@ public class DataFlowOperationClassifierTests
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
-        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var operations = Classify(method);
         var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
         var processStart = operations.Single(operation => operation.Operation == "Process.Start");
 
@@ -491,7 +492,7 @@ public class DataFlowOperationClassifierTests
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
-        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var operations = Classify(method);
         var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
         var processStart = operations.Single(operation => operation.Operation == "Process.Start");
 
@@ -525,7 +526,7 @@ public class DataFlowOperationClassifierTests
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
-        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var operations = Classify(method);
         var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
         var processStart = operations.Single(operation => operation.Operation == "Process.Start");
 
@@ -561,7 +562,7 @@ public class DataFlowOperationClassifierTests
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
-        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var operations = Classify(method);
         var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
         var processStart = operations.Single(operation => operation.Operation == "Process.Start");
 
@@ -602,7 +603,7 @@ public class DataFlowOperationClassifierTests
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
-        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var operations = Classify(method);
         var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
         var processStart = operations.Single(operation => operation.Operation == "Process.Start");
 
@@ -639,7 +640,7 @@ public class DataFlowOperationClassifierTests
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
-        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var operations = Classify(method);
         var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
         var processStart = operations.Single(operation => operation.Operation == "Process.Start");
 
@@ -680,7 +681,7 @@ public class DataFlowOperationClassifierTests
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
-        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var operations = Classify(method);
         var fileWrite = operations.Single(operation => operation.Operation.Contains("File.WriteAllBytes"));
         var processStart = operations.Single(operation => operation.Operation == "Process.Start");
 
@@ -714,7 +715,7 @@ public class DataFlowOperationClassifierTests
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
-        var operations = new DataFlowOperationClassifier().IdentifyInterestingOperations(method, method.Body.Instructions);
+        var operations = Classify(method);
 
         operations.Should().NotContain(operation => operation.Operation.Contains("FileStream"));
     }
@@ -783,5 +784,11 @@ public class DataFlowOperationClassifierTests
         }
 
         return method;
+    }
+
+    private static List<DataFlowInterestingOperation> Classify(MethodDefinition method)
+    {
+        var classifier = new DataFlowOperationClassifier(method.Body.Instructions);
+        return classifier.IdentifyInterestingOperations(method, method.Body.Instructions);
     }
 }

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowReachingDefinitionAnalysisTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowReachingDefinitionAnalysisTests.cs
@@ -1,0 +1,182 @@
+using FluentAssertions;
+using MLVScan.Models.DataFlow;
+using MLVScan.Services.DataFlow;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xunit;
+
+namespace MLVScan.Core.Tests.Unit.Services;
+
+public class DataFlowReachingDefinitionAnalysisTests
+{
+    [Fact]
+    public void RepeatedLocalStoreQuery_ReusesControlFlowGraphAndCachedResult()
+    {
+        using var module = ModuleDefinition.CreateModule("ReachingDefinitionCacheTest", ModuleKind.Dll);
+        var method = CreateMethod(module, "Cache");
+        var local = new VariableDefinition(module.TypeSystem.Int32);
+        method.Body.Variables.Add(local);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, local);
+        for (var index = 0; index < 32; index++)
+        {
+            il.Emit(OpCodes.Nop);
+        }
+
+        il.Emit(OpCodes.Ldloc, local);
+        var consumerIndex = method.Body.Instructions.Count - 1;
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        var analysis = new DataFlowReachingDefinitionAnalysis(method.Body.Instructions);
+
+        analysis.TryGetReachingLocalStoreIndexes(consumerIndex, local.Index, out var first).Should().BeTrue();
+        var workAfterFirstQuery = analysis.WorkUnitsConsumed;
+        analysis.TryGetReachingLocalStoreIndexes(consumerIndex, local.Index, out var second).Should().BeTrue();
+
+        first.Should().ContainSingle().Which.Should().Be(1);
+        second.Should().BeEquivalentTo(first);
+        analysis.ControlFlowGraphBuildCount.Should().Be(1);
+        analysis.WorkUnitsConsumed.Should().Be(workAfterFirstQuery,
+            "an identical reaching-definition query should be served from the per-method cache");
+    }
+
+    [Fact]
+    public void DistinctAdversarialQueries_CannotExceedLinearPerMethodWorkBudget()
+    {
+        using var module = ModuleDefinition.CreateModule("ReachingDefinitionBudgetTest", ModuleKind.Dll);
+        var method = CreateMethod(module, "Stress");
+        var local = new VariableDefinition(module.TypeSystem.Int32);
+        method.Body.Variables.Add(local);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, local);
+
+        var consumerIndexes = new List<int>();
+        for (var index = 0; index < 1_000; index++)
+        {
+            il.Emit(OpCodes.Ldloc, local);
+            consumerIndexes.Add(method.Body.Instructions.Count - 1);
+            il.Emit(OpCodes.Pop);
+        }
+
+        il.Emit(OpCodes.Ret);
+        var analysis = new DataFlowReachingDefinitionAnalysis(method.Body.Instructions);
+
+        var completedAllQueries = true;
+        foreach (var consumerIndex in consumerIndexes)
+        {
+            if (!analysis.TryGetReachingLocalStoreIndexes(consumerIndex, local.Index, out _))
+            {
+                completedAllQueries = false;
+                break;
+            }
+        }
+
+        completedAllQueries.Should().BeFalse();
+        analysis.IsComplete.Should().BeFalse();
+        analysis.ControlFlowGraphBuildCount.Should().Be(1);
+        analysis.WorkBudget.Should().Be(Math.Max(16_384, method.Body.Instructions.Count * 256),
+            "the cumulative budget must remain linear in the method instruction count");
+        analysis.WorkUnitsConsumed.Should().Be(analysis.WorkBudget);
+
+        analysis.TryGetReachingLocalStoreIndexes(
+                consumerIndexes[0],
+                local.Index,
+                out var definitionsAfterExhaustion)
+            .Should().BeFalse("no cached answer should be served after the method budget is exhausted");
+        definitionsAfterExhaustion.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TryGetReachingInstructionIndexes_WithNullPredicate_ThrowsArgumentNullException()
+    {
+        using var module = ModuleDefinition.CreateModule("ReachingDefinitionNullPredicateTest", ModuleKind.Dll);
+        var method = CreateMethod(module, "NullPredicate");
+        method.Body.GetILProcessor().Emit(OpCodes.Ret);
+        var analysis = new DataFlowReachingDefinitionAnalysis(method.Body.Instructions);
+
+        var act = () => analysis.TryGetReachingInstructionIndexes(0, null!, out _);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("isDefinition");
+    }
+
+    [Fact]
+    public void SeparateMethodAnalysisHelpers_DoNotShareBudgetState()
+    {
+        using var module = ModuleDefinition.CreateModule("ReachingDefinitionIsolationTest", ModuleKind.Dll);
+        var method = CreateMethod(module, "Isolation");
+        var local = new VariableDefinition(module.TypeSystem.Int32);
+        method.Body.Variables.Add(local);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, local);
+
+        var consumerIndexes = new List<int>();
+        for (var index = 0; index < 1_000; index++)
+        {
+            il.Emit(OpCodes.Ldloc, local);
+            consumerIndexes.Add(method.Body.Instructions.Count - 1);
+            il.Emit(OpCodes.Pop);
+        }
+
+        il.Emit(OpCodes.Ret);
+        var firstHelper = new DataFlowInstructionHelper(method.Body.Instructions);
+        var firstAnalysis = firstHelper.GetReachingDefinitionAnalysis(method.Body.Instructions);
+
+        foreach (var consumerIndex in consumerIndexes)
+        {
+            if (firstHelper.GetReachingLocalStoreIndexes(
+                    method.Body.Instructions,
+                    consumerIndex,
+                    local.Index).Count == 0)
+            {
+                break;
+            }
+        }
+
+        firstAnalysis.IsComplete.Should().BeFalse();
+
+        var secondHelper = new DataFlowInstructionHelper(method.Body.Instructions);
+        var secondAnalysis = secondHelper.GetReachingDefinitionAnalysis(method.Body.Instructions);
+        var definitions = secondHelper.GetReachingLocalStoreIndexes(
+            method.Body.Instructions,
+            consumerIndexes[0],
+            local.Index);
+
+        secondAnalysis.IsComplete.Should().BeTrue();
+        secondAnalysis.WorkUnitsConsumed.Should().BeGreaterThan(0);
+        definitions.Should().ContainSingle().Which.Should().Be(1);
+    }
+
+    [Fact]
+    public void StoreMethodAnalysis_WhenCompleteResultReplacesIncomplete_ClearsIncompleteMarker()
+    {
+        var state = new DataFlowAnalysisState();
+        const string methodKey = "Test.Type::Method()";
+
+        state.StoreMethodAnalysis(new DataFlowMethodAnalysisResult
+        {
+            MethodKey = methodKey,
+            AnalysisComplete = false
+        });
+        state.IncompleteMethodKeys.Should().Contain(methodKey);
+
+        state.StoreMethodAnalysis(new DataFlowMethodAnalysisResult
+        {
+            MethodKey = methodKey,
+            AnalysisComplete = true
+        });
+
+        state.IncompleteMethodKeys.Should().NotContain(methodKey);
+    }
+
+    private static MethodDefinition CreateMethod(ModuleDefinition module, string name)
+    {
+        return new MethodDefinition(
+            name,
+            MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Void);
+    }
+}

--- a/Models/DataFlow/DataFlowMethodAnalysisResult.cs
+++ b/Models/DataFlow/DataFlowMethodAnalysisResult.cs
@@ -28,5 +28,10 @@ namespace MLVScan.Models.DataFlow
         /// Data-flow chains discovered while analyzing the method.
         /// </summary>
         public List<DataFlowChain> Chains { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets whether bounded per-method data-flow analysis completed.
+        /// </summary>
+        public bool AnalysisComplete { get; set; } = true;
     }
 }

--- a/Services/DataFlow/DataFlowAnalysisState.cs
+++ b/Services/DataFlow/DataFlowAnalysisState.cs
@@ -16,12 +16,15 @@ namespace MLVScan.Services.DataFlow
         public Dictionary<string, Collection<Instruction>> MethodInstructions { get; } =
             new(StringComparer.Ordinal);
 
+        public HashSet<string> IncompleteMethodKeys { get; } = new(StringComparer.Ordinal);
+
         public void Clear()
         {
             MethodDataFlows.Clear();
             MethodFlowInfos.Clear();
             CrossMethodChains.Clear();
             MethodInstructions.Clear();
+            IncompleteMethodKeys.Clear();
         }
 
         public void StoreMethodAnalysis(DataFlowMethodAnalysisResult analysis)
@@ -29,6 +32,14 @@ namespace MLVScan.Services.DataFlow
             MethodInstructions[analysis.MethodKey] = analysis.Instructions;
             MethodFlowInfos[analysis.MethodKey] = analysis.FlowInfo;
             MethodDataFlows[analysis.MethodKey] = analysis.Chains;
+            if (!analysis.AnalysisComplete)
+            {
+                IncompleteMethodKeys.Add(analysis.MethodKey);
+            }
+            else
+            {
+                IncompleteMethodKeys.Remove(analysis.MethodKey);
+            }
         }
 
         public Collection<Instruction> GetInstructionsForMethod(string methodKey)

--- a/Services/DataFlow/DataFlowInstructionHelper.cs
+++ b/Services/DataFlow/DataFlowInstructionHelper.cs
@@ -5,9 +5,18 @@ using Mono.Cecil.Cil;
 
 namespace MLVScan.Services.DataFlow
 {
-    internal static class DataFlowInstructionHelper
+    internal sealed class DataFlowInstructionHelper
     {
-        public static int? TryGetTargetLocalVariable(Collection<Instruction> instructions, int callIndex)
+        private readonly Collection<Instruction> _instructions;
+        private readonly DataFlowReachingDefinitionAnalysis _reachingDefinitionAnalysis;
+
+        public DataFlowInstructionHelper(Collection<Instruction> instructions)
+        {
+            _instructions = instructions ?? throw new ArgumentNullException(nameof(instructions));
+            _reachingDefinitionAnalysis = new DataFlowReachingDefinitionAnalysis(instructions);
+        }
+
+        public int? TryGetTargetLocalVariable(Collection<Instruction> instructions, int callIndex)
         {
             if (callIndex + 1 >= instructions.Count)
             {
@@ -17,7 +26,7 @@ namespace MLVScan.Services.DataFlow
             return instructions[callIndex + 1].TryGetStoredLocalIndex(out var localIndex) ? localIndex : null;
         }
 
-        public static Dictionary<int, int> TryGetParameterMapping(
+        public Dictionary<int, int> TryGetParameterMapping(
             Collection<Instruction> instructions,
             int callIndex,
             MethodReference calledMethod)
@@ -35,7 +44,7 @@ namespace MLVScan.Services.DataFlow
             return mapping;
         }
 
-        public static bool IsReturnValueUsed(Collection<Instruction> instructions, int callIndex)
+        public bool IsReturnValueUsed(Collection<Instruction> instructions, int callIndex)
         {
             if (callIndex + 1 >= instructions.Count)
             {
@@ -55,7 +64,7 @@ namespace MLVScan.Services.DataFlow
                    nextInstruction.OpCode == OpCodes.Stsfld;
         }
 
-        public static bool TryGetCallArgumentLocalVariable(
+        public bool TryGetCallArgumentLocalVariable(
             Collection<Instruction> instructions,
             int callIndex,
             MethodReference calledMethod,
@@ -66,7 +75,7 @@ namespace MLVScan.Services.DataFlow
                 instructions, callIndex, calledMethod, argumentIndex, out localIndex, out _);
         }
 
-        public static bool TryGetCallArgumentLocalVariable(
+        public bool TryGetCallArgumentLocalVariable(
             Collection<Instruction> instructions,
             int callIndex,
             MethodReference calledMethod,
@@ -81,7 +90,7 @@ namespace MLVScan.Services.DataFlow
                    TryGetLocalOrAddressedLocalIndex(instructions[producerIndex], out localIndex);
         }
 
-        public static bool TryGetMethodParameterIndex(
+        public bool TryGetMethodParameterIndex(
             MethodDefinition method,
             Instruction instruction,
             out int parameterIndex)
@@ -98,7 +107,7 @@ namespace MLVScan.Services.DataFlow
             return parameterIndex >= 0 && parameterIndex < method.Parameters.Count;
         }
 
-        public static bool TryGetCallReceiverLocalVariable(
+        public bool TryGetCallReceiverLocalVariable(
             Collection<Instruction> instructions,
             int callIndex,
             MethodReference calledMethod,
@@ -109,7 +118,7 @@ namespace MLVScan.Services.DataFlow
                    TryGetLocalOrAddressedLocalIndex(instructions[producerIndex], out localIndex);
         }
 
-        public static bool TryGetFieldStoreReceiverLocalVariable(
+        public bool TryGetFieldStoreReceiverLocalVariable(
             Collection<Instruction> instructions,
             int fieldStoreIndex,
             out int localIndex)
@@ -125,70 +134,46 @@ namespace MLVScan.Services.DataFlow
             return TryGetLocalOrAddressedLocalIndex(instructions[receiverProducerIndex], out localIndex);
         }
 
-        public static IReadOnlyCollection<int> GetReachingLocalStoreIndexes(
+        public IReadOnlyCollection<int> GetReachingLocalStoreIndexes(
             Collection<Instruction> instructions,
             int localLoadIndex,
             int localIndex)
         {
-            return GetReachingInstructionIndexes(
-                instructions,
+            return GetReachingDefinitionAnalysis(instructions).TryGetReachingLocalStoreIndexes(
                 localLoadIndex,
-                index => instructions[index].TryGetStoredLocalIndex(out var storedLocalIndex) &&
-                         storedLocalIndex == localIndex);
+                localIndex,
+                out var definitionIndexes)
+                    ? definitionIndexes
+                    : Array.Empty<int>();
         }
 
-        public static IReadOnlyCollection<int> GetReachingInstructionIndexes(
+        public IReadOnlyCollection<int> GetReachingInstructionIndexes(
             Collection<Instruction> instructions,
             int consumerIndex,
             Func<int, bool> isDefinition)
         {
-            if (consumerIndex < 0 || consumerIndex >= instructions.Count)
-            {
-                return Array.Empty<int>();
-            }
-
-            var instructionIndexes = instructions
-                .Select((instruction, index) => (instruction, index))
-                .ToDictionary(static entry => entry.instruction, static entry => entry.index);
-            var predecessors = Enumerable.Range(0, instructions.Count)
-                .Select(_ => new List<int>())
-                .ToArray();
-
-            for (var index = 0; index < instructions.Count; index++)
-            {
-                foreach (var successor in GetSuccessorIndexes(instructions, instructionIndexes, index))
-                {
-                    predecessors[successor].Add(index);
-                }
-            }
-
-            var definitions = new HashSet<int>();
-            var pending = new Stack<int>(predecessors[consumerIndex]);
-            var visited = new HashSet<int>();
-            while (pending.Count > 0)
-            {
-                var index = pending.Pop();
-                if (!visited.Add(index))
-                {
-                    continue;
-                }
-
-                if (isDefinition(index))
-                {
-                    definitions.Add(index);
-                    continue;
-                }
-
-                foreach (var predecessor in predecessors[index])
-                {
-                    pending.Push(predecessor);
-                }
-            }
-
-            return definitions;
+            return GetReachingDefinitionAnalysis(instructions).TryGetReachingInstructionIndexes(
+                consumerIndex,
+                isDefinition,
+                out var definitionIndexes)
+                    ? definitionIndexes
+                    : Array.Empty<int>();
         }
 
-        public static bool TryGetCallReceiverProducerIndex(
+        public DataFlowReachingDefinitionAnalysis GetReachingDefinitionAnalysis(
+            Collection<Instruction> instructions)
+        {
+            if (!ReferenceEquals(instructions, _instructions))
+            {
+                throw new ArgumentException(
+                    "The instruction collection must match this method analysis.",
+                    nameof(instructions));
+            }
+
+            return _reachingDefinitionAnalysis;
+        }
+
+        public bool TryGetCallReceiverProducerIndex(
             Collection<Instruction> instructions,
             int callIndex,
             MethodReference calledMethod,
@@ -215,7 +200,7 @@ namespace MLVScan.Services.DataFlow
             return TryFindTopValueProducer(instructions, cursor, out producerIndex);
         }
 
-        public static bool TryGetConsumedValueProducerIndex(
+        public bool TryGetConsumedValueProducerIndex(
             Collection<Instruction> instructions,
             int consumerIndex,
             out int producerIndex)
@@ -225,7 +210,7 @@ namespace MLVScan.Services.DataFlow
                    TryFindTopValueProducer(instructions, consumerIndex - 1, out producerIndex);
         }
 
-        public static bool TryGetCallArgumentProducerIndex(
+        public bool TryGetCallArgumentProducerIndex(
             Collection<Instruction> instructions,
             int callIndex,
             MethodReference calledMethod,
@@ -263,79 +248,25 @@ namespace MLVScan.Services.DataFlow
             return false;
         }
 
-        private static bool TryFindTopValueProducer(
+        private bool TryFindTopValueProducer(
             Collection<Instruction> instructions,
             int beforeIndex,
             out int producerIndex)
         {
-            producerIndex = -1;
-            var needed = 1;
-
-            for (var index = beforeIndex; index >= 0; index--)
-            {
-                var instruction = instructions[index];
-                needed -= instruction.GetPushCount();
-                if (needed <= 0)
-                {
-                    producerIndex = index;
-                    return true;
-                }
-
-                needed += instruction.GetPopCount();
-            }
-
-            return false;
+            return GetReachingDefinitionAnalysis(instructions)
+                .TryFindTopValueProducer(beforeIndex, out producerIndex);
         }
 
-        private static bool TryFindValueExpressionStart(
+        private bool TryFindValueExpressionStart(
             Collection<Instruction> instructions,
             int producerIndex,
             out int expressionStart)
         {
-            expressionStart = -1;
-            var needed = 1;
-            for (var index = producerIndex; index >= 0; index--)
-            {
-                needed -= instructions[index].GetPushCount();
-                needed += instructions[index].GetPopCount();
-                if (needed <= 0)
-                {
-                    expressionStart = index;
-                    return true;
-                }
-            }
-
-            return false;
+            return GetReachingDefinitionAnalysis(instructions)
+                .TryFindValueExpressionStart(producerIndex, out expressionStart);
         }
 
-        private static IEnumerable<int> GetSuccessorIndexes(
-            Collection<Instruction> instructions,
-            IReadOnlyDictionary<Instruction, int> instructionIndexes,
-            int index)
-        {
-            var instruction = instructions[index];
-            if (instruction.Operand is Instruction target)
-            {
-                yield return instructionIndexes[target];
-            }
-            else if (instruction.Operand is Instruction[] targets)
-            {
-                foreach (var switchTarget in targets)
-                {
-                    yield return instructionIndexes[switchTarget];
-                }
-            }
-
-            if (index + 1 >= instructions.Count ||
-                instruction.OpCode.FlowControl is FlowControl.Branch or FlowControl.Return or FlowControl.Throw)
-            {
-                yield break;
-            }
-
-            yield return index + 1;
-        }
-
-        private static bool TryGetLocalOrAddressedLocalIndex(Instruction instruction, out int localIndex)
+        private bool TryGetLocalOrAddressedLocalIndex(Instruction instruction, out int localIndex)
         {
             if (instruction.TryGetLocalIndex(out localIndex))
             {

--- a/Services/DataFlow/DataFlowMethodAnalyzer.cs
+++ b/Services/DataFlow/DataFlowMethodAnalyzer.cs
@@ -9,16 +9,13 @@ namespace MLVScan.Services.DataFlow
 {
     internal sealed class DataFlowMethodAnalyzer
     {
-        private readonly DataFlowOperationClassifier _operationClassifier;
         private readonly DataFlowPatternEvaluator _patternEvaluator;
         private readonly DataFlowNodeFactory _nodeFactory;
 
         public DataFlowMethodAnalyzer(
-            DataFlowOperationClassifier operationClassifier,
             DataFlowPatternEvaluator patternEvaluator,
             DataFlowNodeFactory nodeFactory)
         {
-            _operationClassifier = operationClassifier ?? throw new ArgumentNullException(nameof(operationClassifier));
             _patternEvaluator = patternEvaluator ?? throw new ArgumentNullException(nameof(patternEvaluator));
             _nodeFactory = nodeFactory ?? throw new ArgumentNullException(nameof(nodeFactory));
         }
@@ -26,8 +23,11 @@ namespace MLVScan.Services.DataFlow
         public DataFlowMethodAnalysisResult AnalyzeMethod(MethodDefinition method)
         {
             var instructions = method.Body.Instructions;
-            var operations = _operationClassifier.IdentifyInterestingOperations(method, instructions);
-            var flowInfo = BuildMethodFlowInfo(method, instructions, operations);
+            var instructionHelper = new DataFlowInstructionHelper(instructions);
+            var reachingDefinitionAnalysis = instructionHelper.GetReachingDefinitionAnalysis(instructions);
+            var operationClassifier = new DataFlowOperationClassifier(instructionHelper);
+            var operations = operationClassifier.IdentifyInterestingOperations(method, instructions);
+            var flowInfo = BuildMethodFlowInfo(method, instructions, operations, instructionHelper);
             var chains = operations.Count < 2 ? new List<DataFlowChain>() : BuildDataFlowChains(method, instructions, operations);
 
             return new DataFlowMethodAnalysisResult
@@ -35,14 +35,16 @@ namespace MLVScan.Services.DataFlow
                 MethodKey = method.GetMethodKey(),
                 Instructions = instructions,
                 FlowInfo = flowInfo,
-                Chains = chains
+                Chains = chains,
+                AnalysisComplete = reachingDefinitionAnalysis.IsComplete
             };
         }
 
         private DataFlowMethodFlowInfo BuildMethodFlowInfo(
             MethodDefinition method,
             Collection<Instruction> instructions,
-            List<DataFlowInterestingOperation> operations)
+            List<DataFlowInterestingOperation> operations,
+            DataFlowInstructionHelper instructionHelper)
         {
             var returnTypeName = method.ReturnType.FullName == "System.Void" ? null : method.ReturnType.FullName;
             var returnsData = returnTypeName != null && operations.Any(static operation =>
@@ -72,27 +74,27 @@ namespace MLVScan.Services.DataFlow
                     continue;
                 }
 
-                var parameterMapping = DataFlowInstructionHelper.TryGetParameterMapping(
+                var parameterMapping = instructionHelper.TryGetParameterMapping(
                     instructions, index, calledMethod);
                 var parameterReachingStoreIndexes = new Dictionary<int, HashSet<int>>();
                 var forwardedParameterMapping = new Dictionary<int, int>();
                 foreach (var (parameterIndex, localIndex) in parameterMapping)
                 {
-                    if (!DataFlowInstructionHelper.TryGetCallArgumentProducerIndex(
+                    if (!instructionHelper.TryGetCallArgumentProducerIndex(
                             instructions, index, calledMethod, parameterIndex, out var producerIndex))
                     {
                         continue;
                     }
 
-                    parameterReachingStoreIndexes[parameterIndex] = DataFlowInstructionHelper
+                    parameterReachingStoreIndexes[parameterIndex] = instructionHelper
                         .GetReachingLocalStoreIndexes(instructions, producerIndex, localIndex)
                         .ToHashSet();
                 }
                 for (var parameterIndex = 0; parameterIndex < calledMethod.Parameters.Count; parameterIndex++)
                 {
-                    if (DataFlowInstructionHelper.TryGetCallArgumentProducerIndex(
+                    if (instructionHelper.TryGetCallArgumentProducerIndex(
                             instructions, index, calledMethod, parameterIndex, out var producerIndex) &&
-                        DataFlowInstructionHelper.TryGetMethodParameterIndex(
+                        instructionHelper.TryGetMethodParameterIndex(
                             method, instructions[producerIndex], out var callerParameterIndex))
                     {
                         forwardedParameterMapping[parameterIndex] = callerParameterIndex;
@@ -108,7 +110,7 @@ namespace MLVScan.Services.DataFlow
                     ParameterMapping = parameterMapping,
                     ParameterReachingStoreIndexes = parameterReachingStoreIndexes,
                     ForwardedParameterMapping = forwardedParameterMapping,
-                    ReturnValueUsed = DataFlowInstructionHelper.IsReturnValueUsed(instructions, index),
+                    ReturnValueUsed = instructionHelper.IsReturnValueUsed(instructions, index),
                     CalledMethodReturnsData = calledMethod.ReturnType.FullName != "System.Void"
                 });
             }

--- a/Services/DataFlow/DataFlowOperationClassifier.cs
+++ b/Services/DataFlow/DataFlowOperationClassifier.cs
@@ -10,6 +10,18 @@ namespace MLVScan.Services.DataFlow
 {
     internal sealed class DataFlowOperationClassifier
     {
+        private readonly DataFlowInstructionHelper _instructionHelper;
+
+        public DataFlowOperationClassifier(Collection<Instruction> instructions)
+            : this(new DataFlowInstructionHelper(instructions))
+        {
+        }
+
+        public DataFlowOperationClassifier(DataFlowInstructionHelper instructionHelper)
+        {
+            _instructionHelper = instructionHelper ?? throw new ArgumentNullException(nameof(instructionHelper));
+        }
+
         public List<DataFlowInterestingOperation> IdentifyInterestingOperations(
             MethodDefinition method,
             Collection<Instruction> instructions)
@@ -56,7 +68,7 @@ namespace MLVScan.Services.DataFlow
                         NodeType = operationInfo.Value.NodeType,
                         Operation = operationInfo.Value.Operation,
                         DataDescription = operationInfo.Value.DataDescription,
-                        LocalVariableIndex = DataFlowInstructionHelper.TryGetTargetLocalVariable(instructions, index),
+                        LocalVariableIndex = _instructionHelper.TryGetTargetLocalVariable(instructions, index),
                         PayloadPathIdentities = payloadPathIdentities
                     });
                 }
@@ -80,7 +92,7 @@ namespace MLVScan.Services.DataFlow
             return operations;
         }
 
-        private static HashSet<string> TryGetPayloadPathIdentities(
+        private HashSet<string> TryGetPayloadPathIdentities(
             MethodDefinition method,
             Collection<Instruction> instructions,
             int callIndex,
@@ -112,7 +124,7 @@ namespace MLVScan.Services.DataFlow
                    operation.Contains("FileStream", StringComparison.OrdinalIgnoreCase);
         }
 
-        private static bool IsWritableFileStreamConstructor(
+        private bool IsWritableFileStreamConstructor(
             MethodDefinition method,
             Collection<Instruction> instructions,
             int constructorIndex,
@@ -139,7 +151,7 @@ namespace MLVScan.Services.DataFlow
                    accessValue != 1;
         }
 
-        private static HashSet<string> TryGetProcessStartPathIdentities(
+        private HashSet<string> TryGetProcessStartPathIdentities(
             MethodDefinition method,
             Collection<Instruction> instructions,
             int processStartIndex,
@@ -153,12 +165,12 @@ namespace MLVScan.Services.DataFlow
                 processStartMethod.Parameters.Count == 1 &&
                 processStartMethod.Parameters[0].ParameterType.FullName == "System.Diagnostics.ProcessStartInfo")
             {
-                if (DataFlowInstructionHelper.TryGetCallArgumentLocalVariable(
+                if (_instructionHelper.TryGetCallArgumentLocalVariable(
                         instructions, processStartIndex, processStartMethod, 0, out var resolvedStartInfoLocal))
                 {
                     startInfoLocal = resolvedStartInfoLocal;
                 }
-                else if (DataFlowInstructionHelper.TryGetCallArgumentProducerIndex(
+                else if (_instructionHelper.TryGetCallArgumentProducerIndex(
                              instructions, processStartIndex, processStartMethod, 0, out var producerIndex))
                 {
                     return TryGetStartInfoProducerIdentities(
@@ -171,7 +183,7 @@ namespace MLVScan.Services.DataFlow
             }
             else if (processStartMethod.HasThis)
             {
-                if (!DataFlowInstructionHelper.TryGetCallReceiverProducerIndex(
+                if (!_instructionHelper.TryGetCallReceiverProducerIndex(
                         instructions, processStartIndex, processStartMethod, out var receiverLoadIndex) ||
                     !instructions[receiverLoadIndex].TryGetLocalIndex(out var resolvedProcessLocal))
                 {
@@ -189,19 +201,19 @@ namespace MLVScan.Services.DataFlow
             IReadOnlyCollection<int> startInfoDefinitionIndexes = Array.Empty<int>();
             IReadOnlyCollection<int> processDefinitionIndexes = Array.Empty<int>();
             if (startInfoLocal.HasValue &&
-                DataFlowInstructionHelper.TryGetCallArgumentProducerIndex(
+                _instructionHelper.TryGetCallArgumentProducerIndex(
                     instructions, processStartIndex, processStartMethod, 0, out var startInfoLoadIndex))
             {
-                startInfoDefinitionIndexes = DataFlowInstructionHelper.GetReachingLocalStoreIndexes(
+                startInfoDefinitionIndexes = _instructionHelper.GetReachingLocalStoreIndexes(
                     instructions, startInfoLoadIndex, startInfoLocal.Value);
             }
             else if (processLocal.HasValue && processReceiverLoadIndex.HasValue)
             {
-                processDefinitionIndexes = DataFlowInstructionHelper.GetReachingLocalStoreIndexes(
+                processDefinitionIndexes = _instructionHelper.GetReachingLocalStoreIndexes(
                     instructions, processReceiverLoadIndex.Value, processLocal.Value);
             }
 
-            var setterIndexes = DataFlowInstructionHelper.GetReachingInstructionIndexes(
+            var setterIndexes = _instructionHelper.GetReachingInstructionIndexes(
                 instructions,
                 processStartIndex,
                 index => TryGetStartInfoFileNameSetter(instructions[index], out var setter) &&
@@ -229,7 +241,7 @@ namespace MLVScan.Services.DataFlow
 
             if (processLocal.HasValue)
             {
-                var startInfoAssignmentIndexes = DataFlowInstructionHelper.GetReachingInstructionIndexes(
+                var startInfoAssignmentIndexes = _instructionHelper.GetReachingInstructionIndexes(
                     instructions,
                     processStartIndex,
                     index => TryGetProcessStartInfoSetter(instructions[index], out var setter) &&
@@ -250,13 +262,13 @@ namespace MLVScan.Services.DataFlow
             return identities;
         }
 
-        private static HashSet<string> TryGetAssignedStartInfoIdentities(
+        private HashSet<string> TryGetAssignedStartInfoIdentities(
             MethodDefinition method,
             Collection<Instruction> instructions,
             int setterIndex,
             MethodReference setter)
         {
-            if (!DataFlowInstructionHelper.TryGetCallArgumentProducerIndex(
+            if (!_instructionHelper.TryGetCallArgumentProducerIndex(
                     instructions, setterIndex, setter, 0, out var producerIndex))
             {
                 return EmptyIdentities();
@@ -274,7 +286,7 @@ namespace MLVScan.Services.DataFlow
                 return EmptyIdentities();
             }
 
-            var definitions = DataFlowInstructionHelper.GetReachingLocalStoreIndexes(
+            var definitions = _instructionHelper.GetReachingLocalStoreIndexes(
                 instructions, producerIndex, startInfoLocal);
             var identities = EmptyIdentities();
             foreach (var definitionIndex in definitions)
@@ -283,7 +295,7 @@ namespace MLVScan.Services.DataFlow
                     method, instructions, definitionIndex));
             }
 
-            var fileNameSetterIndexes = DataFlowInstructionHelper.GetReachingInstructionIndexes(
+            var fileNameSetterIndexes = _instructionHelper.GetReachingInstructionIndexes(
                 instructions,
                 setterIndex,
                 index => TryGetStartInfoFileNameSetter(instructions[index], out var fileNameSetter) &&
@@ -305,7 +317,7 @@ namespace MLVScan.Services.DataFlow
             return identities;
         }
 
-        private static HashSet<string> TryGetStartInfoProducerIdentities(
+        private HashSet<string> TryGetStartInfoProducerIdentities(
             MethodDefinition method,
             Collection<Instruction> instructions,
             int producerIndex,
@@ -315,7 +327,7 @@ namespace MLVScan.Services.DataFlow
             var constructorIndex = producerIndex;
             if (instructions[producerIndex].OpCode == OpCodes.Dup)
             {
-                if (!DataFlowInstructionHelper.TryGetConsumedValueProducerIndex(
+                if (!_instructionHelper.TryGetConsumedValueProducerIndex(
                         instructions, producerIndex, out constructorIndex))
                 {
                     return EmptyIdentities();
@@ -340,7 +352,7 @@ namespace MLVScan.Services.DataFlow
             for (var index = initializerStartIndex + 1; index < consumerIndex; index++)
             {
                 if (!TryGetStartInfoFileNameSetter(instructions[index], out var fileNameSetter) ||
-                    !DataFlowInstructionHelper.TryGetCallReceiverProducerIndex(
+                    !_instructionHelper.TryGetCallReceiverProducerIndex(
                         instructions, index, fileNameSetter, out var receiverProducerIndex) ||
                     receiverProducerIndex != initializerStartIndex)
                 {
@@ -354,12 +366,12 @@ namespace MLVScan.Services.DataFlow
             return identities;
         }
 
-        private static HashSet<string> TryGetStoredStartInfoConstructorIdentities(
+        private HashSet<string> TryGetStoredStartInfoConstructorIdentities(
             MethodDefinition method,
             Collection<Instruction> instructions,
             int storeIndex)
         {
-            if (!DataFlowInstructionHelper.TryGetConsumedValueProducerIndex(
+            if (!_instructionHelper.TryGetConsumedValueProducerIndex(
                     instructions, storeIndex, out var producerIndex))
             {
                 return EmptyIdentities();
@@ -368,7 +380,7 @@ namespace MLVScan.Services.DataFlow
             return TryGetStartInfoProducerIdentities(method, instructions, producerIndex, storeIndex);
         }
 
-        private static bool TryGetStartInfoFileNameSetter(
+        private bool TryGetStartInfoFileNameSetter(
             Instruction instruction,
             out MethodReference setter)
         {
@@ -385,7 +397,7 @@ namespace MLVScan.Services.DataFlow
             return true;
         }
 
-        private static bool TryGetProcessStartInfoSetter(
+        private bool TryGetProcessStartInfoSetter(
             Instruction instruction,
             out MethodReference setter)
         {
@@ -402,7 +414,7 @@ namespace MLVScan.Services.DataFlow
             return true;
         }
 
-        private static bool StartInfoSetterBelongsToStartedProcess(
+        private bool StartInfoSetterBelongsToStartedProcess(
             Collection<Instruction> instructions,
             int setterIndex,
             MethodReference setter,
@@ -413,7 +425,7 @@ namespace MLVScan.Services.DataFlow
         {
             if (startInfoLocal.HasValue)
             {
-                if (!DataFlowInstructionHelper.TryGetCallReceiverProducerIndex(
+                if (!_instructionHelper.TryGetCallReceiverProducerIndex(
                         instructions, setterIndex, setter, out var receiverProducerIndex) ||
                     !instructions[receiverProducerIndex].TryGetLocalIndex(out var setterStartInfoLocal) ||
                     setterStartInfoLocal != startInfoLocal.Value)
@@ -426,13 +438,13 @@ namespace MLVScan.Services.DataFlow
                     return true;
                 }
 
-                var setterStartInfoDefinitions = DataFlowInstructionHelper.GetReachingLocalStoreIndexes(
+                var setterStartInfoDefinitions = _instructionHelper.GetReachingLocalStoreIndexes(
                     instructions, receiverProducerIndex, setterStartInfoLocal);
                 return setterStartInfoDefinitions.Intersect(startedStartInfoDefinitions).Any();
             }
 
             if (!processLocal.HasValue ||
-                !DataFlowInstructionHelper.TryGetCallReceiverProducerIndex(
+                !_instructionHelper.TryGetCallReceiverProducerIndex(
                     instructions, setterIndex, setter, out var setterReceiverProducerIndex))
             {
                 return false;
@@ -455,14 +467,14 @@ namespace MLVScan.Services.DataFlow
                 startedProcessDefinitions);
         }
 
-        private static bool ProcessReceiverMatchesStartedProcess(
+        private bool ProcessReceiverMatchesStartedProcess(
             Collection<Instruction> instructions,
             int callIndex,
             MethodReference calledMethod,
             int processLocal,
             IReadOnlyCollection<int> startedProcessDefinitions)
         {
-            if (!DataFlowInstructionHelper.TryGetCallReceiverProducerIndex(
+            if (!_instructionHelper.TryGetCallReceiverProducerIndex(
                     instructions, callIndex, calledMethod, out var receiverProducerIndex) ||
                 !instructions[receiverProducerIndex].TryGetLocalIndex(out var receiverProcessLocal) ||
                 receiverProcessLocal != processLocal)
@@ -475,12 +487,12 @@ namespace MLVScan.Services.DataFlow
                 return true;
             }
 
-            var receiverDefinitions = DataFlowInstructionHelper.GetReachingLocalStoreIndexes(
+            var receiverDefinitions = _instructionHelper.GetReachingLocalStoreIndexes(
                 instructions, receiverProducerIndex, receiverProcessLocal);
             return receiverDefinitions.Intersect(startedProcessDefinitions).Any();
         }
 
-        private static HashSet<string> TryGetNativeExecutionPathIdentities(
+        private HashSet<string> TryGetNativeExecutionPathIdentities(
             MethodDefinition method,
             Collection<Instruction> instructions,
             int callIndex,
@@ -510,7 +522,7 @@ namespace MLVScan.Services.DataFlow
                 : EmptyIdentities();
         }
 
-        private static HashSet<string> TryGetCreateProcessPathIdentities(
+        private HashSet<string> TryGetCreateProcessPathIdentities(
             MethodDefinition method,
             Collection<Instruction> instructions,
             int callIndex,
@@ -576,19 +588,19 @@ namespace MLVScan.Services.DataFlow
             return executable.Length > 0;
         }
 
-        private static HashSet<string> TryGetShellExecuteExFileIdentities(
+        private HashSet<string> TryGetShellExecuteExFileIdentities(
             MethodDefinition method,
             Collection<Instruction> instructions,
             int callIndex,
             MethodReference calledMethod)
         {
-            if (!DataFlowInstructionHelper.TryGetCallArgumentLocalVariable(
+            if (!_instructionHelper.TryGetCallArgumentLocalVariable(
                     instructions, callIndex, calledMethod, 0, out var shellExecuteInfoLocal))
             {
                 return EmptyIdentities();
             }
 
-            var fieldStoreIndexes = DataFlowInstructionHelper.GetReachingInstructionIndexes(
+            var fieldStoreIndexes = _instructionHelper.GetReachingInstructionIndexes(
                 instructions,
                 callIndex,
                 index => IsShellExecuteFileStoreForLocal(
@@ -596,7 +608,7 @@ namespace MLVScan.Services.DataFlow
             var identities = EmptyIdentities();
             foreach (var index in fieldStoreIndexes)
             {
-                if (!DataFlowInstructionHelper.TryGetConsumedValueProducerIndex(
+                if (!_instructionHelper.TryGetConsumedValueProducerIndex(
                         instructions, index, out var valueProducerIndex))
                 {
                     continue;
@@ -620,7 +632,7 @@ namespace MLVScan.Services.DataFlow
             return identities;
         }
 
-        private static bool IsShellExecuteFileStoreForLocal(
+        private bool IsShellExecuteFileStoreForLocal(
             Collection<Instruction> instructions,
             int index,
             int shellExecuteInfoLocal)
@@ -628,12 +640,12 @@ namespace MLVScan.Services.DataFlow
             return instructions[index].OpCode == OpCodes.Stfld &&
                    instructions[index].Operand is FieldReference field &&
                    field.Name.Equals("lpFile", StringComparison.OrdinalIgnoreCase) &&
-                   DataFlowInstructionHelper.TryGetFieldStoreReceiverLocalVariable(
+                   _instructionHelper.TryGetFieldStoreReceiverLocalVariable(
                        instructions, index, out var fieldReceiverLocal) &&
                    fieldReceiverLocal == shellExecuteInfoLocal;
         }
 
-        private static HashSet<string> TryGetCallArgumentIdentities(
+        private HashSet<string> TryGetCallArgumentIdentities(
             MethodDefinition method,
             Collection<Instruction> instructions,
             int callIndex,
@@ -648,14 +660,14 @@ namespace MLVScan.Services.DataFlow
             }
 
             var identities = EmptyIdentities();
-            if (DataFlowInstructionHelper.TryGetCallArgumentLocalVariable(
+            if (_instructionHelper.TryGetCallArgumentLocalVariable(
                     instructions, callIndex, calledMethod, argumentIndex, out var localIndex, out var producerIndex))
             {
                 identities.UnionWith(BuildLocalPathIdentities(method, instructions, producerIndex, localIndex));
             }
-            else if (DataFlowInstructionHelper.TryGetCallArgumentProducerIndex(
+            else if (_instructionHelper.TryGetCallArgumentProducerIndex(
                          instructions, callIndex, calledMethod, argumentIndex, out producerIndex) &&
-                     DataFlowInstructionHelper.TryGetMethodParameterIndex(
+                     _instructionHelper.TryGetMethodParameterIndex(
                          method, instructions[producerIndex], out var parameterIndex))
             {
                 identities.Add(BuildArgumentPathIdentity(method, parameterIndex));
@@ -681,7 +693,7 @@ namespace MLVScan.Services.DataFlow
                    !display.Contains('>');
         }
 
-        private static HashSet<string> BuildLocalPathIdentities(
+        private HashSet<string> BuildLocalPathIdentities(
             MethodDefinition method,
             Collection<Instruction> instructions,
             int localLoadIndex,
@@ -695,7 +707,7 @@ namespace MLVScan.Services.DataFlow
                 new HashSet<(int LoadIndex, int LocalIndex)>());
         }
 
-        private static HashSet<string> BuildLocalPathIdentities(
+        private HashSet<string> BuildLocalPathIdentities(
             MethodDefinition method,
             Collection<Instruction> instructions,
             int localLoadIndex,
@@ -707,7 +719,7 @@ namespace MLVScan.Services.DataFlow
                 return EmptyIdentities();
             }
 
-            var storeIndexes = DataFlowInstructionHelper.GetReachingLocalStoreIndexes(
+            var storeIndexes = _instructionHelper.GetReachingLocalStoreIndexes(
                 instructions, localLoadIndex, localIndex);
             if (storeIndexes.Count == 0)
             {
@@ -719,13 +731,13 @@ namespace MLVScan.Services.DataFlow
                 .ToHashSet(StringComparer.Ordinal);
             foreach (var storeIndex in storeIndexes)
             {
-                if (!DataFlowInstructionHelper.TryGetConsumedValueProducerIndex(
+                if (!_instructionHelper.TryGetConsumedValueProducerIndex(
                         instructions, storeIndex, out var producerIndex))
                 {
                     continue;
                 }
 
-                if (DataFlowInstructionHelper.TryGetMethodParameterIndex(
+                if (_instructionHelper.TryGetMethodParameterIndex(
                         method, instructions[producerIndex], out var parameterIndex))
                 {
                     identities.Add(BuildArgumentPathIdentity(method, parameterIndex));

--- a/Services/DataFlow/DataFlowReachingDefinitionAnalysis.cs
+++ b/Services/DataFlow/DataFlowReachingDefinitionAnalysis.cs
@@ -1,0 +1,267 @@
+using MLVScan.Services.Helpers;
+using Mono.Collections.Generic;
+using Mono.Cecil.Cil;
+
+namespace MLVScan.Services.DataFlow
+{
+    /// <summary>
+    /// Reuses control-flow state and bounds cumulative reaching-definition work for one method.
+    /// </summary>
+    internal sealed class DataFlowReachingDefinitionAnalysis
+    {
+        private const int MinimumWorkBudget = 16_384;
+        private const int WorkBudgetMultiplier = 256;
+
+        private readonly object _sync = new();
+        private readonly Collection<Instruction> _instructions;
+        private readonly Dictionary<(int ConsumerIndex, int LocalIndex), IReadOnlyCollection<int>>
+            _localStoreCache = new();
+        private IReadOnlyDictionary<Instruction, int>? _instructionIndexes;
+        private List<int>[]? _predecessors;
+
+        public DataFlowReachingDefinitionAnalysis(Collection<Instruction> instructions)
+        {
+            _instructions = instructions ?? throw new ArgumentNullException(nameof(instructions));
+            WorkBudget = (int)Math.Min(
+                int.MaxValue,
+                Math.Max(MinimumWorkBudget, (long)Math.Max(1, instructions.Count) * WorkBudgetMultiplier));
+        }
+
+        public bool IsComplete { get; private set; } = true;
+
+        internal int ControlFlowGraphBuildCount { get; private set; }
+
+        internal int WorkBudget { get; }
+
+        internal int WorkUnitsConsumed { get; private set; }
+
+        public bool TryGetReachingLocalStoreIndexes(
+            int consumerIndex,
+            int localIndex,
+            out IReadOnlyCollection<int> definitionIndexes)
+        {
+            lock (_sync)
+            {
+                if (!IsComplete)
+                {
+                    definitionIndexes = Array.Empty<int>();
+                    return false;
+                }
+
+                var cacheKey = (consumerIndex, localIndex);
+                if (_localStoreCache.TryGetValue(cacheKey, out definitionIndexes!))
+                {
+                    return true;
+                }
+
+                if (!TryGetReachingInstructionIndexesCore(
+                        consumerIndex,
+                        index => _instructions[index].TryGetStoredLocalIndex(out var storedLocalIndex) &&
+                                 storedLocalIndex == localIndex,
+                        out definitionIndexes))
+                {
+                    definitionIndexes = Array.Empty<int>();
+                    return false;
+                }
+
+                _localStoreCache[cacheKey] = definitionIndexes;
+                return true;
+            }
+        }
+
+        public bool TryGetReachingInstructionIndexes(
+            int consumerIndex,
+            Func<int, bool> isDefinition,
+            out IReadOnlyCollection<int> definitionIndexes)
+        {
+            if (isDefinition == null)
+            {
+                throw new ArgumentNullException(nameof(isDefinition));
+            }
+
+            lock (_sync)
+            {
+                return TryGetReachingInstructionIndexesCore(
+                    consumerIndex,
+                    isDefinition,
+                    out definitionIndexes);
+            }
+        }
+
+        public bool TryFindTopValueProducer(int beforeIndex, out int producerIndex)
+        {
+            lock (_sync)
+            {
+                producerIndex = -1;
+                var needed = 1;
+
+                for (var index = beforeIndex; index >= 0; index--)
+                {
+                    if (!TryConsumeWorkUnit())
+                    {
+                        return false;
+                    }
+
+                    var instruction = _instructions[index];
+                    needed -= instruction.GetPushCount();
+                    if (needed <= 0)
+                    {
+                        producerIndex = index;
+                        return true;
+                    }
+
+                    needed += instruction.GetPopCount();
+                }
+
+                return false;
+            }
+        }
+
+        public bool TryFindValueExpressionStart(int producerIndex, out int expressionStart)
+        {
+            lock (_sync)
+            {
+                expressionStart = -1;
+                var needed = 1;
+                for (var index = producerIndex; index >= 0; index--)
+                {
+                    if (!TryConsumeWorkUnit())
+                    {
+                        return false;
+                    }
+
+                    needed -= _instructions[index].GetPushCount();
+                    needed += _instructions[index].GetPopCount();
+                    if (needed <= 0)
+                    {
+                        expressionStart = index;
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        private bool TryGetReachingInstructionIndexesCore(
+            int consumerIndex,
+            Func<int, bool> isDefinition,
+            out IReadOnlyCollection<int> definitionIndexes)
+        {
+            definitionIndexes = Array.Empty<int>();
+            if (!IsComplete || consumerIndex < 0 || consumerIndex >= _instructions.Count || !EnsureControlFlowGraph())
+            {
+                return false;
+            }
+
+            var definitions = new HashSet<int>();
+            var pending = new Stack<int>(_predecessors![consumerIndex]);
+            var visited = new HashSet<int>();
+            while (pending.Count > 0)
+            {
+                if (!TryConsumeWorkUnit())
+                {
+                    return false;
+                }
+
+                var index = pending.Pop();
+                if (!visited.Add(index))
+                {
+                    continue;
+                }
+
+                if (isDefinition(index))
+                {
+                    definitions.Add(index);
+                    continue;
+                }
+
+                if (!IsComplete)
+                {
+                    return false;
+                }
+
+                foreach (var predecessor in _predecessors[index])
+                {
+                    pending.Push(predecessor);
+                }
+            }
+
+            definitionIndexes = definitions;
+            return true;
+        }
+
+        private bool EnsureControlFlowGraph()
+        {
+            if (_predecessors != null)
+            {
+                return IsComplete;
+            }
+
+            ControlFlowGraphBuildCount++;
+            _instructionIndexes = _instructions
+                .Select((instruction, index) => (instruction, index))
+                .ToDictionary(static entry => entry.instruction, static entry => entry.index);
+            _predecessors = Enumerable.Range(0, _instructions.Count)
+                .Select(_ => new List<int>())
+                .ToArray();
+
+            for (var index = 0; index < _instructions.Count; index++)
+            {
+                foreach (var successor in GetSuccessorIndexes(index))
+                {
+                    if (!TryConsumeWorkUnit())
+                    {
+                        return false;
+                    }
+
+                    _predecessors[successor].Add(index);
+                }
+            }
+
+            return true;
+        }
+
+        private IEnumerable<int> GetSuccessorIndexes(int index)
+        {
+            var instruction = _instructions[index];
+            if (instruction.Operand is Instruction target)
+            {
+                if (_instructionIndexes!.TryGetValue(target, out var targetIndex))
+                {
+                    yield return targetIndex;
+                }
+            }
+            else if (instruction.Operand is Instruction[] targets)
+            {
+                foreach (var switchTarget in targets)
+                {
+                    if (_instructionIndexes!.TryGetValue(switchTarget, out var switchTargetIndex))
+                    {
+                        yield return switchTargetIndex;
+                    }
+                }
+            }
+
+            if (index + 1 >= _instructions.Count ||
+                instruction.OpCode.FlowControl is FlowControl.Branch or FlowControl.Return or FlowControl.Throw)
+            {
+                yield break;
+            }
+
+            yield return index + 1;
+        }
+
+        private bool TryConsumeWorkUnit()
+        {
+            if (!IsComplete || WorkUnitsConsumed >= WorkBudget)
+            {
+                IsComplete = false;
+                return false;
+            }
+
+            WorkUnitsConsumed++;
+            return true;
+        }
+    }
+}

--- a/Services/DataFlowAnalyzer.cs
+++ b/Services/DataFlowAnalyzer.cs
@@ -102,11 +102,10 @@ namespace MLVScan.Services
 
             _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
 
-            var operationClassifier = new DataFlowOperationClassifier();
             var nodeFactory = new DataFlowNodeFactory(snippetBuilder);
 
             _patternEvaluator = new DataFlowPatternEvaluator();
-            _methodAnalyzer = new DataFlowMethodAnalyzer(operationClassifier, _patternEvaluator, nodeFactory);
+            _methodAnalyzer = new DataFlowMethodAnalyzer(_patternEvaluator, nodeFactory);
             _crossMethodAnalyzer = new CrossMethodDataFlowAnalyzer(_patternEvaluator, nodeFactory, config);
         }
 #pragma warning restore CS0618
@@ -191,8 +190,20 @@ namespace MLVScan.Services
                 }
             }
 
+            foreach (var methodKey in _state.IncompleteMethodKeys.OrderBy(static key => key, StringComparer.Ordinal))
+            {
+                findings.Add(new ScanFinding(
+                    methodKey,
+                    "Warning: Full IL analysis was skipped after the bounded data-flow work limit was reached. Manual review is required.",
+                    Severity.Low)
+                {
+                    RuleId = "DataFlowScanWarning"
+                });
+            }
+
             _telemetry.AddPhaseElapsed("DataFlowAnalyzer.BuildDataFlowFindings", buildFindingsStart);
             _telemetry.IncrementCounter("DataFlowAnalyzer.FindingsEmitted", findings.Count);
+            _telemetry.IncrementCounter("DataFlowAnalyzer.IncompleteMethods", _state.IncompleteMethodKeys.Count);
             return findings;
         }
 


### PR DESCRIPTION
## What changed

- builds each method's control-flow predecessor graph once per method analysis
- caches identical reaching-local-store queries
- accounts for CFG edge construction, backward stack walks, and predecessor traversal under a cumulative per-method work budget
- keeps that budget strictly linear at `max(16,384, instructionCount × 256)`, calibrated against both real corpora and a representative call-heavy method
- scopes cache and budget state to one method analysis so repeated scans remain independent and deterministic
- clears stale incomplete state if the same method key is successfully reanalyzed
- refuses to serve previously cached answers after the cumulative budget is exhausted
- emits a `DataFlowScanWarning` when the budget is exhausted, which maps to incomplete analysis and `ManualReviewRequired`

## Root cause

Reaching-definition queries rebuilt the instruction index and predecessor graph for each local argument query, then walked the graph without a cumulative bound. Attacker-controlled IL with many distinct consumers could therefore drive effectively quadratic scan work.

## Security behavior

The fix fails closed. If adversarial IL consumes the linear budget, Core does not silently return a clean result; it retains an incomplete-analysis warning and recommends blocking for manual review.

The calibrated bound allows a representative 400-call valid method to complete while 800-call and 1,000-query adversarial cases exhaust the bounded analysis and fail closed.

## Corpus impact

- all 113 managed assemblies under `FALSE_POSITIVES` remain `Clean` with no family match
- all 48 managed assemblies under `QUARANTINE` remain `KnownThreat`
- quarantine files were analyzed statically only and were never loaded or executed

## Validation

- data-flow tests: 182 passed
- false-positive suite: 43 passed, 6 optional-fixture skips
- quarantine suite: 180 passed, 1 optional-fixture skip
- full solution: 1,534 passed, 18 fixture-dependent skips
- `dotnet build MLVScan.Core.csproj --no-restore`
- `git diff --check`

The final local rerun used the installed .NET SDK 8.0.319 explicitly because the newly active SDK 10.0.303 environment lacks `wasm-tools-net8`. The repository-wide formatter verifier remains noisy from pre-existing CRLF/whitespace diagnostics across untouched files, so no unrelated mass-formatting is included.