### PR TITLE
Fail closed when bounded static RVA analysis is truncated

### DIFF
--- a/MLVScan.Core.Tests/Unit/Rules/ObfuscatedReflectiveExecutionRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ObfuscatedReflectiveExecutionRuleTests.cs
@@ -384,6 +384,112 @@ namespace MLVScan.Core.Tests.Unit.Rules
             decoded.Should().Contain("System.Net.WebClient");
         }
 
+        [Fact]
+        public void PostAnalysisRefine_WhenStaticArrayStringBudgetIsExhausted_FailsClosedForManualReview()
+        {
+            var assembly = TestAssemblyBuilder.Create("StaticArrayBudgetExhaustion").Build();
+            ModuleDefinition module = assembly.MainModule;
+            var type = new TypeDefinition(
+                "TestNamespace",
+                "StaticData",
+                TypeAttributes.Public | TypeAttributes.Class,
+                module.TypeSystem.Object);
+            module.Types.Add(type);
+
+            for (var index = 0; index < 256; index++)
+            {
+                type.Fields.Add(new FieldDefinition(
+                    $"Padding{index}",
+                    FieldAttributes.Private | FieldAttributes.Static | FieldAttributes.HasFieldRVA,
+                    module.TypeSystem.Byte)
+                {
+                    InitialValue = System.Text.Encoding.ASCII.GetBytes($"benign-padding-{index:D3}")
+                });
+            }
+            type.Fields.Add(new FieldDefinition(
+                "LaterMalwareMarker",
+                FieldAttributes.Private | FieldAttributes.Static | FieldAttributes.HasFieldRVA,
+                module.TypeSystem.Byte)
+            {
+                InitialValue = System.Text.Encoding.ASCII.GetBytes("System.Net.WebClient")
+            });
+
+            List<ScanFinding> findings = _rule
+                .PostAnalysisRefine(module, Enumerable.Empty<ScanFinding>())
+                .ToList();
+
+            findings.Should().ContainSingle(finding => finding.RuleId == "StaticRvaScanWarning");
+            findings.Single().Severity.Should().Be(Severity.Low);
+            findings.Single().Description.Should().ContainEquivalentOf("manual review");
+        }
+
+        [Fact]
+        public void PostAnalysisRefine_WhenEveryStaticArrayStringFitsBudget_RemainsComplete()
+        {
+            var assembly = TestAssemblyBuilder.Create("StaticArrayWithinBudget").Build();
+            ModuleDefinition module = assembly.MainModule;
+            var type = new TypeDefinition(
+                "TestNamespace",
+                "StaticData",
+                TypeAttributes.Public | TypeAttributes.Class,
+                module.TypeSystem.Object);
+            module.Types.Add(type);
+
+            for (var index = 0; index < 256; index++)
+            {
+                type.Fields.Add(new FieldDefinition(
+                    $"Value{index}",
+                    FieldAttributes.Private | FieldAttributes.Static | FieldAttributes.HasFieldRVA,
+                    module.TypeSystem.Byte)
+                {
+                    InitialValue = System.Text.Encoding.ASCII.GetBytes($"benign-value-{index:D3}")
+                });
+            }
+
+            List<ScanFinding> findings = _rule
+                .PostAnalysisRefine(module, Enumerable.Empty<ScanFinding>())
+                .ToList();
+
+            findings.Should().NotContain(finding => finding.RuleId == "StaticRvaScanWarning");
+        }
+
+        [Fact]
+        public void PostAnalysisRefine_WhenStaticArrayByteBudgetIsExhausted_FailsClosedForManualReview()
+        {
+            var assembly = TestAssemblyBuilder.Create("StaticArrayByteBudgetExhaustion").Build();
+            ModuleDefinition module = assembly.MainModule;
+            var type = new TypeDefinition(
+                "TestNamespace",
+                "StaticData",
+                TypeAttributes.Public | TypeAttributes.Class,
+                module.TypeSystem.Object);
+            module.Types.Add(type);
+
+            for (var index = 0; index < 64; index++)
+            {
+                type.Fields.Add(new FieldDefinition(
+                    $"Block{index}",
+                    FieldAttributes.Private | FieldAttributes.Static | FieldAttributes.HasFieldRVA,
+                    module.TypeSystem.Byte)
+                {
+                    InitialValue = Enumerable.Repeat((byte)'A', 4096).ToArray()
+                });
+            }
+            type.Fields.Add(new FieldDefinition(
+                "LaterEligibleValue",
+                FieldAttributes.Private | FieldAttributes.Static | FieldAttributes.HasFieldRVA,
+                module.TypeSystem.Byte)
+            {
+                InitialValue = System.Text.Encoding.ASCII.GetBytes("later-value")
+            });
+
+            List<ScanFinding> findings = _rule
+                .PostAnalysisRefine(module, Enumerable.Empty<ScanFinding>())
+                .ToList();
+
+            findings.Should().ContainSingle(finding => finding.RuleId == "StaticRvaScanWarning");
+        }
+
         private static (MethodDefinition Method, ModuleDefinition Module) CreateTestMethod()
         {
             var assembly = TestAssemblyBuilder.Create("TestAssembly").Build();

--- a/Models/Rules/ObfuscatedReflectiveExecutionRule.cs
+++ b/Models/Rules/ObfuscatedReflectiveExecutionRule.cs
@@ -118,8 +118,24 @@ namespace MLVScan.Models.Rules
 
             List<ScanFinding> priorFindings = existingFindings?.ToList() ?? new List<ScanFinding>();
             var findings = new List<ScanFinding>();
-            IReadOnlyList<string> moduleDecodedStrings = CollectDecodedStaticArrayStrings(module);
+            (IReadOnlyList<string> moduleDecodedStrings, bool staticArrayCollectionTruncated) =
+                CollectDecodedStaticArrayStringsWithStatus(module);
             var moduleDecodedMarkerCache = new Dictionary<string, bool>(StringComparer.Ordinal);
+
+            if (staticArrayCollectionTruncated)
+            {
+                findings.Add(new ScanFinding(
+                    module.Name,
+                    "Static RVA string analysis reached its bounded work budget before every eligible field " +
+                    "could be inspected. Full IL analysis was skipped for the remaining static data and manual " +
+                    "review is required.",
+                    Severity.Low)
+                {
+                    RuleId = "StaticRvaScanWarning",
+                    RiskScore = 20,
+                    BypassCompanionCheck = true
+                });
+            }
 
             foreach (var namespaceGroup in EnumerateTypes(module)
                          .Where(static type => !string.IsNullOrWhiteSpace(type.Namespace))
@@ -517,6 +533,12 @@ namespace MLVScan.Models.Rules
 
         private static IReadOnlyList<string> CollectDecodedStaticArrayStrings(ModuleDefinition module)
         {
+            return CollectDecodedStaticArrayStringsWithStatus(module).Strings;
+        }
+
+        private static (IReadOnlyList<string> Strings, bool WasTruncated)
+            CollectDecodedStaticArrayStringsWithStatus(ModuleDefinition module)
+        {
             var strings = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             int inspectedBytes = 0;
 
@@ -539,7 +561,7 @@ namespace MLVScan.Models.Rules
                     if (strings.Count >= MaximumDecodedStaticArrayStrings ||
                         field.InitialValue.Length > MaximumDecodedStaticArrayBytes - inspectedBytes)
                     {
-                        return strings.ToList();
+                        return (strings.ToList(), true);
                     }
 
                     inspectedBytes += field.InitialValue.Length;
@@ -550,7 +572,7 @@ namespace MLVScan.Models.Rules
                 }
             }
 
-            return strings.ToList();
+            return (strings.ToList(), false);
         }
 
         private static bool TryDecodePrintableBytes(byte[] bytes, out string decoded)


### PR DESCRIPTION
## What changed

- records whether bounded static-RVA string collection completed
- emits a low-severity `StaticRvaScanWarning` when either the string-count or byte budget is exhausted
- lets the existing completeness pipeline map that warning to incomplete analysis and manual review
- preserves complete results when every eligible static field fits within the existing budget

## Why

A bounded post-analysis pass could stop before inspecting every eligible static field while leaving the overall scan eligible for a complete/clean disposition. The repair preserves the resource bound and fails closed whenever that analysis is truncated.

This description intentionally omits reproduction details and attack-path specifics from the public PR.

## Validation

- focused rule tests: 14 passed
- false-positive suite: 43 passed, 6 optional-fixture skips
  - all 113 managed assemblies remain Clean with no family match
- quarantine suite: 180 passed, 1 optional companion-fixture skip
  - all 48 managed samples remain KnownThreat
- full solution before the review-only test addition: 1,536 passed, 18 fixture-dependent skips
- `git diff --check`

Quarantine samples were analyzed statically only and were never loaded or executed.