### PR TITLE
Preserve persistence destination resolution for initialized arrays

### DIFF
--- a/MLVScan.Core.Tests/Unit/Rules/PersistenceRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/PersistenceRuleTests.cs
@@ -176,6 +176,66 @@ public class PersistenceRuleTests
     }
 
     [Fact]
+    public void AnalyzeContextualPattern_DetectsPersistenceWriteWithInlineByteArrayPayload()
+    {
+        var context = CreateContext("System.IO.File", "WriteAllBytes", builder =>
+        {
+            ILProcessor il = builder.MethodDefinition.Body.GetILProcessor();
+            il.Emit(OpCodes.Ldstr, @"C:\Users\Test\AppData\Local\payload.exe");
+            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.Newarr, builder.Module.TypeSystem.Byte);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Ldc_I4, 0x4d);
+            il.Emit(OpCodes.Stelem_I1);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Ldc_I4, 0x5a);
+            il.Emit(OpCodes.Stelem_I1);
+        });
+
+        int callIndex = context.Method.Body.Instructions.Count - 2;
+        List<ScanFinding> findings = Analyze(context, callIndex);
+
+        findings.Should().ContainSingle();
+        findings[0].Severity.Should().Be(Severity.High);
+        findings[0].Description.Should().Contain("Potential persistence");
+    }
+
+    [Fact]
+    public void AnalyzeContextualPattern_DetectsPersistenceWriteWithStaticArrayInitializer()
+    {
+        var context = CreateContext("System.IO.File", "WriteAllBytes", builder =>
+        {
+            ILProcessor il = builder.MethodDefinition.Body.GetILProcessor();
+            var dataField = new FieldReference(
+                "PayloadData",
+                new ArrayType(builder.Module.TypeSystem.Byte),
+                builder.MethodDefinition.DeclaringType);
+            var initializeArray = new MethodReference(
+                "InitializeArray",
+                builder.Module.TypeSystem.Void,
+                CreateTypeReference(builder.Module, "System.Runtime.CompilerServices.RuntimeHelpers"));
+            initializeArray.Parameters.Add(new ParameterDefinition(CreateTypeReference(builder.Module, "System.Array")));
+            initializeArray.Parameters.Add(new ParameterDefinition(
+                CreateTypeReference(builder.Module, "System.RuntimeFieldHandle")));
+
+            il.Emit(OpCodes.Ldstr, @"C:\Users\Test\AppData\Local\payload.exe");
+            il.Emit(OpCodes.Ldc_I4, 256);
+            il.Emit(OpCodes.Newarr, builder.Module.TypeSystem.Byte);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldtoken, dataField);
+            il.Emit(OpCodes.Call, initializeArray);
+        });
+
+        int callIndex = context.Method.Body.Instructions.Count - 2;
+        List<ScanFinding> findings = Analyze(context, callIndex);
+
+        findings.Should().ContainSingle();
+        findings[0].Severity.Should().Be(Severity.High);
+    }
+
+    [Fact]
     public void AnalyzeContextualPattern_DoesNotDetect_WhenNotFileOperation()
     {
         var context = CreateContext("System.Console", "WriteLine", builder =>

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using System.Runtime.CompilerServices;
 using MLVScan.Services.Helpers;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -12,6 +13,10 @@ namespace MLVScan.Models.Rules.Helpers
     internal static class InstructionValueResolver
     {
         private const int MaxDepth = 16;
+        private const int MaxTrackedCallArguments = 32;
+
+        private static readonly ConditionalWeakTable<
+            Mono.Collections.Generic.Collection<Instruction>, CallArgumentProducerMap> CallArgumentProducerMaps = new();
 
         private static readonly Regex ExecutableNameRegex =
             new Regex(@"([A-Za-z0-9._-]+\.(?:exe|bat|cmd|com|ps1|msi))",
@@ -124,6 +129,12 @@ namespace MLVScan.Models.Rules.Helpers
             }
 
             var context = new ResolverContext(containingMethod?.Module);
+            if (TryResolveCallArgumentFromBasicBlock(context, containingMethod, instructions, callIndex,
+                    calledMethod.Parameters.Count, argumentIndex, out valueDisplay))
+            {
+                return true;
+            }
+
             if (!TryResolveCallArguments(context, containingMethod, instructions, callIndex,
                     calledMethod.Parameters.Count, null, 0, out var arguments))
             {
@@ -132,6 +143,159 @@ namespace MLVScan.Models.Rules.Helpers
 
             valueDisplay = arguments[argumentIndex].Display;
             return true;
+        }
+
+        private static bool TryResolveCallArgumentFromBasicBlock(
+            ResolverContext context,
+            MethodDefinition? containingMethod,
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            int callIndex,
+            int parameterCount,
+            int argumentIndex,
+            out string valueDisplay)
+        {
+            valueDisplay = "<unknown/non-literal>";
+            var producerMap = CallArgumentProducerMaps.GetValue(instructions, BuildCallArgumentProducerMap);
+            if (!producerMap.TryGetProducer(callIndex, parameterCount, argumentIndex, out int producerIndex))
+                return false;
+
+            if (!TryResolveValueFromProducer(context, containingMethod, instructions, producerIndex, null, 1,
+                    out var resolved))
+            {
+                return false;
+            }
+
+            valueDisplay = resolved.Display;
+            return true;
+        }
+
+        private static CallArgumentProducerMap BuildCallArgumentProducerMap(
+            Mono.Collections.Generic.Collection<Instruction> instructions)
+        {
+            var instructionIndices = new Dictionary<Instruction, int>(instructions.Count);
+            for (int i = 0; i < instructions.Count; i++)
+                instructionIndices[instructions[i]] = i;
+
+            var blockStarts = new bool[instructions.Count];
+            if (blockStarts.Length > 0)
+                blockStarts[0] = true;
+
+            for (int i = 0; i < instructions.Count; i++)
+            {
+                var flowControl = instructions[i].OpCode.FlowControl;
+                if ((flowControl is FlowControl.Branch or FlowControl.Cond_Branch or
+                     FlowControl.Return or FlowControl.Throw) && i + 1 < instructions.Count)
+                    blockStarts[i + 1] = true;
+
+                if (instructions[i].Operand is Instruction target)
+                {
+                    if (instructionIndices.TryGetValue(target, out int targetIndex))
+                        blockStarts[targetIndex] = true;
+                }
+                else if (instructions[i].Operand is Instruction[] targets)
+                {
+                    foreach (var switchTarget in targets)
+                    {
+                        if (instructionIndices.TryGetValue(switchTarget, out int targetIndex))
+                            blockStarts[targetIndex] = true;
+                    }
+                }
+            }
+
+            var producersByCallIndex = new Dictionary<int, int[]>();
+            var stack = new List<int>();
+            bool validBlock = true;
+
+            for (int i = 0; i < instructions.Count; i++)
+            {
+                if (blockStarts[i])
+                {
+                    stack.Clear();
+                    validBlock = true;
+                }
+
+                if (!validBlock)
+                    continue;
+
+                var instruction = instructions[i];
+                if ((instruction.OpCode == OpCodes.Call || instruction.OpCode == OpCodes.Callvirt) &&
+                    instruction.Operand is MethodReference calledMethod &&
+                    calledMethod.Parameters.Count <= MaxTrackedCallArguments &&
+                    stack.Count >= calledMethod.Parameters.Count)
+                {
+                    int parameterCount = calledMethod.Parameters.Count;
+                    int firstArgumentIndex = stack.Count - parameterCount;
+                    var argumentProducers = new int[parameterCount];
+                    for (int argumentIndex = 0; argumentIndex < parameterCount; argumentIndex++)
+                        argumentProducers[argumentIndex] = stack[firstArgumentIndex + argumentIndex];
+
+                    producersByCallIndex[i] = argumentProducers;
+                }
+
+                if (instruction.OpCode == OpCodes.Dup)
+                {
+                    if (stack.Count == 0)
+                    {
+                        validBlock = false;
+                        continue;
+                    }
+
+                    stack.Add(stack[^1]);
+                    continue;
+                }
+
+                if (instruction.OpCode == OpCodes.Calli)
+                {
+                    validBlock = false;
+                    continue;
+                }
+
+                int popCount = IsArrayElementStore(instruction) ? 3 : instruction.GetPopCount();
+                if (popCount > stack.Count)
+                {
+                    validBlock = false;
+                    continue;
+                }
+
+                if (popCount > 0)
+                    stack.RemoveRange(stack.Count - popCount, popCount);
+
+                int pushCount = instruction.GetPushCount();
+                for (int push = 0; push < pushCount; push++)
+                    stack.Add(i);
+            }
+
+            return new CallArgumentProducerMap(producersByCallIndex);
+        }
+
+        private static bool IsArrayElementStore(Instruction instruction)
+        {
+            return instruction.OpCode.Code is
+                Code.Stelem_Any or Code.Stelem_I or Code.Stelem_I1 or Code.Stelem_I2 or Code.Stelem_I4 or
+                Code.Stelem_I8 or Code.Stelem_R4 or Code.Stelem_R8 or Code.Stelem_Ref;
+        }
+
+        private sealed class CallArgumentProducerMap
+        {
+            private readonly Dictionary<int, int[]> _producersByCallIndex;
+
+            public CallArgumentProducerMap(Dictionary<int, int[]> producersByCallIndex)
+            {
+                _producersByCallIndex = producersByCallIndex;
+            }
+
+            public bool TryGetProducer(int callIndex, int parameterCount, int argumentIndex, out int producerIndex)
+            {
+                producerIndex = -1;
+                if (!_producersByCallIndex.TryGetValue(callIndex, out var producers) ||
+                    producers.Length != parameterCount || argumentIndex < 0 || argumentIndex >= producers.Length)
+                {
+                    return false;
+                }
+
+                producerIndex = producers[argumentIndex];
+                return true;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- preserve file-write destination resolution when a later call argument is initialized inline
- keep fallback analysis within the call site's lexical basic block and track duplicated evaluation-stack origins
- cover both element-by-element and compiler-style static array initialization

## Validation

- `PersistenceRuleTests`: 43 passed
- `FALSE_POSITIVES`: 31 passed, 5 intentional skips; every corpus assembly remains `Clean` with no threat-family match
- `QUARANTINE`: 180 passed, 1 optional skip; all modeled samples remain `KnownThreat`
- full solution: 1,539 passed, 18 existing skips

Security-sensitive reproduction and attack-path details are intentionally omitted from this public PR.