### PR TITLE
Prevent clean verdicts for standalone critical findings

### DIFF
--- a/MLVScan.Core.Tests/Unit/Services/ScanResultMapperTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/ScanResultMapperTests.cs
@@ -564,6 +564,26 @@ public class ScanResultMapperTests
     }
 
     [Fact]
+    public void ToDto_WithStandaloneCriticalFinding_MapsBlockingDispositionAndDefaultVisibility()
+    {
+        var finding = new ScanFinding(
+            "Suspicious.Mod.Initialize",
+            "Critical native behavior detected",
+            Severity.Critical)
+        {
+            RuleId = "DllImportRule"
+        };
+
+        var result = ScanResultMapper.ToDto(new[] { finding }, "test.dll", _testAssemblyBytes, false);
+
+        result.Disposition.Should().NotBeNull();
+        result.Disposition!.Classification.Should().Be("Suspicious");
+        result.Disposition.BlockingRecommended.Should().BeTrue();
+        result.Findings.Should().ContainSingle().Which.Visibility.Should().Be("Default");
+        result.Disposition.RelatedFindingIds.Should().Contain(result.Findings[0].Id);
+    }
+
+    [Fact]
     public void ToDto_WithSuspiciousDataFlow_MapsSuspiciousDisposition()
     {
         var dataFlow = new DataFlowChain(

--- a/MLVScan.Core.Tests/Unit/Services/ThreatDispositionClassifierTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/ThreatDispositionClassifierTests.cs
@@ -274,6 +274,28 @@ public class ThreatDispositionClassifierTests
         result.BlockingRecommended.Should().BeFalse();
     }
 
+    [Theory]
+    [InlineData("ProcessStartRule")]
+    [InlineData("MultiSignalDetection")]
+    [InlineData("DllImportRule")]
+    public void Classify_WithStandaloneCriticalFinding_ReturnsSuspicious(string ruleId)
+    {
+        var classifier = new ThreatDispositionClassifier();
+        var finding = new ScanFinding(
+            "Suspicious.Mod.Initialize",
+            "Critical security behavior detected",
+            Severity.Critical)
+        {
+            RuleId = ruleId
+        };
+
+        var result = classifier.Classify(new[] { finding }, threatFamilies: null);
+
+        result.Classification.Should().Be(ThreatDispositionClassification.Suspicious);
+        result.RelatedFindings.Should().ContainSingle().Which.Should().BeSameAs(finding);
+        result.BlockingRecommended.Should().BeTrue();
+    }
+
     [Fact]
     public void Classify_WithSingleHighSeverityCallChainFinding_ReturnsClean()
     {

--- a/Services/ThreatIntel/ThreatDispositionClassifier.cs
+++ b/Services/ThreatIntel/ThreatDispositionClassifier.cs
@@ -259,6 +259,11 @@ public sealed class ThreatDispositionClassifier
             return false;
         }
 
+        if (finding.Severity == Severity.Critical)
+        {
+            return true;
+        }
+
         if (finding.HasDataFlow && IsSuspiciousDataFlowSeed(finding))
         {
             return true;


### PR DESCRIPTION
## Summary

- enforce that unreviewed `Critical` findings produce a blocking `Suspicious` disposition
- preserve the reviewed exact-sample benign override and existing correlation policy for `High` findings
- keep critical findings visible by default in mapped scan results

## Validation

- disposition and mapper suites: 49 passed
- `FALSE_POSITIVES`: 31 passed, 5 intentional skips; every corpus assembly remains `Clean` with no threat-family match
- `QUARANTINE`: 180 passed, 1 optional skip; all modeled samples remain `KnownThreat`
- full solution: 1,543 passed, 18 existing skips

Security-sensitive reproduction and attack-path details are intentionally omitted from this public PR.