### PR TITLE
Harden shell folder launch suppression

### DIFF
--- a/MLVScan.Core.Tests/Integration/FalsePositiveEdgeCaseTests.cs
+++ b/MLVScan.Core.Tests/Integration/FalsePositiveEdgeCaseTests.cs
@@ -51,20 +51,437 @@ public class FalsePositiveEdgeCaseTests
         type.Methods.Add(method);
 
         var il = method.Body.GetILProcessor();
+        var processStartInfoType = CreateType(module, "System.Diagnostics.ProcessStartInfo");
+        var startInfoLocal = new VariableDefinition(processStartInfoType);
+        method.Body.Variables.Add(startInfoLocal);
+        method.Body.InitLocals = true;
+        var returnInstruction = il.Create(OpCodes.Ret);
+
         il.Emit(OpCodes.Ldstr, @"C:\Games\ScheduleI\Mods");
         il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.IO.Directory", "Exists", module.TypeSystem.Boolean, module.TypeSystem.String));
-        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Brfalse_S, returnInstruction);
+
+        il.Emit(OpCodes.Newobj, CreateInstanceMethod(module, "System.Diagnostics.ProcessStartInfo", ".ctor", module.TypeSystem.Void));
+        il.Emit(OpCodes.Stloc, startInfoLocal);
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
         il.Emit(OpCodes.Ldstr, @"C:\Games\ScheduleI\Mods");
         il.Emit(OpCodes.Callvirt, CreateInstanceMethod(module, "System.Diagnostics.ProcessStartInfo", "set_FileName", module.TypeSystem.Void, module.TypeSystem.String));
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Callvirt, CreateInstanceMethod(module, "System.Diagnostics.ProcessStartInfo", "set_UseShellExecute", module.TypeSystem.Void, module.TypeSystem.Boolean));
-        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.Diagnostics.Process", "Start", module.TypeSystem.Object, CreateType(module, "System.Diagnostics.ProcessStartInfo")));
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.Diagnostics.Process", "Start", module.TypeSystem.Object, processStartInfoType));
         il.Emit(OpCodes.Pop);
-        il.Emit(OpCodes.Ret);
+        il.Append(returnInstruction);
 
         var findings = Scan(assembly, "SafeShellFolderOpen.dll");
 
         findings.Should().BeEmpty("shell-opening a folder with UseShellExecute=true and no arguments should stay benign");
+    }
+
+    [Fact]
+    public void Scan_EnsureDirectoryThenShellOpen_DoesNotEmitFindings()
+    {
+        var assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition("EnsureDirectoryShellOpen", new Version(1, 0, 0, 0)),
+            "EnsureDirectoryShellOpen",
+            ModuleKind.Dll);
+        var module = assembly.MainModule;
+        var type = new TypeDefinition("Legit", "FolderOpener", TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(type);
+        var method = new MethodDefinition("OpenFolder", MethodAttributes.Public | MethodAttributes.Static, module.TypeSystem.Void);
+        type.Methods.Add(method);
+        var processStartInfoType = CreateType(module, "System.Diagnostics.ProcessStartInfo");
+        var startInfo = new VariableDefinition(processStartInfoType);
+        method.Body.Variables.Add(startInfo);
+        method.Body.InitLocals = true;
+        var il = method.Body.GetILProcessor();
+        var launchSetup = il.Create(OpCodes.Newobj,
+            CreateInstanceMethod(module, "System.Diagnostics.ProcessStartInfo", ".ctor", module.TypeSystem.Void));
+
+        il.Emit(OpCodes.Ldstr, @"C:\Games\plugins.dll");
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.IO.Directory", "Exists", module.TypeSystem.Boolean, module.TypeSystem.String));
+        il.Emit(OpCodes.Brtrue_S, launchSetup);
+        il.Emit(OpCodes.Ldstr, @"C:\Games\plugins.dll");
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.IO.Directory", "CreateDirectory", CreateType(module, "System.IO.DirectoryInfo"), module.TypeSystem.String));
+        il.Emit(OpCodes.Pop);
+        il.Append(launchSetup);
+        il.Emit(OpCodes.Stloc, startInfo);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Ldstr, @"C:\Games\plugins.dll");
+        il.Emit(OpCodes.Callvirt, CreateInstanceMethod(module, "System.Diagnostics.ProcessStartInfo", "set_FileName", module.TypeSystem.Void, module.TypeSystem.String));
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Callvirt, CreateInstanceMethod(module, "System.Diagnostics.ProcessStartInfo", "set_UseShellExecute", module.TypeSystem.Void, module.TypeSystem.Boolean));
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.Diagnostics.Process", "Start", module.TypeSystem.Object, processStartInfoType));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        Scan(assembly, "EnsureDirectoryShellOpen.dll").Should().BeEmpty(
+            "both the existing-directory and create-directory paths establish the exact folder target");
+    }
+
+    [Fact]
+    public void Scan_IgnoredDirectoryExistsBeforeShellLaunch_EmitsFinding()
+    {
+        var assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition("IgnoredDirectoryCheck", new Version(1, 0, 0, 0)),
+            "IgnoredDirectoryCheck",
+            ModuleKind.Dll);
+        var module = assembly.MainModule;
+        var type = new TypeDefinition("Test", "Launcher", TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(type);
+        var method = new MethodDefinition("Launch", MethodAttributes.Public | MethodAttributes.Static, module.TypeSystem.Void);
+        type.Methods.Add(method);
+        var processStartInfoType = CreateType(module, "System.Diagnostics.ProcessStartInfo");
+        var startInfoLocal = new VariableDefinition(processStartInfoType);
+        method.Body.Variables.Add(startInfoLocal);
+        method.Body.InitLocals = true;
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldstr, @"C:\payload.lnk");
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.IO.Directory", "Exists", module.TypeSystem.Boolean, module.TypeSystem.String));
+        il.Emit(OpCodes.Pop);
+        EmitStartInfoConstruction(il, module, startInfoLocal, @"C:\payload.lnk");
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.Diagnostics.Process", "Start", module.TypeSystem.Object, processStartInfoType));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        Scan(assembly, "IgnoredDirectoryCheck.dll").Should().NotBeEmpty(
+            "discarding Directory.Exists must not validate a shell-launch target");
+    }
+
+    [Fact]
+    public void Scan_BenignStartInfoBeforeStringLaunch_EmitsFinding()
+    {
+        var assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition("UnrelatedStringLaunch", new Version(1, 0, 0, 0)),
+            "UnrelatedStringLaunch",
+            ModuleKind.Dll);
+        var module = assembly.MainModule;
+        var type = new TypeDefinition("Test", "Launcher", TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(type);
+        var method = new MethodDefinition("Launch", MethodAttributes.Public | MethodAttributes.Static, module.TypeSystem.Void);
+        type.Methods.Add(method);
+        var processStartInfoType = CreateType(module, "System.Diagnostics.ProcessStartInfo");
+        var benignStartInfo = new VariableDefinition(processStartInfoType);
+        method.Body.Variables.Add(benignStartInfo);
+        method.Body.InitLocals = true;
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldstr, @"C:\BenignFolder");
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.IO.Directory", "CreateDirectory", CreateType(module, "System.IO.DirectoryInfo"), module.TypeSystem.String));
+        il.Emit(OpCodes.Pop);
+        EmitStartInfoConstruction(il, module, benignStartInfo, @"C:\BenignFolder");
+        il.Emit(OpCodes.Ldstr, "powershell.exe");
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.Diagnostics.Process", "Start", module.TypeSystem.Object, module.TypeSystem.String));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        Scan(assembly, "UnrelatedStringLaunch.dll").Should().NotBeEmpty(
+            "a configured folder start-info must not suppress a direct string launch");
+    }
+
+    [Fact]
+    public void Scan_DifferentStartInfoInstance_EmitsFinding()
+    {
+        var assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition("DifferentStartInfo", new Version(1, 0, 0, 0)),
+            "DifferentStartInfo",
+            ModuleKind.Dll);
+        var module = assembly.MainModule;
+        var type = new TypeDefinition("Test", "Launcher", TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(type);
+        var method = new MethodDefinition("Launch", MethodAttributes.Public | MethodAttributes.Static, module.TypeSystem.Void);
+        type.Methods.Add(method);
+        var processStartInfoType = CreateType(module, "System.Diagnostics.ProcessStartInfo");
+        var launchedStartInfo = new VariableDefinition(processStartInfoType);
+        var benignStartInfo = new VariableDefinition(processStartInfoType);
+        method.Body.Variables.Add(launchedStartInfo);
+        method.Body.Variables.Add(benignStartInfo);
+        method.Body.InitLocals = true;
+        var il = method.Body.GetILProcessor();
+
+        EmitStartInfoConstruction(il, module, launchedStartInfo, "powershell.exe");
+        il.Emit(OpCodes.Ldstr, @"C:\BenignFolder");
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.IO.Directory", "CreateDirectory", CreateType(module, "System.IO.DirectoryInfo"), module.TypeSystem.String));
+        il.Emit(OpCodes.Pop);
+        EmitStartInfoConstruction(il, module, benignStartInfo, @"C:\BenignFolder");
+        il.Emit(OpCodes.Ldloc, launchedStartInfo);
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.Diagnostics.Process", "Start", module.TypeSystem.Object, processStartInfoType));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        Scan(assembly, "DifferentStartInfo.dll").Should().NotBeEmpty(
+            "settings from another ProcessStartInfo instance must not suppress the launched instance");
+    }
+
+    [Fact]
+    public void Scan_ReassignedStartInfoLocal_EmitsFinding()
+    {
+        var assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition("ReassignedStartInfo", new Version(1, 0, 0, 0)),
+            "ReassignedStartInfo",
+            ModuleKind.Dll);
+        var module = assembly.MainModule;
+        var type = new TypeDefinition("Test", "Launcher", TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(type);
+        var method = new MethodDefinition("Launch", MethodAttributes.Public | MethodAttributes.Static, module.TypeSystem.Void);
+        type.Methods.Add(method);
+        var processStartInfoType = CreateType(module, "System.Diagnostics.ProcessStartInfo");
+        var startInfo = new VariableDefinition(processStartInfoType);
+        method.Body.Variables.Add(startInfo);
+        method.Body.InitLocals = true;
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldstr, @"C:\BenignFolder");
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.IO.Directory", "CreateDirectory", CreateType(module, "System.IO.DirectoryInfo"), module.TypeSystem.String));
+        il.Emit(OpCodes.Pop);
+        EmitStartInfoConstruction(il, module, startInfo, @"C:\BenignFolder");
+
+        il.Emit(OpCodes.Ldstr, "powershell.exe");
+        il.Emit(OpCodes.Newobj, CreateInstanceMethod(module, "System.Diagnostics.ProcessStartInfo", ".ctor", module.TypeSystem.Void, module.TypeSystem.String));
+        il.Emit(OpCodes.Stloc, startInfo);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.Diagnostics.Process", "Start", module.TypeSystem.Object, processStartInfoType));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        Scan(assembly, "ReassignedStartInfo.dll").Should().NotBeEmpty(
+            "settings from an earlier object stored in the same local must not suppress its replacement");
+    }
+
+    [Fact]
+    public void Scan_SkippedDirectoryCreationBeforeShellLaunch_EmitsFinding()
+    {
+        var assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition("SkippedDirectoryValidation", new Version(1, 0, 0, 0)),
+            "SkippedDirectoryValidation",
+            ModuleKind.Dll);
+        var module = assembly.MainModule;
+        var type = new TypeDefinition("Test", "Launcher", TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(type);
+        var method = new MethodDefinition("Launch", MethodAttributes.Public | MethodAttributes.Static, module.TypeSystem.Void);
+        type.Methods.Add(method);
+        var processStartInfoType = CreateType(module, "System.Diagnostics.ProcessStartInfo");
+        var startInfo = new VariableDefinition(processStartInfoType);
+        method.Body.Variables.Add(startInfo);
+        method.Body.InitLocals = true;
+        var il = method.Body.GetILProcessor();
+
+        EmitStartInfoConstruction(il, module, startInfo, @"C:\payload.exe");
+        var launchInstruction = il.Create(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Brtrue_S, launchInstruction);
+        il.Emit(OpCodes.Ldstr, @"C:\payload.exe");
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.IO.Directory", "CreateDirectory", CreateType(module, "System.IO.DirectoryInfo"), module.TypeSystem.String));
+        il.Emit(OpCodes.Pop);
+        il.Append(launchInstruction);
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.Diagnostics.Process", "Start", module.TypeSystem.Object, processStartInfoType));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        Scan(assembly, "SkippedDirectoryValidation.dll").Should().NotBeEmpty(
+            "directory validation that does not dominate the launch must fail closed");
+    }
+
+    [Fact]
+    public void Scan_SameNamedUnresolvedFieldsBeforeShellLaunch_EmitsFinding()
+    {
+        var assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition("AmbiguousFieldTargets", new Version(1, 0, 0, 0)),
+            "AmbiguousFieldTargets",
+            ModuleKind.Dll);
+        var module = assembly.MainModule;
+        var safeHolder = new TypeDefinition("Test", "SafeHolder", TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        var payloadHolder = new TypeDefinition("Test", "PayloadHolder", TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        var safePath = new FieldDefinition("Path", FieldAttributes.Public | FieldAttributes.Static, module.TypeSystem.String);
+        var payloadPath = new FieldDefinition("Path", FieldAttributes.Public | FieldAttributes.Static, module.TypeSystem.String);
+        safeHolder.Fields.Add(safePath);
+        payloadHolder.Fields.Add(payloadPath);
+        module.Types.Add(safeHolder);
+        module.Types.Add(payloadHolder);
+
+        var type = new TypeDefinition("Test", "Launcher", TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(type);
+        var method = new MethodDefinition("Launch", MethodAttributes.Public | MethodAttributes.Static, module.TypeSystem.Void);
+        type.Methods.Add(method);
+        var processStartInfoType = CreateType(module, "System.Diagnostics.ProcessStartInfo");
+        var startInfo = new VariableDefinition(processStartInfoType);
+        method.Body.Variables.Add(startInfo);
+        method.Body.InitLocals = true;
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldsfld, safePath);
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.IO.Directory", "CreateDirectory", CreateType(module, "System.IO.DirectoryInfo"), module.TypeSystem.String));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Newobj, CreateInstanceMethod(module, "System.Diagnostics.ProcessStartInfo", ".ctor", module.TypeSystem.Void));
+        il.Emit(OpCodes.Stloc, startInfo);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Ldsfld, payloadPath);
+        il.Emit(OpCodes.Callvirt, CreateInstanceMethod(module, "System.Diagnostics.ProcessStartInfo", "set_FileName", module.TypeSystem.Void, module.TypeSystem.String));
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Callvirt, CreateInstanceMethod(module, "System.Diagnostics.ProcessStartInfo", "set_UseShellExecute", module.TypeSystem.Void, module.TypeSystem.Boolean));
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.Diagnostics.Process", "Start", module.TypeSystem.Object, processStartInfoType));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        Scan(assembly, "AmbiguousFieldTargets.dll").Should().NotBeEmpty(
+            "lossy field displays must not be used as target identities");
+    }
+
+    [Fact]
+    public void Scan_InstanceMethodParameterSlotsRemainDistinct_EmitsFinding()
+    {
+        var assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition("DistinctParameterSlots", new Version(1, 0, 0, 0)),
+            "DistinctParameterSlots",
+            ModuleKind.Dll);
+        var module = assembly.MainModule;
+        var type = new TypeDefinition("Test", "Launcher", TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(type);
+        var processStartInfoType = CreateType(module, "System.Diagnostics.ProcessStartInfo");
+        var method = new MethodDefinition("Launch", MethodAttributes.Public, module.TypeSystem.Void);
+        var benignStartInfo = new ParameterDefinition("benign", ParameterAttributes.None, processStartInfoType);
+        var launchedStartInfo = new ParameterDefinition("launched", ParameterAttributes.None, processStartInfoType);
+        method.Parameters.Add(benignStartInfo);
+        method.Parameters.Add(launchedStartInfo);
+        type.Methods.Add(method);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldstr, @"C:\BenignFolder");
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.IO.Directory", "CreateDirectory", CreateType(module, "System.IO.DirectoryInfo"), module.TypeSystem.String));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldstr, @"C:\BenignFolder");
+        il.Emit(OpCodes.Callvirt, CreateInstanceMethod(module, "System.Diagnostics.ProcessStartInfo", "set_FileName", module.TypeSystem.Void, module.TypeSystem.String));
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Callvirt, CreateInstanceMethod(module, "System.Diagnostics.ProcessStartInfo", "set_UseShellExecute", module.TypeSystem.Void, module.TypeSystem.Boolean));
+        il.Emit(OpCodes.Ldarg, launchedStartInfo);
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.Diagnostics.Process", "Start", module.TypeSystem.Object, processStartInfoType));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        Scan(assembly, "DistinctParameterSlots.dll").Should().NotBeEmpty(
+            "the hidden this slot must not collide with explicit parameter identities");
+    }
+
+    [Fact]
+    public void Scan_MultiArgumentCreateDirectoryThenShellOpen_DoesNotEmitFindings()
+    {
+        var assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition("MultiArgumentCreateDirectory", new Version(1, 0, 0, 0)),
+            "MultiArgumentCreateDirectory",
+            ModuleKind.Dll);
+        var module = assembly.MainModule;
+        var type = new TypeDefinition("Legit", "FolderOpener", TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(type);
+        var method = new MethodDefinition("OpenFolder", MethodAttributes.Public | MethodAttributes.Static, module.TypeSystem.Void);
+        type.Methods.Add(method);
+        var processStartInfoType = CreateType(module, "System.Diagnostics.ProcessStartInfo");
+        var startInfo = new VariableDefinition(processStartInfoType);
+        method.Body.Variables.Add(startInfo);
+        method.Body.InitLocals = true;
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldstr, @"C:\Games\Mods");
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.IO.Directory", "CreateDirectory",
+            CreateType(module, "System.IO.DirectoryInfo"), module.TypeSystem.String, module.TypeSystem.Int32));
+        il.Emit(OpCodes.Pop);
+        EmitStartInfoConstruction(il, module, startInfo, @"C:\Games\Mods");
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.Diagnostics.Process", "Start", module.TypeSystem.Object, processStartInfoType));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        Scan(assembly, "MultiArgumentCreateDirectory.dll").Should().BeEmpty(
+            "directory validation must resolve the path argument rather than the final overload argument");
+    }
+
+    [Fact]
+    public void Scan_ConditionalFileNameSetterBeforeShellLaunch_EmitsFinding()
+    {
+        var assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition("ConditionalFileNameSetter", new Version(1, 0, 0, 0)),
+            "ConditionalFileNameSetter",
+            ModuleKind.Dll);
+        var module = assembly.MainModule;
+        var type = new TypeDefinition("Test", "Launcher", TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(type);
+        var method = new MethodDefinition("Launch", MethodAttributes.Public | MethodAttributes.Static, module.TypeSystem.Void);
+        type.Methods.Add(method);
+        var processStartInfoType = CreateType(module, "System.Diagnostics.ProcessStartInfo");
+        var startInfo = new VariableDefinition(processStartInfoType);
+        method.Body.Variables.Add(startInfo);
+        method.Body.InitLocals = true;
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldstr, "payload.exe");
+        il.Emit(OpCodes.Newobj, CreateInstanceMethod(module, "System.Diagnostics.ProcessStartInfo", ".ctor", module.TypeSystem.Void, module.TypeSystem.String));
+        il.Emit(OpCodes.Stloc, startInfo);
+        var validationStart = il.Create(OpCodes.Ldstr, @"C:\BenignFolder");
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Brtrue_S, validationStart);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Ldstr, @"C:\BenignFolder");
+        il.Emit(OpCodes.Callvirt, CreateInstanceMethod(module, "System.Diagnostics.ProcessStartInfo", "set_FileName", module.TypeSystem.Void, module.TypeSystem.String));
+        il.Append(validationStart);
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.IO.Directory", "CreateDirectory", CreateType(module, "System.IO.DirectoryInfo"), module.TypeSystem.String));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Callvirt, CreateInstanceMethod(module, "System.Diagnostics.ProcessStartInfo", "set_UseShellExecute", module.TypeSystem.Void, module.TypeSystem.Boolean));
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.Diagnostics.Process", "Start", module.TypeSystem.Object, processStartInfoType));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        Scan(assembly, "ConditionalFileNameSetter.dll").Should().NotBeEmpty(
+            "a filename setter that does not dominate the launch must fail closed");
+    }
+
+    [Fact]
+    public void Scan_ObjectInitializerFolderShellOpen_DoesNotEmitFindings()
+    {
+        var assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition("ObjectInitializerFolderOpen", new Version(1, 0, 0, 0)),
+            "ObjectInitializerFolderOpen",
+            ModuleKind.Dll);
+        var module = assembly.MainModule;
+        var type = new TypeDefinition("Legit", "FolderOpener", TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(type);
+        var method = new MethodDefinition("OpenFolder", MethodAttributes.Public | MethodAttributes.Static, module.TypeSystem.Void);
+        type.Methods.Add(method);
+        var processStartInfoType = CreateType(module, "System.Diagnostics.ProcessStartInfo");
+        var startInfo = new VariableDefinition(processStartInfoType);
+        method.Body.Variables.Add(startInfo);
+        method.Body.InitLocals = true;
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldstr, @"C:\Games\Mods");
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.IO.Directory", "CreateDirectory", CreateType(module, "System.IO.DirectoryInfo"), module.TypeSystem.String));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Newobj, CreateInstanceMethod(module, "System.Diagnostics.ProcessStartInfo", ".ctor", module.TypeSystem.Void));
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldstr, @"C:\Games\Mods");
+        il.Emit(OpCodes.Callvirt, CreateInstanceMethod(module, "System.Diagnostics.ProcessStartInfo", "set_FileName", module.TypeSystem.Void, module.TypeSystem.String));
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Callvirt, CreateInstanceMethod(module, "System.Diagnostics.ProcessStartInfo", "set_UseShellExecute", module.TypeSystem.Void, module.TypeSystem.Boolean));
+        il.Emit(OpCodes.Stloc, startInfo);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Call, CreateStaticMethod(module, "System.Diagnostics.Process", "Start", module.TypeSystem.Object, processStartInfoType));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        Scan(assembly, "ObjectInitializerFolderOpen.dll").Should().BeEmpty(
+            "the stloc producer map must preserve the object created below initializer setters");
     }
 
     [Fact]
@@ -259,6 +676,22 @@ public class FalsePositiveEdgeCaseTests
         var method = CreateStaticMethod(module, declaringTypeFullName, methodName, returnType, parameterTypes);
         method.HasThis = true;
         return method;
+    }
+
+    private static void EmitStartInfoConstruction(
+        ILProcessor il,
+        ModuleDefinition module,
+        VariableDefinition local,
+        string fileName)
+    {
+        il.Emit(OpCodes.Newobj, CreateInstanceMethod(module, "System.Diagnostics.ProcessStartInfo", ".ctor", module.TypeSystem.Void));
+        il.Emit(OpCodes.Stloc, local);
+        il.Emit(OpCodes.Ldloc, local);
+        il.Emit(OpCodes.Ldstr, fileName);
+        il.Emit(OpCodes.Callvirt, CreateInstanceMethod(module, "System.Diagnostics.ProcessStartInfo", "set_FileName", module.TypeSystem.Void, module.TypeSystem.String));
+        il.Emit(OpCodes.Ldloc, local);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Callvirt, CreateInstanceMethod(module, "System.Diagnostics.ProcessStartInfo", "set_UseShellExecute", module.TypeSystem.Void, module.TypeSystem.Boolean));
     }
 
     private static TypeReference CreateType(ModuleDefinition module, string fullName)

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using MLVScan.Core.Tests.TestUtilities;
 using MLVScan.Models;
 using MLVScan.Models.Rules;
+using MLVScan.Models.Rules.Helpers;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Xunit;
@@ -718,27 +719,184 @@ public class ProcessStartRuleTests
     [Fact]
     public void ShouldSuppressFinding_ShellFolderLaunch_ReturnsTrue()
     {
-        var method = new MethodDefinition("TestMethod", MethodAttributes.Public, new TypeReference("", "Void", null, null));
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("", "Void", null, null));
+        method.Parameters.Add(new ParameterDefinition(new TypeReference("", "String", null, null)));
         var processor = method.Body.GetILProcessor();
+        var processStartInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var startInfoLocal = new VariableDefinition(processStartInfoType);
+        method.Body.Variables.Add(startInfoLocal);
+
+        var createDirectory = new MethodReference("CreateDirectory", new TypeReference("", "DirectoryInfo", null, null),
+            new TypeReference("System.IO", "Directory", null, null));
+        createDirectory.Parameters.Add(new ParameterDefinition(new TypeReference("", "String", null, null)));
+
+        var constructor = new MethodReference(".ctor", new TypeReference("", "Void", null, null), processStartInfoType)
+        {
+            HasThis = true
+        };
+        var setFileName = new MethodReference("set_FileName", new TypeReference("", "Void", null, null), processStartInfoType)
+        {
+            HasThis = true
+        };
+        setFileName.Parameters.Add(new ParameterDefinition(new TypeReference("", "String", null, null)));
+        var setUseShellExecute = new MethodReference("set_UseShellExecute", new TypeReference("", "Void", null, null), processStartInfoType)
+        {
+            HasThis = true
+        };
+        setUseShellExecute.Parameters.Add(new ParameterDefinition(new TypeReference("", "Boolean", null, null)));
+        var processStart = new MethodReference("Start", new TypeReference("", "Process", null, null),
+            new TypeReference("System.Diagnostics", "Process", null, null));
+        processStart.Parameters.Add(new ParameterDefinition(processStartInfoType));
 
         processor.Emit(OpCodes.Ldarg_0);
-        processor.Emit(OpCodes.Call, new MethodReference("Exists", new TypeReference("", "Boolean", null, null), new TypeReference("System.IO", "Directory", null, null)));
+        processor.Emit(OpCodes.Call, createDirectory);
         processor.Emit(OpCodes.Pop);
+
+        processor.Emit(OpCodes.Newobj, constructor);
+        processor.Emit(OpCodes.Stloc, startInfoLocal);
+        processor.Emit(OpCodes.Ldloc, startInfoLocal);
         processor.Emit(OpCodes.Ldarg_0);
-        processor.Emit(OpCodes.Call, new MethodReference("CreateDirectory", new TypeReference("", "DirectoryInfo", null, null), new TypeReference("System.IO", "Directory", null, null)));
-        processor.Emit(OpCodes.Pop);
-        processor.Emit(OpCodes.Ldarg_0);
-        processor.Emit(OpCodes.Callvirt, new MethodReference("set_FileName", new TypeReference("", "Void", null, null), new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null)));
+        processor.Emit(OpCodes.Callvirt, setFileName);
+        processor.Emit(OpCodes.Ldloc, startInfoLocal);
         processor.Emit(OpCodes.Ldc_I4_1);
-        processor.Emit(OpCodes.Callvirt, new MethodReference("set_UseShellExecute", new TypeReference("", "Void", null, null), new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null)));
-        processor.Emit(OpCodes.Call, new MethodReference("Start", new TypeReference("", "Process", null, null), new TypeReference("System.Diagnostics", "Process", null, null)));
+        processor.Emit(OpCodes.Callvirt, setUseShellExecute);
+        processor.Emit(OpCodes.Ldloc, startInfoLocal);
+        processor.Emit(OpCodes.Call, processStart);
 
         var instructions = method.Body.Instructions;
         var callIndex = instructions.Count - 1;
 
-        var result = _rule.ShouldSuppressFinding(null!, instructions, callIndex, new MethodSignals());
+        var result = _rule.ShouldSuppressFinding(processStart, instructions, callIndex, new MethodSignals());
 
         result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_UnrelatedDirectoryCheckBeforeShellExecutable_ReturnsFalse()
+    {
+        var scenario = BuildShellFolderLaunchScenario(@"C:\BenignFolder", "powershell.exe", useDirectoryExists: true);
+
+        var result = _rule.ShouldSuppressFinding(scenario.ProcessStart, scenario.Instructions,
+            scenario.ProcessStartIndex, new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_DifferentDirectoryTargetBeforeShellLaunch_ReturnsFalse()
+    {
+        var scenario = BuildShellFolderLaunchScenario(@"C:\BenignFolder", "powershell.exe");
+
+        var result = _rule.ShouldSuppressFinding(scenario.ProcessStart, scenario.Instructions,
+            scenario.ProcessStartIndex, new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_ShellProtocolTarget_ReturnsFalse()
+    {
+        var scenario = BuildShellFolderLaunchScenario("shell:AppsFolder", "shell:AppsFolder");
+
+        var result = _rule.ShouldSuppressFinding(scenario.ProcessStart, scenario.Instructions,
+            scenario.ProcessStartIndex, new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_ComposedDynamicTarget_ReturnsFalse()
+    {
+        var scenario = BuildShellFolderLaunchScenario(
+            @"C:\Base\<dynamic via Next>",
+            @"C:\Base\<dynamic via Next>");
+
+        var result = _rule.ShouldSuppressFinding(scenario.ProcessStart, scenario.Instructions,
+            scenario.ProcessStartIndex, new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_ReassignedPathParameter_ReturnsFalse()
+    {
+        var scenario = BuildShellFolderLaunchScenario(
+            @"C:\BenignFolder",
+            "different.exe",
+            useParameterTarget: true,
+            reassignParameter: true);
+
+        var result = _rule.ShouldSuppressFinding(scenario.ProcessStart, scenario.Instructions,
+            scenario.ProcessStartIndex, new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_EarlyReturnDirectoryExistsGuard_ReturnsTrue()
+    {
+        var scenario = BuildShellFolderLaunchScenario(
+            @"C:\BenignFolder",
+            @"C:\BenignFolder",
+            useDirectoryExists: true,
+            earlyReturnExists: true);
+
+        var result = _rule.ShouldSuppressFinding(scenario.ProcessStart, scenario.Instructions,
+            scenario.ProcessStartIndex, new MethodSignals());
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_ConditionalStartInfoAliasStore_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("", "Void", null, null));
+        var processStartInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var alias = new VariableDefinition(processStartInfoType);
+        var first = new VariableDefinition(processStartInfoType);
+        var second = new VariableDefinition(processStartInfoType);
+        method.Body.Variables.Add(alias);
+        method.Body.Variables.Add(first);
+        method.Body.Variables.Add(second);
+        method.Parameters.Add(new ParameterDefinition(new TypeReference("System", "Boolean", null, null)));
+        var constructor = new MethodReference(".ctor", method.ReturnType, processStartInfoType) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, processStartInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(new TypeReference("System", "String", null, null)));
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stloc, first);
+        il.Emit(OpCodes.Ldloc, first);
+        il.Emit(OpCodes.Stloc, alias);
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stloc, second);
+        il.Emit(OpCodes.Ldarg_0);
+        var useAlias = Instruction.Create(OpCodes.Nop);
+        il.Emit(OpCodes.Brfalse, useAlias);
+        il.Emit(OpCodes.Ldloc, second);
+        il.Emit(OpCodes.Stloc, alias);
+        il.Append(useAlias);
+        il.Emit(OpCodes.Ldloc, alias);
+        il.Emit(OpCodes.Ldstr, "folder");
+        il.Emit(OpCodes.Callvirt, setFileName);
+
+        var result = InstructionValueResolver.TryResolveCallReceiverIdentity(
+            method.Body.Instructions, method.Body.Instructions.Count - 1, out _);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_CreatedExtensionlessFolder_ReturnsTrue()
+    {
+        var scenario = BuildShellFolderLaunchScenario("powershell", "powershell");
+
+        var result = _rule.ShouldSuppressFinding(scenario.ProcessStart, scenario.Instructions,
+            scenario.ProcessStartIndex, new MethodSignals());
+
+        result.Should().BeTrue("successful directory creation proves this target is a folder, not an interpreter lookup");
     }
 
     [Fact]
@@ -976,6 +1134,89 @@ public class ProcessStartRuleTests
 
         // Assert - Should NOT suppress because type has file writes (cross-method attack)
         result.Should().BeFalse("Process.Start should NOT be suppressed when type has file writes in other methods");
+    }
+
+    private static (MethodReference ProcessStart, InstructionCollection Instructions, int ProcessStartIndex)
+        BuildShellFolderLaunchScenario(
+            string directoryTarget,
+            string fileNameTarget,
+            bool useDirectoryExists = false,
+            bool useParameterTarget = false,
+            bool reassignParameter = false,
+            bool earlyReturnExists = false)
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("", "Void", null, null));
+        var processor = method.Body.GetILProcessor();
+        var stringType = new TypeReference("System", "String", null, null);
+        var boolType = new TypeReference("System", "Boolean", null, null);
+        var voidType = new TypeReference("System", "Void", null, null);
+        var processStartInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var startInfoLocal = new VariableDefinition(processStartInfoType);
+        method.Body.Variables.Add(startInfoLocal);
+        ParameterDefinition? pathParameter = null;
+        if (useParameterTarget)
+        {
+            pathParameter = new ParameterDefinition(stringType);
+            method.Parameters.Add(pathParameter);
+        }
+
+        var directoryMethod = new MethodReference(
+            useDirectoryExists ? "Exists" : "CreateDirectory",
+            useDirectoryExists ? boolType : new TypeReference("System.IO", "DirectoryInfo", null, null),
+            new TypeReference("System.IO", "Directory", null, null));
+        directoryMethod.Parameters.Add(new ParameterDefinition(stringType));
+        var constructor = new MethodReference(".ctor", voidType, processStartInfoType) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", voidType, processStartInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var setUseShellExecute = new MethodReference("set_UseShellExecute", voidType, processStartInfoType)
+        {
+            HasThis = true
+        };
+        setUseShellExecute.Parameters.Add(new ParameterDefinition(boolType));
+        var processStart = new MethodReference("Start", new TypeReference("System.Diagnostics", "Process", null, null),
+            new TypeReference("System.Diagnostics", "Process", null, null));
+        processStart.Parameters.Add(new ParameterDefinition(processStartInfoType));
+
+        if (useParameterTarget)
+            processor.Emit(OpCodes.Ldarg, pathParameter!);
+        else
+            processor.Emit(OpCodes.Ldstr, directoryTarget);
+        processor.Emit(OpCodes.Call, directoryMethod);
+        Instruction? guardedLaunch = null;
+        if (useDirectoryExists && earlyReturnExists)
+        {
+            guardedLaunch = Instruction.Create(OpCodes.Nop);
+            processor.Emit(OpCodes.Brtrue, guardedLaunch);
+            processor.Emit(OpCodes.Ret);
+            processor.Append(guardedLaunch);
+        }
+        else
+        {
+            processor.Emit(OpCodes.Pop);
+        }
+
+        if (reassignParameter)
+        {
+            processor.Emit(OpCodes.Ldstr, fileNameTarget);
+            processor.Emit(OpCodes.Starg, pathParameter!);
+        }
+
+        processor.Emit(OpCodes.Newobj, constructor);
+        processor.Emit(OpCodes.Stloc, startInfoLocal);
+        processor.Emit(OpCodes.Ldloc, startInfoLocal);
+        if (useParameterTarget)
+            processor.Emit(OpCodes.Ldarg, pathParameter!);
+        else
+            processor.Emit(OpCodes.Ldstr, fileNameTarget);
+        processor.Emit(OpCodes.Callvirt, setFileName);
+        processor.Emit(OpCodes.Ldloc, startInfoLocal);
+        processor.Emit(OpCodes.Ldc_I4_1);
+        processor.Emit(OpCodes.Callvirt, setUseShellExecute);
+        processor.Emit(OpCodes.Ldloc, startInfoLocal);
+        processor.Emit(OpCodes.Call, processStart);
+
+        return (processStart, method.Body.Instructions, method.Body.Instructions.Count - 1);
     }
 
     #endregion

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -145,6 +145,162 @@ namespace MLVScan.Models.Rules.Helpers
             return true;
         }
 
+        /// <summary>
+        /// Tries to identify the receiver consumed by an instance call.
+        /// </summary>
+        public static bool TryResolveCallReceiverIdentity(
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            int callIndex,
+            out string identity)
+        {
+            identity = string.Empty;
+            var producerMap = CallArgumentProducerMaps.GetValue(instructions, BuildCallArgumentProducerMap);
+            return producerMap.TryGetReceiverProducer(callIndex, out int producerIndex) &&
+                   TryBuildProducerIdentity(instructions, producerIndex, out identity);
+        }
+
+        /// <summary>
+        /// Tries to identify one argument consumed by a call.
+        /// </summary>
+        public static bool TryResolveCallArgumentIdentity(
+            MethodReference calledMethod,
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            int callIndex,
+            int argumentIndex,
+            out string identity)
+        {
+            identity = string.Empty;
+            if (argumentIndex < 0 || argumentIndex >= calledMethod.Parameters.Count)
+                return false;
+
+            var producerMap = CallArgumentProducerMaps.GetValue(instructions, BuildCallArgumentProducerMap);
+            return producerMap.TryGetProducer(callIndex, calledMethod.Parameters.Count, argumentIndex,
+                       out int producerIndex) &&
+                   TryBuildProducerIdentity(instructions, producerIndex, out identity);
+        }
+
+        private static bool TryBuildProducerIdentity(
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            int producerIndex,
+            out string identity)
+        {
+            return TryBuildProducerIdentity(instructions, producerIndex, 0, out identity);
+        }
+
+        private static bool TryBuildProducerIdentity(
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            int producerIndex,
+            int depth,
+            out string identity)
+        {
+            identity = string.Empty;
+            if (producerIndex < 0 || producerIndex >= instructions.Count || depth > MaxDepth)
+                return false;
+
+            var producer = instructions[producerIndex];
+            if (TryGetLoadedLocalIndex(producer, out int localIndex))
+            {
+                for (int i = producerIndex - 1; i >= 0; i--)
+                {
+                    if (!TryGetStoredLocalIndex(instructions[i], out int storedLocalIndex) ||
+                        storedLocalIndex != localIndex)
+                    {
+                        continue;
+                    }
+
+                    if (!HasUnambiguousLinearReach(instructions, i, producerIndex))
+                        return false;
+
+                    var producerMap = CallArgumentProducerMaps.GetValue(instructions, BuildCallArgumentProducerMap);
+                    return producerMap.TryGetStoredValueProducer(i, out int storedValueProducer) &&
+                           TryBuildProducerIdentity(instructions, storedValueProducer, depth + 1, out identity);
+                }
+
+                return false;
+            }
+
+            identity = producer.OpCode.Code switch
+            {
+                Code.Ldarg_0 => "argument:0",
+                Code.Ldarg_1 => "argument:1",
+                Code.Ldarg_2 => "argument:2",
+                Code.Ldarg_3 => "argument:3",
+                Code.Ldarg or Code.Ldarg_S when producer.Operand is ParameterDefinition parameter =>
+                    $"argument:{parameter.Index + (parameter.Method?.HasThis == true ? 1 : 0)}",
+                Code.Newobj => $"new:{producerIndex}",
+                _ => string.Empty
+            };
+
+            return identity.Length > 0;
+        }
+
+        private static bool TryGetLoadedLocalIndex(Instruction instruction, out int localIndex)
+        {
+            localIndex = instruction.OpCode.Code switch
+            {
+                Code.Ldloc_0 => 0,
+                Code.Ldloc_1 => 1,
+                Code.Ldloc_2 => 2,
+                Code.Ldloc_3 => 3,
+                Code.Ldloc or Code.Ldloc_S when instruction.Operand is VariableDefinition variable => variable.Index,
+                _ => -1
+            };
+
+            return localIndex >= 0;
+        }
+
+        private static bool HasUnambiguousLinearReach(
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            int definitionIndex,
+            int useIndex)
+        {
+            for (int i = definitionIndex + 1; i < useIndex; i++)
+            {
+                var flowControl = instructions[i].OpCode.FlowControl;
+                if (flowControl is FlowControl.Branch or FlowControl.Cond_Branch or
+                    FlowControl.Return or FlowControl.Throw)
+                {
+                    return false;
+                }
+            }
+
+            for (int i = 0; i < instructions.Count; i++)
+            {
+                if (instructions[i].Operand is Instruction target)
+                {
+                    int targetIndex = instructions.IndexOf(target);
+                    if (targetIndex > definitionIndex && targetIndex <= useIndex)
+                        return false;
+                }
+                else if (instructions[i].Operand is Instruction[] targets)
+                {
+                    foreach (var switchTarget in targets)
+                    {
+                        int targetIndex = instructions.IndexOf(switchTarget);
+                        if (targetIndex > definitionIndex && targetIndex <= useIndex)
+                            return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private static bool TryGetStoredLocalIndex(Instruction instruction, out int localIndex)
+        {
+            localIndex = instruction.OpCode.Code switch
+            {
+                Code.Stloc_0 => 0,
+                Code.Stloc_1 => 1,
+                Code.Stloc_2 => 2,
+                Code.Stloc_3 => 3,
+                Code.Stloc or Code.Stloc_S when instruction.Operand is VariableDefinition variable => variable.Index,
+                _ => -1
+            };
+
+            return localIndex >= 0;
+        }
+
         private static bool TryResolveCallArgumentFromBasicBlock(
             ResolverContext context,
             MethodDefinition? containingMethod,
@@ -202,7 +358,8 @@ namespace MLVScan.Models.Rules.Helpers
                 }
             }
 
-            var producersByCallIndex = new Dictionary<int, int[]>();
+            var producersByCallIndex = new Dictionary<int, CallProducers>();
+            var producersByStoreIndex = new Dictionary<int, int>();
             var stack = new List<int>();
             bool validBlock = true;
 
@@ -218,18 +375,29 @@ namespace MLVScan.Models.Rules.Helpers
                     continue;
 
                 var instruction = instructions[i];
+                if (TryGetStoredLocalIndex(instruction, out _) && stack.Count > 0)
+                {
+                    producersByStoreIndex[i] = stack[^1];
+                }
+
                 if ((instruction.OpCode == OpCodes.Call || instruction.OpCode == OpCodes.Callvirt) &&
                     instruction.Operand is MethodReference calledMethod &&
-                    calledMethod.Parameters.Count <= MaxTrackedCallArguments &&
-                    stack.Count >= calledMethod.Parameters.Count)
+                    calledMethod.Parameters.Count <= MaxTrackedCallArguments)
                 {
                     int parameterCount = calledMethod.Parameters.Count;
-                    int firstArgumentIndex = stack.Count - parameterCount;
-                    var argumentProducers = new int[parameterCount];
-                    for (int argumentIndex = 0; argumentIndex < parameterCount; argumentIndex++)
-                        argumentProducers[argumentIndex] = stack[firstArgumentIndex + argumentIndex];
+                    int receiverCount = calledMethod.HasThis ? 1 : 0;
+                    int consumedCount = parameterCount + receiverCount;
+                    if (stack.Count >= consumedCount)
+                    {
+                        int firstConsumedIndex = stack.Count - consumedCount;
+                        int receiverProducer = receiverCount == 1 ? stack[firstConsumedIndex] : -1;
+                        int firstArgumentIndex = stack.Count - parameterCount;
+                        var argumentProducers = new int[parameterCount];
+                        for (int argumentIndex = 0; argumentIndex < parameterCount; argumentIndex++)
+                            argumentProducers[argumentIndex] = stack[firstArgumentIndex + argumentIndex];
 
-                    producersByCallIndex[i] = argumentProducers;
+                        producersByCallIndex[i] = new CallProducers(argumentProducers, receiverProducer);
+                    }
                 }
 
                 if (instruction.OpCode == OpCodes.Dup)
@@ -265,7 +433,7 @@ namespace MLVScan.Models.Rules.Helpers
                     stack.Add(i);
             }
 
-            return new CallArgumentProducerMap(producersByCallIndex);
+            return new CallArgumentProducerMap(producersByCallIndex, producersByStoreIndex);
         }
 
         private static bool IsArrayElementStore(Instruction instruction)
@@ -277,25 +445,54 @@ namespace MLVScan.Models.Rules.Helpers
 
         private sealed class CallArgumentProducerMap
         {
-            private readonly Dictionary<int, int[]> _producersByCallIndex;
+            private readonly Dictionary<int, CallProducers> _producersByCallIndex;
+            private readonly Dictionary<int, int> _producersByStoreIndex;
 
-            public CallArgumentProducerMap(Dictionary<int, int[]> producersByCallIndex)
+            public CallArgumentProducerMap(
+                Dictionary<int, CallProducers> producersByCallIndex,
+                Dictionary<int, int> producersByStoreIndex)
             {
                 _producersByCallIndex = producersByCallIndex;
+                _producersByStoreIndex = producersByStoreIndex;
             }
 
             public bool TryGetProducer(int callIndex, int parameterCount, int argumentIndex, out int producerIndex)
             {
                 producerIndex = -1;
                 if (!_producersByCallIndex.TryGetValue(callIndex, out var producers) ||
-                    producers.Length != parameterCount || argumentIndex < 0 || argumentIndex >= producers.Length)
+                    producers.Arguments.Length != parameterCount || argumentIndex < 0 ||
+                    argumentIndex >= producers.Arguments.Length)
                 {
                     return false;
                 }
 
-                producerIndex = producers[argumentIndex];
+                producerIndex = producers.Arguments[argumentIndex];
                 return true;
             }
+
+            public bool TryGetReceiverProducer(int callIndex, out int producerIndex)
+            {
+                producerIndex = -1;
+                return _producersByCallIndex.TryGetValue(callIndex, out var producers) &&
+                       (producerIndex = producers.Receiver) >= 0;
+            }
+
+            public bool TryGetStoredValueProducer(int storeIndex, out int producerIndex)
+            {
+                return _producersByStoreIndex.TryGetValue(storeIndex, out producerIndex);
+            }
+        }
+
+        private readonly struct CallProducers
+        {
+            public CallProducers(int[] arguments, int receiver)
+            {
+                Arguments = arguments;
+                Receiver = receiver;
+            }
+
+            public int[] Arguments { get; }
+            public int Receiver { get; }
         }
 
         /// <summary>
@@ -754,6 +951,11 @@ namespace MLVScan.Models.Rules.Helpers
 
             if (instruction.TryGetArgumentIndex(out int argumentIndex))
             {
+                if (instruction.Operand is ParameterDefinition parameter && parameter.Method?.HasThis == true)
+                {
+                    argumentIndex++;
+                }
+
                 if (argumentMap != null && argumentMap.TryGetValue(argumentIndex, out var mapped))
                 {
                     value = mapped;

--- a/Models/Rules/ProcessStartRule.cs
+++ b/Models/Rules/ProcessStartRule.cs
@@ -650,7 +650,7 @@ namespace MLVScan.Models.Rules
                 return true;
             }
 
-            if (IsSafeShellFolderLaunch(instructions, instructionIndex))
+            if (IsSafeShellFolderLaunch(method, instructions, instructionIndex))
             {
                 return true;
             }
@@ -694,19 +694,22 @@ namespace MLVScan.Models.Rules
         }
 
         private static bool IsSafeShellFolderLaunch(
+            MethodReference processStartMethod,
             Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
             int processStartIndex)
         {
-            var hasUseShell = InstructionValueResolver.TryResolveUseShellExecute(null, instructions, processStartIndex,
-                out var useShell);
-
-            if (!hasUseShell || useShell != true)
+            if (processStartMethod == null ||
+                processStartMethod.Parameters.Count != 1 ||
+                processStartMethod.Parameters[0].ParameterType.FullName != "System.Diagnostics.ProcessStartInfo" ||
+                !InstructionValueResolver.TryResolveCallArgumentIdentity(processStartMethod, instructions,
+                    processStartIndex, 0, out var launchedStartInfoIdentity))
             {
                 return false;
             }
 
-            bool touchesDirectoryApis = false;
-            bool setsFileName = false;
+            var checkedDirectoryTargets = new Dictionary<string, int>(StringComparer.Ordinal);
+            string? fileNameTarget = null;
+            bool useShell = false;
             bool setsArguments = false;
             int searchStart = Math.Max(0, processStartIndex - 40);
             for (int i = searchStart; i < processStartIndex; i++)
@@ -721,25 +724,271 @@ namespace MLVScan.Models.Rules
                 if (methodRef.DeclaringType?.FullName == "System.IO.Directory" &&
                     (methodRef.Name == "Exists" || methodRef.Name == "CreateDirectory"))
                 {
-                    touchesDirectoryApis = true;
+                    if (InstructionValueResolver.TryResolveCallArgumentDisplay(null, methodRef, instructions, i, 0,
+                            out var directoryTarget))
+                    {
+                        bool validatesDirectory = methodRef.Name == "CreateDirectory"
+                            ? HasStraightLineDominance(instructions, i, processStartIndex)
+                            : IsTrueDirectoryExistsGuard(instructions, i, processStartIndex) ||
+                              IsEnsureDirectoryGuard(instructions, i, processStartIndex, directoryTarget);
+                        if (validatesDirectory)
+                        {
+                            checkedDirectoryTargets[directoryTarget] = i;
+                        }
+                    }
+
                     continue;
                 }
 
                 if (methodRef.DeclaringType?.FullName == "System.Diagnostics.ProcessStartInfo" &&
                     methodRef.Name == "set_FileName")
                 {
-                    setsFileName = true;
+                    if (HasMatchingReceiverIdentity(instructions, i, launchedStartInfoIdentity) &&
+                        HasStraightLineDominance(instructions, i, processStartIndex) &&
+                        InstructionValueResolver.TryResolveStackValueDisplay(null, instructions, i - 1,
+                            out var resolvedFileName))
+                    {
+                        fileNameTarget = resolvedFileName;
+                    }
+
+                    continue;
+                }
+
+                if (methodRef.DeclaringType?.FullName == "System.Diagnostics.ProcessStartInfo" &&
+                    methodRef.Name == "set_UseShellExecute")
+                {
+                    if (HasMatchingReceiverIdentity(instructions, i, launchedStartInfoIdentity) &&
+                        HasStraightLineDominance(instructions, i, processStartIndex) &&
+                        InstructionValueResolver.TryResolveStackValueDisplay(null, instructions, i - 1,
+                            out var resolvedUseShell))
+                    {
+                        useShell = resolvedUseShell is "True" or "true" or "1";
+                    }
+
                     continue;
                 }
 
                 if (methodRef.DeclaringType?.FullName == "System.Diagnostics.ProcessStartInfo" &&
                     methodRef.Name == "set_Arguments")
                 {
-                    setsArguments = true;
+                    if (HasMatchingReceiverIdentity(instructions, i, launchedStartInfoIdentity))
+                    {
+                        setsArguments = true;
+                    }
                 }
             }
 
-            return touchesDirectoryApis && setsFileName && !setsArguments;
+            return useShell &&
+                   !setsArguments &&
+                   fileNameTarget != null &&
+                   !IsUnsafeShellTarget(fileNameTarget) &&
+                   checkedDirectoryTargets.TryGetValue(fileNameTarget, out int validationIndex) &&
+                   !HasStoredArgumentBetween(fileNameTarget, instructions, validationIndex, processStartIndex);
+        }
+
+        private static bool HasMatchingReceiverIdentity(
+            Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
+            int callIndex,
+            string expectedIdentity)
+        {
+            return InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, callIndex,
+                       out var receiverIdentity) &&
+                   receiverIdentity == expectedIdentity;
+        }
+
+        private static bool IsTrueDirectoryExistsGuard(
+            Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
+            int existsCallIndex,
+            int processStartIndex)
+        {
+            int branchIndex = existsCallIndex + 1;
+            if (branchIndex >= instructions.Count ||
+                instructions[branchIndex].Operand is not Instruction branchTarget)
+            {
+                return false;
+            }
+
+            int targetIndex = instructions.IndexOf(branchTarget);
+            var branchOp = instructions[branchIndex].OpCode;
+            if (branchOp == OpCodes.Brfalse || branchOp == OpCodes.Brfalse_S)
+            {
+                return targetIndex > processStartIndex &&
+                       HasStraightLineDominance(instructions, branchIndex, processStartIndex);
+            }
+
+            if (instructions[branchIndex].OpCode != OpCodes.Brtrue &&
+                instructions[branchIndex].OpCode != OpCodes.Brtrue_S)
+            {
+                return false;
+            }
+
+            if (targetIndex <= branchIndex || targetIndex > processStartIndex ||
+                !HasTerminatingFallthrough(instructions, branchIndex + 1, targetIndex) ||
+                !HasStraightLineDominance(instructions, targetIndex, processStartIndex))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool HasTerminatingFallthrough(
+            Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
+            int startIndex,
+            int endIndex)
+        {
+            for (int i = startIndex; i < endIndex; i++)
+            {
+                var flowControl = instructions[i].OpCode.FlowControl;
+                if (flowControl is FlowControl.Return or FlowControl.Throw)
+                    return true;
+
+                if (flowControl is FlowControl.Branch or FlowControl.Cond_Branch)
+                    return false;
+            }
+
+            return false;
+        }
+
+        private static bool HasStoredArgumentBetween(
+            string target,
+            Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
+            int startIndex,
+            int endIndex)
+        {
+            const string prefix = "<arg ";
+            int markerEnd = target.IndexOf('>', prefix.Length);
+            if (!target.StartsWith(prefix, StringComparison.Ordinal) ||
+                markerEnd < 0 ||
+                !int.TryParse(target.Substring(prefix.Length, markerEnd - prefix.Length), out int argumentIndex))
+            {
+                return false;
+            }
+
+            for (int i = startIndex + 1; i < endIndex; i++)
+            {
+                var instruction = instructions[i];
+                if ((instruction.OpCode != OpCodes.Starg && instruction.OpCode != OpCodes.Starg_S) ||
+                    instruction.Operand is not ParameterDefinition parameter)
+                {
+                    continue;
+                }
+
+                int storedArgumentIndex = parameter.Index + (parameter.Method?.HasThis == true ? 1 : 0);
+                if (storedArgumentIndex == argumentIndex)
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static bool HasStraightLineDominance(
+            Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
+            int validationIndex,
+            int processStartIndex)
+        {
+            for (int i = validationIndex + 1; i < processStartIndex; i++)
+            {
+                var flowControl = instructions[i].OpCode.FlowControl;
+                if (flowControl is FlowControl.Branch or FlowControl.Cond_Branch or
+                    FlowControl.Return or FlowControl.Throw)
+                {
+                    return false;
+                }
+            }
+
+            for (int i = 0; i < instructions.Count; i++)
+            {
+                if (instructions[i].Operand is Instruction target)
+                {
+                    int targetIndex = instructions.IndexOf(target);
+                    if (targetIndex > validationIndex && targetIndex <= processStartIndex)
+                        return false;
+                }
+                else if (instructions[i].Operand is Instruction[] targets)
+                {
+                    foreach (var switchTarget in targets)
+                    {
+                        int targetIndex = instructions.IndexOf(switchTarget);
+                        if (targetIndex > validationIndex && targetIndex <= processStartIndex)
+                            return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private static bool IsEnsureDirectoryGuard(
+            Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
+            int existsCallIndex,
+            int processStartIndex,
+            string existsTarget)
+        {
+            int branchIndex = existsCallIndex + 1;
+            if (branchIndex >= instructions.Count ||
+                (instructions[branchIndex].OpCode != OpCodes.Brtrue &&
+                 instructions[branchIndex].OpCode != OpCodes.Brtrue_S) ||
+                instructions[branchIndex].Operand is not Instruction joinTarget)
+            {
+                return false;
+            }
+
+            int joinIndex = instructions.IndexOf(joinTarget);
+            if (joinIndex <= branchIndex || joinIndex >= processStartIndex ||
+                !HasStraightLineDominance(instructions, joinIndex, processStartIndex))
+            {
+                return false;
+            }
+
+            bool createsMatchingDirectory = false;
+            for (int i = branchIndex + 1; i < joinIndex; i++)
+            {
+                var flowControl = instructions[i].OpCode.FlowControl;
+                if (flowControl is FlowControl.Branch or FlowControl.Cond_Branch or
+                    FlowControl.Return or FlowControl.Throw)
+                {
+                    return false;
+                }
+
+                if ((instructions[i].OpCode == OpCodes.Call || instructions[i].OpCode == OpCodes.Callvirt) &&
+                    instructions[i].Operand is MethodReference methodRef &&
+                    methodRef.DeclaringType?.FullName == "System.IO.Directory" &&
+                    methodRef.Name == "CreateDirectory" &&
+                    InstructionValueResolver.TryResolveCallArgumentDisplay(null, methodRef, instructions, i, 0,
+                        out var createTarget) &&
+                    createTarget == existsTarget &&
+                    HasStraightLineDominance(instructions, branchIndex, i))
+                {
+                    createsMatchingDirectory = true;
+                }
+            }
+
+            return createsMatchingDirectory;
+        }
+
+        private static bool IsUnsafeShellTarget(string target)
+        {
+            var normalized = target.Trim().Trim('"');
+            if (normalized.Length == 0 ||
+                normalized.IndexOf("<unknown", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                normalized.IndexOf("<dynamic", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                normalized.IndexOf("<field ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                normalized.IndexOf("<static-field ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                normalized.IndexOf("<local ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                normalized.StartsWith(@"\\", StringComparison.Ordinal) ||
+                normalized.Contains("://"))
+            {
+                return true;
+            }
+
+            int colonIndex = normalized.IndexOf(':');
+            if (colonIndex >= 0 && !(colonIndex == 1 && char.IsLetter(normalized[0])))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private static bool HasPathManipulation(


### PR DESCRIPTION
## Summary

- bind benign shell-folder suppression to an exactly resolved directory target and launched start-info instance
- fail closed for ambiguous values, receiver aliases, reassigned parameters, arguments, and non-folder targets
- recognize proven directory-existence guards, including a terminating early-return form
- add focused regressions for safe launches and conservative rejection paths

## Validation

- focused resolver, ProcessStart, edge-case, and Musicfy coverage: 108 passed
- false-positive surface: 54 passed, 6 optional samples skipped; all present corpus assemblies remain Clean with no threat family
- quarantine surface: 180 passed, 1 optional paired sample skipped; all present samples remain KnownThreat
- full solution: 1,562 passed, 18 expected skips

Security-sensitive reproduction details are intentionally omitted from this public PR.