### PR TITLE
Preserve contextual findings for dynamic loads and exception handlers

### DIFF
--- a/MLVScan.Core.Tests/Integration/SecurityRegressionEdgeCaseTests.cs
+++ b/MLVScan.Core.Tests/Integration/SecurityRegressionEdgeCaseTests.cs
@@ -247,6 +247,39 @@ public class SecurityRegressionEdgeCaseTests
             f.Description.Contains("unknown", StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public void Scan_UncorrelatedRelativeAssemblyPath_RetainsLowAuditFinding()
+    {
+        var assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition("OptionalDependencyLoader", new Version(1, 0, 0, 0)),
+            "OptionalDependencyLoader",
+            ModuleKind.Dll);
+        var module = assembly.MainModule;
+        var type = new TypeDefinition("Legit", "PluginLoader", TypeAttributes.Public | TypeAttributes.Class,
+            module.TypeSystem.Object);
+        module.Types.Add(type);
+        var method = new MethodDefinition("LoadOptionalDependency",
+            MethodAttributes.Public | MethodAttributes.Static, module.TypeSystem.Void);
+        type.Methods.Add(method);
+        var il = method.Body.GetILProcessor();
+        var loadFrom = CreateStaticMethod(module, "System.Reflection.Assembly", "LoadFrom",
+            CreateType(module, "System.Reflection.Assembly"), module.TypeSystem.String);
+        il.Emit(OpCodes.Ldstr, "Plugins\\OptionalDependency.dll");
+        il.Emit(OpCodes.Call, loadFrom);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        using var stream = new MemoryStream();
+        assembly.Write(stream);
+        stream.Position = 0;
+        var scanner = new AssemblyScanner(RuleFactory.CreateDefaultRules());
+
+        var findings = scanner.Scan(stream, "OptionalDependencyLoader.dll").ToList();
+
+        findings.Should().ContainSingle(f => f.RuleId == "AssemblyDynamicLoadRule");
+        findings.Single(f => f.RuleId == "AssemblyDynamicLoadRule").Severity.Should().Be(Severity.Low);
+    }
+
     private sealed class ThrowingPostAnalysisRule : IScanRule
     {
         public string Description => "Throws during post-analysis";

--- a/MLVScan.Core.Tests/Unit/Rules/AssemblyDynamicLoadRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/AssemblyDynamicLoadRuleTests.cs
@@ -515,6 +515,26 @@ public class AssemblyDynamicLoadRuleTests
         findings.Should().NotBeEmpty();
     }
 
+    [Theory]
+    [InlineData("Plugins\\OptionalDependency.dll")]
+    [InlineData("\\\\server\\share\\OptionalDependency.dll")]
+    public void AnalyzeContextualPattern_PathLoadWithoutStagingSignals_ProducesLowAuditFinding(string path)
+    {
+        var methodRef = CreateAssemblyLoadMethod("System.String");
+        methodRef.Name = "LoadFrom";
+        var instructions = new Mono.Collections.Generic.Collection<Instruction>
+        {
+            Instruction.Create(OpCodes.Ldstr, path),
+            Instruction.Create(OpCodes.Call, methodRef)
+        };
+
+        var findings = _rule.AnalyzeContextualPattern(methodRef, instructions, 1, new MethodSignals()).ToList();
+
+        findings.Should().ContainSingle();
+        findings[0].Severity.Should().Be(Severity.Low);
+        findings[0].BypassCompanionCheck.Should().BeFalse();
+    }
+
     [Fact]
     public void ShouldSuppressFinding_SafeAssemblyNameLoad_ReturnsTrue()
     {

--- a/MLVScan.Core.Tests/Unit/Services/ExceptionHandlerAnalyzerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/ExceptionHandlerAnalyzerTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using MLVScan.Abstractions;
 using MLVScan.Models;
+using MLVScan.Models.Rules;
 using MLVScan.Services;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -53,6 +54,24 @@ public class ExceptionHandlerAnalyzerTests
         methodSignals.HasTriggeredRuleOtherThan("SomeOtherRule").Should().BeTrue();
     }
 
+    [Fact]
+    public void AnalyzeExceptionHandlers_WithUncorrelatedPathLoad_RetainsLowContextualFinding()
+    {
+        var config = new ScanConfig { AnalyzeExceptionHandlers = true, EnableMultiSignalDetection = true };
+        var tracker = new SignalTracker(config);
+        var analyzer = new ExceptionHandlerAnalyzer([new AssemblyDynamicLoadRule()], tracker,
+            new CodeSnippetBuilder(), config);
+        var method = CreateMethodWithCatchLoadingPath();
+
+        var findings = analyzer.AnalyzeExceptionHandlers(method, method.Body.ExceptionHandlers,
+            new MethodSignals(), method.DeclaringType!.FullName).ToList();
+
+        findings.Should().ContainSingle();
+        findings[0].RuleId.Should().Be("AssemblyDynamicLoadRule");
+        findings[0].Severity.Should().Be(Severity.Low);
+        findings[0].Description.Should().Contain("exception catch block");
+    }
+
     private static MethodDefinition CreateMethodWithCatchCalling(string calledType, string calledMethod)
     {
         var assembly = AssemblyDefinition.CreateAssembly(
@@ -102,6 +121,21 @@ public class ExceptionHandlerAnalyzerTests
             CatchType = module.ImportReference(typeof(Exception))
         });
 
+        return method;
+    }
+
+    private static MethodDefinition CreateMethodWithCatchLoadingPath()
+    {
+        var method = CreateMethodWithCatchCalling("System.Reflection.Assembly", "LoadFrom");
+        var call = method.Body.Instructions.Single(i =>
+            i.OpCode == OpCodes.Call && i.Operand is MethodReference reference && reference.Name == "LoadFrom");
+        var loadFrom = (MethodReference)call.Operand;
+        loadFrom.ReturnType = new TypeReference("System.Reflection", "Assembly", method.Module,
+            method.Module.TypeSystem.CoreLibrary);
+        loadFrom.Parameters.Add(new ParameterDefinition(method.Module.TypeSystem.String));
+        var il = method.Body.GetILProcessor();
+        il.InsertBefore(call, il.Create(OpCodes.Ldstr, "Plugins\\OptionalDependency.dll"));
+        il.InsertAfter(call, il.Create(OpCodes.Pop));
         return method;
     }
 

--- a/Models/Rules/AssemblyDynamicLoadRule.cs
+++ b/Models/Rules/AssemblyDynamicLoadRule.cs
@@ -135,11 +135,14 @@ namespace MLVScan.Models.Rules
             if (!ShouldReportDirectLoad(overload, provenance, postLoadScore, correlationScore))
                 yield break;
 
+            bool auditOnlyPathLoad = IsPathBasedDirectLoad(overload) &&
+                                     !HasDirectLoadRiskIndicators(provenance, postLoadScore, correlationScore);
+
             int totalScore = baseScore + provenanceScore + postLoadScore + evasionScore + resolveScore +
                              correlationScore;
 
             // Map score to severity
-            var severity = MapScoreToSeverity(totalScore);
+            var severity = auditOnlyPathLoad ? Severity.Low : MapScoreToSeverity(totalScore);
 
             if (severity == null)
                 yield break; // Score too low to report
@@ -290,6 +293,9 @@ namespace MLVScan.Models.Rules
 
             if (typeSignals != null)
                 correlationScore = Math.Max(correlationScore, ComputeCorrelationScore(typeSignals));
+
+            if (IsPathBasedDirectLoad(overload))
+                return !HasDirectLoadRiskIndicators(provenance, postLoadScore, correlationScore);
 
             return !ShouldReportDirectLoad(overload, provenance, postLoadScore, correlationScore);
         }
@@ -457,24 +463,30 @@ namespace MLVScan.Models.Rules
             if (overload == LoadOverload.LoadBytes ||
                 overload == LoadOverload.LoadBytesWithPdb ||
                 overload == LoadOverload.ALCLoadFromStream ||
-                overload == LoadOverload.ALCLoadFromStreamPdb)
+                overload == LoadOverload.ALCLoadFromStreamPdb ||
+                IsPathBasedDirectLoad(overload))
             {
                 return true;
             }
 
-            if (provenance.HasNetworkSource ||
-                provenance.HasBase64 ||
-                provenance.HasCrypto ||
-                provenance.HasCompression ||
-                provenance.HasResourceSource ||
-                provenance.HasTempPath ||
-                provenance.HasSensitivePath ||
-                provenance.HasWriteThenLoad)
-            {
-                return true;
-            }
+            return HasDirectLoadRiskIndicators(provenance, postLoadScore, correlationScore);
+        }
 
-            return postLoadScore > 0 || correlationScore > 0;
+        private static bool HasDirectLoadRiskIndicators(
+            ProvenanceResult provenance,
+            int postLoadScore,
+            int correlationScore)
+        {
+            return provenance.HasNetworkSource ||
+                   provenance.HasBase64 ||
+                   provenance.HasCrypto ||
+                   provenance.HasCompression ||
+                   provenance.HasResourceSource ||
+                   provenance.HasTempPath ||
+                   provenance.HasSensitivePath ||
+                   provenance.HasWriteThenLoad ||
+                   postLoadScore > 0 ||
+                   correlationScore > 0;
         }
 
         #endregion

--- a/Services/ExceptionHandlerAnalyzer.cs
+++ b/Services/ExceptionHandlerAnalyzer.cs
@@ -91,6 +91,56 @@ namespace MLVScan.Services
                             if (rule.IsSuspicious(calledMethod))
                             {
                                 var instructionIndex = allInstructions.IndexOf(instruction);
+                                var effectiveSignals = methodSignals ?? new MethodSignals();
+                                var handlerTypeDesc = GetHandlerTypeDescription(handler);
+                                bool addedContextualFinding = false;
+
+                                if (instructionIndex >= 0)
+                                {
+                                    foreach (var contextualFinding in rule.AnalyzeContextualPattern(
+                                                 calledMethod, allInstructions, instructionIndex, effectiveSignals))
+                                    {
+                                        if (rule.RequiresCompanionFinding &&
+                                            contextualFinding.Severity != Severity.Low &&
+                                            !contextualFinding.BypassCompanionCheck)
+                                        {
+                                            bool hasOtherMethodRule = methodSignals != null &&
+                                                                      methodSignals.HasTriggeredRuleOtherThan(
+                                                                          rule.RuleId);
+                                            var typeSignals = string.IsNullOrEmpty(typeFullName)
+                                                ? null
+                                                : _signalTracker.GetTypeSignals(typeFullName);
+                                            bool hasOtherTypeRule = typeSignals != null &&
+                                                                    typeSignals.HasTriggeredRuleOtherThan(rule.RuleId);
+                                            if (!hasOtherMethodRule && !hasOtherTypeRule)
+                                                continue;
+                                        }
+
+                                        contextualFinding.Description += $" (found in exception {handlerTypeDesc})";
+                                        contextualFinding.RuleId = rule.RuleId;
+                                        contextualFinding.DeveloperGuidance = rule.DeveloperGuidance;
+                                        findings.Add(contextualFinding);
+                                        addedContextualFinding = true;
+
+                                        if (methodSignals != null &&
+                                            !(rule.RequiresCompanionFinding &&
+                                              contextualFinding.Severity == Severity.Low))
+                                        {
+                                            _signalTracker.MarkRuleTriggered(methodSignals, method.DeclaringType,
+                                                rule.RuleId);
+                                        }
+
+                                        if (methodSignals != null)
+                                        {
+                                            _signalTracker.MarkSuspiciousExceptionHandling(methodSignals,
+                                                method.DeclaringType);
+                                        }
+                                    }
+                                }
+
+                                if (addedContextualFinding)
+                                    continue;
+
                                 if (instructionIndex >= 0 &&
                                     methodSignals != null &&
                                     rule.ShouldSuppressFinding(calledMethod, allInstructions, instructionIndex,
@@ -101,7 +151,6 @@ namespace MLVScan.Services
 
                                 var snippet = _snippetBuilder.BuildSnippet(allInstructions, instructionIndex, 2);
 
-                                var handlerTypeDesc = GetHandlerTypeDescription(handler);
                                 var finding = new ScanFinding(
                                     $"{method.DeclaringType?.FullName}.{method.Name}:{instruction.Offset}",
                                     rule.Description + $" (found in exception {handlerTypeDesc})",


### PR DESCRIPTION
## Summary

- retain an audit-visible finding for uncorrelated path-based assembly loads
- keep benign optional-dependency loads at Low severity while preserving existing risk escalation
- run contextual rule analysis inside exception handlers and avoid generic duplicate findings
- cover relative and network paths, catch-block handling, and the end-to-end scanner pipeline

## Validation

- focused dynamic-load and exception-handler coverage: 53 passed
- false-positive surface: 54 passed, 6 optional samples skipped; all present corpus assemblies remain Clean with no threat family
- quarantine surface: 180 passed, 1 optional paired sample skipped; all present samples remain KnownThreat
- full solution: 1,566 passed, 18 expected skips

Security-sensitive reproduction details are intentionally omitted from this public PR.