### PR TITLE
Preserve data-flow exfiltration findings

### DIFF
--- a/MLVScan.Core.Tests/Integration/FalsePositiveEdgeCaseTests.cs
+++ b/MLVScan.Core.Tests/Integration/FalsePositiveEdgeCaseTests.cs
@@ -563,7 +563,7 @@ public class FalsePositiveEdgeCaseTests
     }
 
     [Fact]
-    public void Scan_TelemetryUploadDataFlow_DoesNotEmitStandaloneMalwareFinding()
+    public void Scan_TelemetryUploadDataFlow_EmitsNonBlockingAuditFinding()
     {
         var builder = TestAssemblyBuilder.Create("BenignTelemetryUpload");
         var module = builder.Module;
@@ -583,8 +583,14 @@ public class FalsePositiveEdgeCaseTests
 
         var findings = Scan(assembly, "BenignTelemetryUpload.dll");
 
-        findings.Should().NotContain(f => f.RuleId == "DataFlowAnalysis",
-            "plain data exfiltration-shaped telemetry should require stronger context before becoming a standalone malware finding");
+        findings.Should().ContainSingle(f =>
+            f.RuleId == "DataFlowAnalysis" && f.Severity == Severity.Medium,
+            "plain upload-shaped telemetry should remain visible without becoming a blocking malware finding");
+
+        var dto = ScanResultMapper.ToDto(findings, "BenignTelemetryUpload.dll", Array.Empty<byte>(), false);
+        dto.Disposition.Should().NotBeNull();
+        dto.Disposition!.Classification.Should().Be("Clean");
+        dto.Disposition.BlockingRecommended.Should().BeFalse();
     }
 
     [Fact]

--- a/MLVScan.Core.Tests/Integration/FalsePositiveEdgeCaseTests.cs
+++ b/MLVScan.Core.Tests/Integration/FalsePositiveEdgeCaseTests.cs
@@ -568,7 +568,7 @@ public class FalsePositiveEdgeCaseTests
         var builder = TestAssemblyBuilder.Create("BenignTelemetryUpload");
         var module = builder.Module;
         var assembly = builder
-            .AddType("Legit.Telemetry")
+            .AddType("Legit.SecretTelemetry")
             .AddMethod("UploadDiagnostics")
             .AddLocal(module.TypeSystem.String, out var localIndex)
             .EmitString("diagnostics.json")

--- a/MLVScan.Core.Tests/Integration/FalsePositiveEdgeCaseTests.cs
+++ b/MLVScan.Core.Tests/Integration/FalsePositiveEdgeCaseTests.cs
@@ -586,6 +586,7 @@ public class FalsePositiveEdgeCaseTests
         findings.Should().ContainSingle(f =>
             f.RuleId == "DataFlowAnalysis" && f.Severity == Severity.Medium,
             "plain upload-shaped telemetry should remain visible without becoming a blocking malware finding");
+        findings.Single(f => f.RuleId == "DataFlowAnalysis").Description.Should().NotContain("sensitive data");
 
         var dto = ScanResultMapper.ToDto(findings, "BenignTelemetryUpload.dll", Array.Empty<byte>(), false);
         dto.Disposition.Should().NotBeNull();

--- a/MLVScan.Core.Tests/Integration/FalsePositiveScanTests.cs
+++ b/MLVScan.Core.Tests/Integration/FalsePositiveScanTests.cs
@@ -184,13 +184,23 @@ public class FalsePositiveScanTests
         var findings = scanner.Scan(path).ToList();
         LogFindings(findings, filename);
 
-        findings.Should().BeEmpty($"{filename} is a known false positive and should not trigger findings");
+        if (filename is "SaveFileSharing.dll" or "UnlimitedLaundering.dll")
+        {
+            findings.Should().ContainSingle(finding =>
+                finding.RuleId == "DataFlowAnalysis" && finding.Severity == Severity.Medium,
+                $"{filename} should retain only its non-blocking upload audit signal");
+        }
+        else
+        {
+            findings.Should().BeEmpty($"{filename} is a known false positive and should not trigger findings");
+        }
 
         var dto = ScanResultMapper.ToDto(findings, Path.GetFileName(path), File.ReadAllBytes(path), false);
         dto.Disposition.Should().NotBeNull();
         dto.Disposition!.Classification.Should().Be("Clean");
         dto.ThreatFamilies.Should().BeNull();
-        dto.Findings.Should().BeEmpty();
+        dto.Findings.Should().OnlyContain(finding =>
+            finding.Severity == "Low" || finding.Severity == "Medium");
     }
 
     /// <summary>

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowAnalyzerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowAnalyzerTests.cs
@@ -564,7 +564,8 @@ public class DataFlowAnalyzerTests
         typeBuilder.AddMethod("StealData", MethodAttributes.Public | MethodAttributes.Static)
             .AddLocal(module.TypeSystem.String, out var localIdx)
             .EmitString("passwords.txt")
-            .EmitCall("System.IO.File", "ReadAllText", module.TypeSystem.String)
+            .EmitCallWithParams("System.IO.File", "ReadAllText", module.TypeSystem.String,
+                module.TypeSystem.String)
             .EmitStloc(localIdx)
             .EmitLdloc(localIdx)
             .EmitCallInternal(sinkMethod)
@@ -601,11 +602,15 @@ public class DataFlowAnalyzerTests
         var typeBuilder = builder.AddType("TestNamespace.Exfiltrator");
 
         typeBuilder.AddMethod("UploadCredentials", MethodAttributes.Public | MethodAttributes.Static)
-            .AddLocal(module.TypeSystem.String, out var localIdx)
+            .AddLocal(module.TypeSystem.String, out var pathLocalIdx)
+            .AddLocal(module.TypeSystem.String, out var dataLocalIdx)
             .EmitString("passwords.txt")
-            .EmitCall("System.IO.File", "ReadAllText", module.TypeSystem.String)
-            .EmitStloc(localIdx)
-            .EmitLdloc(localIdx)
+            .EmitStloc(pathLocalIdx)
+            .EmitLdloc(pathLocalIdx)
+            .EmitCallWithParams("System.IO.File", "ReadAllText", module.TypeSystem.String,
+                module.TypeSystem.String)
+            .EmitStloc(dataLocalIdx)
+            .EmitLdloc(dataLocalIdx)
             .EmitCall("System.Net.WebClient", "UploadString", module.TypeSystem.String)
             .EmitPop()
             .EndMethod();
@@ -621,6 +626,49 @@ public class DataFlowAnalyzerTests
         analyzer.AnalyzeMethod(method);
 
         analyzer.SuspiciousChainCount.Should().BeGreaterThan(0);
+        analyzer.BuildDataFlowFindings().Should().ContainSingle(finding =>
+            finding.RuleId == "DataFlowAnalysis" &&
+            finding.Severity == Severity.Critical &&
+            finding.DataFlowChain != null &&
+            finding.DataFlowChain.Pattern == DataFlowPattern.DataExfiltration);
+    }
+
+    [Fact]
+    public void BuildDataFlowFindings_SensitiveRegistrySource_EmitsCriticalFinding()
+    {
+        var builder = TestAssemblyBuilder.Create("RegistryExfiltrationTest");
+        var module = builder.Module;
+        var typeBuilder = builder.AddType("TestNamespace.RegistryReader");
+
+        typeBuilder.AddMethod("UploadCredential", MethodAttributes.Public | MethodAttributes.Static)
+            .AddLocal(module.TypeSystem.Object, out var dataLocalIdx)
+            .EmitString(@"HKEY_CURRENT_USER\Software\Vendor\Account")
+            .EmitString("password")
+            .EmitString(string.Empty)
+            .EmitCallWithParams(
+                "Microsoft.Win32.Registry",
+                "GetValue",
+                module.TypeSystem.Object,
+                module.TypeSystem.String,
+                module.TypeSystem.String,
+                module.TypeSystem.Object)
+            .EmitStloc(dataLocalIdx)
+            .EmitLdloc(dataLocalIdx)
+            .EmitCallWithParams(
+                "System.Net.WebClient",
+                "UploadString",
+                module.TypeSystem.String,
+                module.TypeSystem.Object)
+            .EmitPop()
+            .EndMethod();
+
+        var assembly = builder.Build();
+        var method = assembly.MainModule.Types.First(t => t.Name == "RegistryReader")
+            .Methods.First(m => m.Name == "UploadCredential");
+        var analyzer = new DataFlowAnalyzer(RuleFactory.CreateDefaultRules(), new CodeSnippetBuilder());
+
+        analyzer.AnalyzeMethod(method);
+
         analyzer.BuildDataFlowFindings().Should().ContainSingle(finding =>
             finding.RuleId == "DataFlowAnalysis" &&
             finding.Severity == Severity.Critical &&

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowAnalyzerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowAnalyzerTests.cs
@@ -677,6 +677,127 @@ public class DataFlowAnalyzerTests
     }
 
     [Fact]
+    public void BuildDataFlowFindings_PartiallyResolvedSensitivePath_EmitsCriticalFinding()
+    {
+        var builder = TestAssemblyBuilder.Create("PartialPathExfiltrationTest");
+        var module = builder.Module;
+        var typeBuilder = builder.AddType("TestNamespace.BrowserReader");
+
+        typeBuilder.AddMethod("UploadBrowserData", MethodAttributes.Public | MethodAttributes.Static)
+            .AddLocal(module.TypeSystem.String, out var pathLocalIdx)
+            .AddLocal(module.TypeSystem.String, out var dataLocalIdx)
+            .EmitInt(26)
+            .EmitCallWithParams(
+                "System.Environment",
+                "GetFolderPath",
+                module.TypeSystem.String,
+                module.TypeSystem.Int32)
+            .EmitString(@"Google\Chrome\User Data\Login Data")
+            .EmitCallWithParams(
+                "System.IO.Path",
+                "Combine",
+                module.TypeSystem.String,
+                module.TypeSystem.String,
+                module.TypeSystem.String)
+            .EmitStloc(pathLocalIdx)
+            .EmitLdloc(pathLocalIdx)
+            .EmitCallWithParams(
+                "System.IO.File",
+                "ReadAllText",
+                module.TypeSystem.String,
+                module.TypeSystem.String)
+            .EmitStloc(dataLocalIdx)
+            .EmitLdloc(dataLocalIdx)
+            .EmitCallWithParams(
+                "System.Net.WebClient",
+                "UploadString",
+                module.TypeSystem.String,
+                module.TypeSystem.String)
+            .EmitPop()
+            .EndMethod();
+
+        var assembly = builder.Build();
+        var method = assembly.MainModule.Types.First(t => t.Name == "BrowserReader")
+            .Methods.First(m => m.Name == "UploadBrowserData");
+        var analyzer = new DataFlowAnalyzer(RuleFactory.CreateDefaultRules(), new CodeSnippetBuilder());
+
+        analyzer.AnalyzeMethod(method);
+
+        analyzer.BuildDataFlowFindings().Should().ContainSingle(finding =>
+            finding.RuleId == "DataFlowAnalysis" &&
+            finding.Severity == Severity.Critical &&
+            finding.DataFlowChain != null &&
+            finding.DataFlowChain.Pattern == DataFlowPattern.DataExfiltration);
+    }
+
+    [Fact]
+    public void BuildDataFlowFindings_RegistryKeyReceiverPath_EmitsCriticalFinding()
+    {
+        using var module = ModuleDefinition.CreateModule("RegistryKeyExfiltrationTest", ModuleKind.Dll);
+        var type = new TypeDefinition(
+            "TestNamespace",
+            "RegistryKeyReader",
+            TypeAttributes.Public | TypeAttributes.Class,
+            module.TypeSystem.Object);
+        module.Types.Add(type);
+
+        var registryKeyType = new TypeReference(
+            "Microsoft.Win32", "RegistryKey", module, module.TypeSystem.CoreLibrary);
+        var method = new MethodDefinition(
+            "UploadCredential",
+            MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Void);
+        var keyLocal = new VariableDefinition(registryKeyType);
+        var dataLocal = new VariableDefinition(module.TypeSystem.Object);
+        method.Body.Variables.Add(keyLocal);
+        method.Body.Variables.Add(dataLocal);
+        method.Body.InitLocals = true;
+        type.Methods.Add(method);
+
+        var openSubKey = new MethodReference("OpenSubKey", registryKeyType, registryKeyType)
+        {
+            HasThis = true
+        };
+        openSubKey.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        var getValue = new MethodReference("GetValue", module.TypeSystem.Object, registryKeyType)
+        {
+            HasThis = true
+        };
+        getValue.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        var upload = new MethodReference(
+            "UploadString",
+            module.TypeSystem.String,
+            new TypeReference("System.Net", "WebClient", module, module.TypeSystem.CoreLibrary))
+        {
+            HasThis = false
+        };
+        upload.Parameters.Add(new ParameterDefinition(module.TypeSystem.Object));
+
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ldstr, @"Software\Vendor\Credentials");
+        il.Emit(OpCodes.Callvirt, openSubKey);
+        il.Emit(OpCodes.Stloc, keyLocal);
+        il.Emit(OpCodes.Ldloc, keyLocal);
+        il.Emit(OpCodes.Ldstr, "Data");
+        il.Emit(OpCodes.Callvirt, getValue);
+        il.Emit(OpCodes.Stloc, dataLocal);
+        il.Emit(OpCodes.Ldloc, dataLocal);
+        il.Emit(OpCodes.Call, upload);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        var analyzer = new DataFlowAnalyzer(RuleFactory.CreateDefaultRules(), new CodeSnippetBuilder());
+        analyzer.AnalyzeMethod(method);
+
+        analyzer.BuildDataFlowFindings().Should().ContainSingle(finding =>
+            finding.RuleId == "DataFlowAnalysis" &&
+            finding.Severity == Severity.Critical &&
+            finding.DataFlowChain != null &&
+            finding.DataFlowChain.Pattern == DataFlowPattern.DataExfiltration);
+    }
+
+    [Fact]
     public void DataFlowChain_IsCrossMethod_FlagSetCorrectly()
     {
         // Arrange: Directly test the DataFlowChain model

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowAnalyzerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowAnalyzerTests.cs
@@ -585,22 +585,24 @@ public class DataFlowAnalyzerTests
         analyzer.AnalyzeCrossMethodFlows();
         var findings = analyzer.BuildDataFlowFindings().ToList();
 
-        // Assert
-        // Should have at least some findings (single-method or cross-method)
-        // The exact count depends on pattern recognition
-        findings.Should().NotBeNull();
+        findings.Should().Contain(finding =>
+            finding.RuleId == "DataFlowAnalysis" &&
+            finding.Severity == Severity.Critical &&
+            finding.DataFlowChain != null &&
+            finding.DataFlowChain.Pattern == DataFlowPattern.DataExfiltration &&
+            finding.DataFlowChain.IsCrossMethod);
     }
 
     [Fact]
-    public void BuildDataFlowFindings_DataExfiltrationPattern_DoesNotEmitStandaloneFinding()
+    public void BuildDataFlowFindings_DataExfiltrationPattern_EmitsCriticalFinding()
     {
         var builder = TestAssemblyBuilder.Create("StandaloneExfiltrationTest");
         var module = builder.Module;
-        var typeBuilder = builder.AddType("TestNamespace.TelemetryClass");
+        var typeBuilder = builder.AddType("TestNamespace.Exfiltrator");
 
-        typeBuilder.AddMethod("UploadTelemetry", MethodAttributes.Public | MethodAttributes.Static)
+        typeBuilder.AddMethod("UploadCredentials", MethodAttributes.Public | MethodAttributes.Static)
             .AddLocal(module.TypeSystem.String, out var localIdx)
-            .EmitString("telemetry.json")
+            .EmitString("passwords.txt")
             .EmitCall("System.IO.File", "ReadAllText", module.TypeSystem.String)
             .EmitStloc(localIdx)
             .EmitLdloc(localIdx)
@@ -609,8 +611,8 @@ public class DataFlowAnalyzerTests
             .EndMethod();
 
         var assembly = builder.Build();
-        var method = assembly.MainModule.Types.First(t => t.Name == "TelemetryClass")
-            .Methods.First(m => m.Name == "UploadTelemetry");
+        var method = assembly.MainModule.Types.First(t => t.Name == "Exfiltrator")
+            .Methods.First(m => m.Name == "UploadCredentials");
 
         var rules = RuleFactory.CreateDefaultRules();
         var snippetBuilder = new CodeSnippetBuilder();
@@ -619,7 +621,11 @@ public class DataFlowAnalyzerTests
         analyzer.AnalyzeMethod(method);
 
         analyzer.SuspiciousChainCount.Should().BeGreaterThan(0);
-        analyzer.BuildDataFlowFindings().Should().BeEmpty();
+        analyzer.BuildDataFlowFindings().Should().ContainSingle(finding =>
+            finding.RuleId == "DataFlowAnalysis" &&
+            finding.Severity == Severity.Critical &&
+            finding.DataFlowChain != null &&
+            finding.DataFlowChain.Pattern == DataFlowPattern.DataExfiltration);
     }
 
     [Fact]

--- a/Services/DataFlow/DataFlowOperationClassifier.cs
+++ b/Services/DataFlow/DataFlowOperationClassifier.cs
@@ -98,7 +98,7 @@ namespace MLVScan.Services.DataFlow
             return operations;
         }
 
-        private static string BuildDataDescription(
+        private string BuildDataDescription(
             MethodDefinition method,
             Collection<Instruction> instructions,
             int callIndex,
@@ -112,30 +112,107 @@ namespace MLVScan.Services.DataFlow
             }
 
             var declaringType = calledMethod.DeclaringType?.FullName ?? string.Empty;
-            int[] sourceArgumentIndexes = IsFileSource(declaringType, calledMethod.Name)
-                ? new[] { 0 }
-                : IsRegistrySource(declaringType, calledMethod.Name)
-                    ? new[] { 0, 1 }
-                    : Array.Empty<int>();
+            var resolvedArguments = new List<string>();
+            if (IsFileSource(declaringType, calledMethod.Name))
+            {
+                AddResolvedSourceArgument(
+                    resolvedArguments, method, instructions, callIndex, calledMethod, 0);
+            }
+            else if (IsRegistrySource(declaringType, calledMethod.Name))
+            {
+                if (calledMethod.HasThis)
+                {
+                    AddRegistryReceiverSourceArguments(
+                        resolvedArguments, method, instructions, callIndex, calledMethod);
+                    AddResolvedSourceArgument(
+                        resolvedArguments, method, instructions, callIndex, calledMethod, 0);
+                }
+                else
+                {
+                    AddResolvedSourceArgument(
+                        resolvedArguments, method, instructions, callIndex, calledMethod, 0);
+                    AddResolvedSourceArgument(
+                        resolvedArguments, method, instructions, callIndex, calledMethod, 1);
+                }
+            }
 
-            var resolvedArguments = sourceArgumentIndexes
-                .Where(argumentIndex => argumentIndex < calledMethod.Parameters.Count)
-                .Select(argumentIndex => InstructionValueResolver.TryResolveCallArgumentDisplay(
+            return resolvedArguments.Count == 0
+                ? baseDescription
+                : $"{baseDescription}; source argument(s): {string.Join(", ", resolvedArguments)}";
+        }
+
+        private static void AddResolvedSourceArgument(
+            ICollection<string> resolvedArguments,
+            MethodDefinition method,
+            Collection<Instruction> instructions,
+            int callIndex,
+            MethodReference calledMethod,
+            int argumentIndex)
+        {
+            if (argumentIndex >= calledMethod.Parameters.Count ||
+                !InstructionValueResolver.TryResolveCallArgumentDisplay(
                     method,
                     calledMethod,
                     instructions,
                     callIndex,
                     argumentIndex,
-                    out var display)
-                        ? display
-                        : string.Empty)
-                .Where(IsConcreteResolvedPath)
-                .Select(static display => display.Length <= 256 ? display : display[..256])
-                .ToList();
+                    out var display) ||
+                !IsUsableResolvedSourceArgument(display))
+            {
+                return;
+            }
 
-            return resolvedArguments.Count == 0
-                ? baseDescription
-                : $"{baseDescription}; source argument(s): {string.Join(", ", resolvedArguments)}";
+            resolvedArguments.Add(display.Length <= 256 ? display : display[..256]);
+        }
+
+        private void AddRegistryReceiverSourceArguments(
+            ICollection<string> resolvedArguments,
+            MethodDefinition method,
+            Collection<Instruction> instructions,
+            int callIndex,
+            MethodReference calledMethod)
+        {
+            if (!_instructionHelper.TryGetCallReceiverProducerIndex(
+                    instructions, callIndex, calledMethod, out var receiverProducerIndex))
+            {
+                return;
+            }
+
+            var candidateProducerIndexes = new HashSet<int> { receiverProducerIndex };
+            if (instructions[receiverProducerIndex].TryGetLocalIndex(out var receiverLocalIndex))
+            {
+                foreach (var storeIndex in _instructionHelper.GetReachingLocalStoreIndexes(
+                             instructions, receiverProducerIndex, receiverLocalIndex))
+                {
+                    if (_instructionHelper.TryGetConsumedValueProducerIndex(
+                            instructions, storeIndex, out var storedValueProducerIndex))
+                    {
+                        candidateProducerIndexes.Add(storedValueProducerIndex);
+                    }
+                }
+            }
+
+            foreach (var producerIndex in candidateProducerIndexes)
+            {
+                if (instructions[producerIndex].Operand is not MethodReference receiverFactory ||
+                    !receiverFactory.Name.Equals("OpenSubKey", StringComparison.OrdinalIgnoreCase) ||
+                    !(receiverFactory.DeclaringType?.FullName ?? string.Empty)
+                        .Contains("Microsoft.Win32.RegistryKey", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                AddResolvedSourceArgument(
+                    resolvedArguments, method, instructions, producerIndex, receiverFactory, 0);
+            }
+        }
+
+        private static bool IsUsableResolvedSourceArgument(string display)
+        {
+            return !string.IsNullOrWhiteSpace(display) &&
+                   !display.Equals("<unknown/non-literal>", StringComparison.OrdinalIgnoreCase) &&
+                   !display.Equals("<unknown>", StringComparison.OrdinalIgnoreCase) &&
+                   !display.Equals("<null>", StringComparison.OrdinalIgnoreCase);
         }
 
         private HashSet<string> TryGetPayloadPathIdentities(

--- a/Services/DataFlow/DataFlowOperationClassifier.cs
+++ b/Services/DataFlow/DataFlowOperationClassifier.cs
@@ -67,7 +67,13 @@ namespace MLVScan.Services.DataFlow
                         MethodReference = calledMethod,
                         NodeType = operationInfo.Value.NodeType,
                         Operation = operationInfo.Value.Operation,
-                        DataDescription = operationInfo.Value.DataDescription,
+                        DataDescription = BuildDataDescription(
+                            method,
+                            instructions,
+                            index,
+                            calledMethod,
+                            operationInfo.Value.NodeType,
+                            operationInfo.Value.DataDescription),
                         LocalVariableIndex = _instructionHelper.TryGetTargetLocalVariable(instructions, index),
                         PayloadPathIdentities = payloadPathIdentities
                     });
@@ -90,6 +96,46 @@ namespace MLVScan.Services.DataFlow
             }
 
             return operations;
+        }
+
+        private static string BuildDataDescription(
+            MethodDefinition method,
+            Collection<Instruction> instructions,
+            int callIndex,
+            MethodReference calledMethod,
+            DataFlowNodeType nodeType,
+            string baseDescription)
+        {
+            if (nodeType != DataFlowNodeType.Source)
+            {
+                return baseDescription;
+            }
+
+            var declaringType = calledMethod.DeclaringType?.FullName ?? string.Empty;
+            int[] sourceArgumentIndexes = IsFileSource(declaringType, calledMethod.Name)
+                ? new[] { 0 }
+                : IsRegistrySource(declaringType, calledMethod.Name)
+                    ? new[] { 0, 1 }
+                    : Array.Empty<int>();
+
+            var resolvedArguments = sourceArgumentIndexes
+                .Where(argumentIndex => argumentIndex < calledMethod.Parameters.Count)
+                .Select(argumentIndex => InstructionValueResolver.TryResolveCallArgumentDisplay(
+                    method,
+                    calledMethod,
+                    instructions,
+                    callIndex,
+                    argumentIndex,
+                    out var display)
+                        ? display
+                        : string.Empty)
+                .Where(IsConcreteResolvedPath)
+                .Select(static display => display.Length <= 256 ? display : display[..256])
+                .ToList();
+
+            return resolvedArguments.Count == 0
+                ? baseDescription
+                : $"{baseDescription}; source argument(s): {string.Join(", ", resolvedArguments)}";
         }
 
         private HashSet<string> TryGetPayloadPathIdentities(

--- a/Services/DataFlow/DataFlowPatternEvaluator.cs
+++ b/Services/DataFlow/DataFlowPatternEvaluator.cs
@@ -5,6 +5,13 @@ namespace MLVScan.Services.DataFlow
 {
     internal sealed class DataFlowPatternEvaluator
     {
+        private static readonly string[] SensitiveSourceTerms =
+        {
+            "password", "credential", "cookie", "login data", "local state",
+            "access_token", "refresh_token", "auth token", "secret", "wallet",
+            "seed phrase", ".ssh", ".aws", ".kube", "discord token"
+        };
+
         public DataFlowPattern RecognizePattern(IReadOnlyList<DataFlowInterestingOperation> operations)
         {
             if (HasResourceSource(operations) && HasLinkedEmbeddedPayloadExecution(operations))
@@ -85,6 +92,11 @@ namespace MLVScan.Services.DataFlow
 
         public ScanFinding CreateFinding(DataFlowChain chain)
         {
+            if (chain.Pattern == DataFlowPattern.DataExfiltration && !HasSensitiveSourceEvidence(chain))
+            {
+                chain.Severity = Severity.Medium;
+            }
+
             return new ScanFinding(
                 chain.MethodLocation,
                 chain.ToDetailedDescription(),
@@ -96,12 +108,28 @@ namespace MLVScan.Services.DataFlow
             };
         }
 
-        public bool ShouldEmitFinding(DataFlowPattern pattern)
+        public bool ShouldEmitFinding(DataFlowChain chain)
         {
-            return pattern == DataFlowPattern.EmbeddedResourceDropAndExecute ||
-                   pattern == DataFlowPattern.DownloadAndExecute ||
-                   pattern == DataFlowPattern.DynamicCodeLoading ||
-                   pattern == DataFlowPattern.ObfuscatedPersistence;
+            return chain.Pattern == DataFlowPattern.EmbeddedResourceDropAndExecute ||
+                   chain.Pattern == DataFlowPattern.DownloadAndExecute ||
+                   chain.Pattern == DataFlowPattern.DataExfiltration ||
+                   chain.Pattern == DataFlowPattern.DynamicCodeLoading ||
+                   chain.Pattern == DataFlowPattern.ObfuscatedPersistence;
+        }
+
+        private static bool HasSensitiveSourceEvidence(DataFlowChain chain)
+        {
+            return chain.Nodes
+                .Where(static node => node.NodeType == DataFlowNodeType.Source)
+                .SelectMany(static node => new[]
+                {
+                    node.Location,
+                    node.Operation,
+                    node.DataDescription,
+                    node.CodeSnippet ?? string.Empty
+                })
+                .Any(value => SensitiveSourceTerms.Any(term =>
+                    value.Contains(term, StringComparison.OrdinalIgnoreCase)));
         }
 
         private static bool HasNetworkSource(IEnumerable<DataFlowInterestingOperation> operations)

--- a/Services/DataFlow/DataFlowPatternEvaluator.cs
+++ b/Services/DataFlow/DataFlowPatternEvaluator.cs
@@ -95,6 +95,8 @@ namespace MLVScan.Services.DataFlow
             if (chain.Pattern == DataFlowPattern.DataExfiltration && !HasSensitiveSourceEvidence(chain))
             {
                 chain.Severity = Severity.Medium;
+                chain.Summary =
+                    $"Data flow audit: Reads file or registry data and sends it over the network ({chain.Nodes.Count} operations)";
             }
 
             return new ScanFinding(

--- a/Services/DataFlow/DataFlowPatternEvaluator.cs
+++ b/Services/DataFlow/DataFlowPatternEvaluator.cs
@@ -121,13 +121,7 @@ namespace MLVScan.Services.DataFlow
         {
             return chain.Nodes
                 .Where(static node => node.NodeType == DataFlowNodeType.Source)
-                .SelectMany(static node => new[]
-                {
-                    node.Location,
-                    node.Operation,
-                    node.DataDescription,
-                    node.CodeSnippet ?? string.Empty
-                })
+                .Select(static node => node.DataDescription)
                 .Any(value => SensitiveSourceTerms.Any(term =>
                     value.Contains(term, StringComparison.OrdinalIgnoreCase)));
         }

--- a/Services/DataFlowAnalyzer.cs
+++ b/Services/DataFlowAnalyzer.cs
@@ -176,7 +176,7 @@ namespace MLVScan.Services
 
             foreach (var chain in _state.MethodDataFlows.Values.SelectMany(static list => list))
             {
-                if (chain.IsSuspicious && _patternEvaluator.ShouldEmitFinding(chain.Pattern))
+                if (chain.IsSuspicious && _patternEvaluator.ShouldEmitFinding(chain))
                 {
                     findings.Add(_patternEvaluator.CreateFinding(chain));
                 }
@@ -184,7 +184,7 @@ namespace MLVScan.Services
 
             foreach (var chain in _state.CrossMethodChains)
             {
-                if (chain.IsSuspicious && _patternEvaluator.ShouldEmitFinding(chain.Pattern))
+                if (chain.IsSuspicious && _patternEvaluator.ShouldEmitFinding(chain))
                 {
                     findings.Add(_patternEvaluator.CreateFinding(chain));
                 }


### PR DESCRIPTION
## Summary

- retain recognized outbound data-flow findings instead of discarding them during materialization
- keep ordinary upload-shaped flows visible as non-blocking audit signals
- escalate flows with sensitive-source evidence while preserving clean trusted-corpus dispositions
- cover both single-method and cross-method analysis paths

## Validation

- focused data-flow and false-positive tests: 49 passed
- false-positive suite: 54 passed, 6 optional samples skipped; all present samples remain Clean with no threat-family matches
- quarantine suite: 180 passed, 1 optional sample skipped; all present samples remain KnownThreat
- full suite: 1,566 passed, 18 expected skips