### PR TITLE
Preserve blocking process execution signals

### DIFF
--- a/MLVScan.Core.Tests/Integration/ThreatFamilyQuarantineTests.cs
+++ b/MLVScan.Core.Tests/Integration/ThreatFamilyQuarantineTests.cs
@@ -216,7 +216,7 @@ public class ThreatFamilyQuarantineTests
     }
 
     [SkippableFact]
-    public void Scan_RecursiveQuarantineSamplesWithBehaviorEvidence_ShouldClassifyAsKnownThreat()
+    public void Scan_RecursiveQuarantineSamplesWithBehaviorEvidence_ShouldNotClassifyAsClean()
     {
         Skip.If(_quarantineFolder == null, "QUARANTINE folder not found. This test requires malware samples which are not available in CI.");
 
@@ -238,7 +238,10 @@ public class ThreatFamilyQuarantineTests
             _output.WriteLine(
                 $"{relativePath} => Disposition={classification}, ThreatFamilies={(familyIds.Count == 0 ? "None" : string.Join(", ", familyIds))}, Findings={findings.Count}");
 
-            if (!string.Equals(classification, "KnownThreat", StringComparison.Ordinal))
+            bool hasAcceptableDisposition =
+                string.Equals(classification, "KnownThreat", StringComparison.Ordinal) ||
+                string.Equals(classification, "Suspicious", StringComparison.Ordinal);
+            if (!hasAcceptableDisposition || findings.Count == 0)
             {
                 failures.Add(
                     $"{relativePath} => Disposition={classification}, ThreatFamilies={(familyIds.Count == 0 ? "None" : string.Join(", ", familyIds))}, Findings={findings.Count}");
@@ -247,7 +250,8 @@ public class ThreatFamilyQuarantineTests
 
         }
 
-        failures.Should().BeEmpty("every modeled quarantine behavior should classify as a known threat");
+        failures.Should().BeEmpty(
+            "every modeled quarantine behavior should retain findings and classify as KnownThreat or Suspicious, never Clean");
     }
 
     [SkippableFact]

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -395,6 +395,221 @@ public class ProcessStartRuleTests
     }
 
     [Fact]
+    public void GetFindingDescription_DirectDownloaderOverload_ResolvesUrlArgumentsAsCritical()
+    {
+        using var module = ModuleDefinition.CreateModule("TestAssembly", ModuleKind.Dll);
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Void);
+        var type = new TypeDefinition("Tests", "TestType", TypeAttributes.Public);
+        module.Types.Add(type);
+        type.Methods.Add(method);
+
+        var process = new TypeReference("System.Diagnostics", "Process", module, module.TypeSystem.CoreLibrary);
+        var start = new MethodReference("Start", process, process) { HasThis = false };
+        start.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        start.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+
+        var processor = method.Body.GetILProcessor();
+        processor.Emit(OpCodes.Ldstr, "curl.exe");
+        processor.Emit(OpCodes.Ldstr, "https://example.invalid/package.bin");
+        processor.Emit(OpCodes.Call, start);
+
+        string description = _rule.GetFindingDescription(method, start, method.Body.Instructions,
+            method.Body.Instructions.Count - 1);
+
+        description.Should().Contain("Arguments: https://example.invalid/package.bin");
+        description.Should().Contain("Downloader executable with URL arguments");
+        _rule.Severity.Should().Be(Severity.Critical);
+    }
+
+    [Fact]
+    public void GetFindingDescription_StartInfoConstructor_ResolvesUrlArgumentsAsCritical()
+    {
+        using var module = ModuleDefinition.CreateModule("TestAssembly", ModuleKind.Dll);
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Void);
+        var type = new TypeDefinition("Tests", "TestType", TypeAttributes.Public);
+        module.Types.Add(type);
+        type.Methods.Add(method);
+
+        var process = new TypeReference("System.Diagnostics", "Process", module, module.TypeSystem.CoreLibrary);
+        var startInfo = new TypeReference("System.Diagnostics", "ProcessStartInfo", module,
+            module.TypeSystem.CoreLibrary);
+        var constructor = new MethodReference(".ctor", module.TypeSystem.Void, startInfo) { HasThis = true };
+        constructor.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        constructor.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        var start = new MethodReference("Start", process, process) { HasThis = false };
+        start.Parameters.Add(new ParameterDefinition(startInfo));
+
+        var processor = method.Body.GetILProcessor();
+        processor.Emit(OpCodes.Ldstr, "wget.exe");
+        processor.Emit(OpCodes.Ldstr, "https://example.invalid/package.bin");
+        processor.Emit(OpCodes.Newobj, constructor);
+        processor.Emit(OpCodes.Call, start);
+
+        string description = _rule.GetFindingDescription(method, start, method.Body.Instructions,
+            method.Body.Instructions.Count - 1);
+
+        description.Should().Contain("Arguments: https://example.invalid/package.bin");
+        description.Should().Contain("Downloader executable with URL arguments");
+        _rule.Severity.Should().Be(Severity.Critical);
+    }
+
+    [Fact]
+    public void GetFindingDescription_UnrelatedStartInfoConstructor_DoesNotSupplyArguments()
+    {
+        using var module = ModuleDefinition.CreateModule("TestAssembly", ModuleKind.Dll);
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Void);
+        var type = new TypeDefinition("Tests", "TestType", TypeAttributes.Public);
+        module.Types.Add(type);
+        type.Methods.Add(method);
+
+        var process = new TypeReference("System.Diagnostics", "Process", module, module.TypeSystem.CoreLibrary);
+        var startInfo = new TypeReference("System.Diagnostics", "ProcessStartInfo", module,
+            module.TypeSystem.CoreLibrary);
+        var unrelatedConstructor = new MethodReference(".ctor", module.TypeSystem.Void, startInfo) { HasThis = true };
+        unrelatedConstructor.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        unrelatedConstructor.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        var actualConstructor = new MethodReference(".ctor", module.TypeSystem.Void, startInfo) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", module.TypeSystem.Void, startInfo) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        var start = new MethodReference("Start", process, process) { HasThis = false };
+        start.Parameters.Add(new ParameterDefinition(startInfo));
+        var actualStartInfo = new VariableDefinition(startInfo);
+        method.Body.Variables.Add(actualStartInfo);
+
+        var processor = method.Body.GetILProcessor();
+        processor.Emit(OpCodes.Ldstr, "unrelated.exe");
+        processor.Emit(OpCodes.Ldstr, "https://example.invalid/unrelated.bin");
+        processor.Emit(OpCodes.Newobj, unrelatedConstructor);
+        processor.Emit(OpCodes.Pop);
+        processor.Emit(OpCodes.Newobj, actualConstructor);
+        processor.Emit(OpCodes.Stloc, actualStartInfo);
+        processor.Emit(OpCodes.Ldloc, actualStartInfo);
+        processor.Emit(OpCodes.Ldstr, "curl.exe");
+        processor.Emit(OpCodes.Callvirt, setFileName);
+        processor.Emit(OpCodes.Ldloc, actualStartInfo);
+        processor.Emit(OpCodes.Call, start);
+
+        string description = _rule.GetFindingDescription(method, start, method.Body.Instructions,
+            method.Body.Instructions.Count - 1);
+
+        description.Should().Contain("Target: \"curl.exe\"");
+        description.Should().Contain("Arguments: <unknown/no-arguments>");
+        description.Should().NotContain("Downloader executable with URL arguments");
+        _rule.Severity.Should().Be(Severity.Medium);
+    }
+
+    [Fact]
+    public void GetFindingDescription_DirectOverload_IgnoresUnrelatedStartInfoArgumentsSetter()
+    {
+        using var module = ModuleDefinition.CreateModule("TestAssembly", ModuleKind.Dll);
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Void);
+        var type = new TypeDefinition("Tests", "TestType", TypeAttributes.Public);
+        module.Types.Add(type);
+        type.Methods.Add(method);
+
+        var process = new TypeReference("System.Diagnostics", "Process", module, module.TypeSystem.CoreLibrary);
+        var startInfo = new TypeReference("System.Diagnostics", "ProcessStartInfo", module,
+            module.TypeSystem.CoreLibrary);
+        var constructor = new MethodReference(".ctor", module.TypeSystem.Void, startInfo) { HasThis = true };
+        var setArguments = new MethodReference("set_Arguments", module.TypeSystem.Void, startInfo) { HasThis = true };
+        setArguments.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        var directStart = new MethodReference("Start", process, process) { HasThis = false };
+        directStart.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        directStart.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+
+        var processor = method.Body.GetILProcessor();
+        processor.Emit(OpCodes.Newobj, constructor);
+        processor.Emit(OpCodes.Dup);
+        processor.Emit(OpCodes.Ldstr, "https://example.invalid/unrelated.bin");
+        processor.Emit(OpCodes.Callvirt, setArguments);
+        processor.Emit(OpCodes.Pop);
+        processor.Emit(OpCodes.Ldstr, "curl.exe");
+        processor.Emit(OpCodes.Ldstr, "--version");
+        processor.Emit(OpCodes.Call, directStart);
+
+        string description = _rule.GetFindingDescription(method, directStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1);
+
+        description.Should().Contain("Arguments: --version");
+        description.Should().NotContain("Downloader executable with URL arguments");
+        _rule.Severity.Should().Be(Severity.Medium);
+    }
+
+    [Fact]
+    public void GetFindingDescription_CredentialOverload_DoesNotTreatUsernameAsArguments()
+    {
+        using var module = ModuleDefinition.CreateModule("TestAssembly", ModuleKind.Dll);
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Void);
+        var type = new TypeDefinition("Tests", "TestType", TypeAttributes.Public);
+        module.Types.Add(type);
+        type.Methods.Add(method);
+
+        var process = new TypeReference("System.Diagnostics", "Process", module, module.TypeSystem.CoreLibrary);
+        var secureString = new TypeReference("System.Security", "SecureString", module,
+            module.TypeSystem.CoreLibrary);
+        var start = new MethodReference("Start", process, process) { HasThis = false };
+        start.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        start.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        start.Parameters.Add(new ParameterDefinition(secureString));
+        start.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+
+        var processor = method.Body.GetILProcessor();
+        processor.Emit(OpCodes.Ldstr, "ordinary-tool.exe");
+        processor.Emit(OpCodes.Ldstr, "curl");
+        processor.Emit(OpCodes.Ldnull);
+        processor.Emit(OpCodes.Ldstr, "example-domain");
+        processor.Emit(OpCodes.Call, start);
+
+        string description = _rule.GetFindingDescription(method, start, method.Body.Instructions,
+            method.Body.Instructions.Count - 1);
+
+        description.Should().Contain("Arguments: <unknown/no-arguments>");
+        description.Should().NotContain("suspicious arguments");
+        _rule.Severity.Should().Be(Severity.Medium);
+    }
+
+    [Fact]
+    public void GetFindingDescription_FiveArgumentOverload_ResolvesCommandArguments()
+    {
+        using var module = ModuleDefinition.CreateModule("TestAssembly", ModuleKind.Dll);
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Void);
+        var type = new TypeDefinition("Tests", "TestType", TypeAttributes.Public);
+        module.Types.Add(type);
+        type.Methods.Add(method);
+
+        var process = new TypeReference("System.Diagnostics", "Process", module, module.TypeSystem.CoreLibrary);
+        var secureString = new TypeReference("System.Security", "SecureString", module,
+            module.TypeSystem.CoreLibrary);
+        var start = new MethodReference("Start", process, process) { HasThis = false };
+        start.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        start.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        start.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        start.Parameters.Add(new ParameterDefinition(secureString));
+        start.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+
+        var processor = method.Body.GetILProcessor();
+        processor.Emit(OpCodes.Ldstr, "curl.exe");
+        processor.Emit(OpCodes.Ldstr, "https://example.invalid/package.bin");
+        processor.Emit(OpCodes.Ldstr, "user");
+        processor.Emit(OpCodes.Ldnull);
+        processor.Emit(OpCodes.Ldstr, "example-domain");
+        processor.Emit(OpCodes.Call, start);
+
+        string description = _rule.GetFindingDescription(method, start, method.Body.Instructions,
+            method.Body.Instructions.Count - 1);
+
+        description.Should().Contain("Arguments: https://example.invalid/package.bin");
+        description.Should().Contain("Downloader executable with URL arguments");
+        _rule.Severity.Should().Be(Severity.Critical);
+    }
+
+    [Fact]
     public void DetermineSeverity_KnownSafeToolWithCreateNoWindowAndPlaceholderArgs_ReturnsMedium()
     {
         var result = InvokeDetermineSeverity(
@@ -429,6 +644,65 @@ public class ProcessStartRuleTests
 
         result.severity.Should().Be(Severity.Critical);
         result.reason.Should().Contain("ProcessStartInfo execution with suspicious arguments");
+    }
+
+    [Fact]
+    public void DetermineSeverity_LolBinWithSuspiciousLiteralAndPlaceholder_ReturnsCritical()
+    {
+        var result = InvokeDetermineSeverity(
+            targetLower: "powershell.exe",
+            argumentsLower: "-ep bypass <arg 0>");
+
+        result.severity.Should().Be(Severity.Critical);
+        result.reason.Should().Contain("suspicious arguments");
+    }
+
+    [Fact]
+    public void DetermineSeverity_PlaceholderNameAlone_DoesNotCreateSuspiciousArgumentEvidence()
+    {
+        var result = InvokeDetermineSeverity(
+            targetLower: "random-tool.exe",
+            argumentsLower: "<dynamic via DownloadString>");
+
+        result.severity.Should().Be(Severity.Medium);
+        result.reason.Should().Be("External process execution");
+    }
+
+    [Fact]
+    public void DetermineSeverity_PlaceholderUrlAlone_DoesNotCreateDownloadEvidence()
+    {
+        var result = InvokeDetermineSeverity(
+            targetLower: "curl.exe",
+            argumentsLower: "<dynamic via https://example.test>");
+
+        result.severity.Should().Be(Severity.Medium);
+        result.reason.Should().Be("External process execution");
+    }
+
+    [Theory]
+    [InlineData("curling")]
+    [InlineData("wgetbackup")]
+    public void DetermineSeverity_DownloaderNameSubstring_DoesNotCreateSuspiciousArgumentEvidence(string arguments)
+    {
+        var result = InvokeDetermineSeverity(
+            targetLower: "random-tool.exe",
+            argumentsLower: arguments);
+
+        result.severity.Should().Be(Severity.Medium);
+        result.reason.Should().Be("External process execution");
+    }
+
+    [Theory]
+    [InlineData("curl.exe")]
+    [InlineData("wget.exe")]
+    public void DetermineSeverity_DownloaderTargetWithUrl_ReturnsCritical(string target)
+    {
+        var result = InvokeDetermineSeverity(
+            targetLower: target,
+            argumentsLower: "https://example.test/payload");
+
+        result.severity.Should().Be(Severity.Critical);
+        result.reason.Should().ContainEquivalentOf("downloader");
     }
 
     [Fact]

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -60,20 +60,26 @@ namespace MLVScan.Models.Rules.Helpers
         /// Tries to resolve the argument string passed to a process-launching call.
         /// </summary>
         /// <param name="containingMethod">The method containing the call site.</param>
+        /// <param name="calledMethod">The process-launching method being invoked.</param>
         /// <param name="instructions">The method body instructions.</param>
         /// <param name="processStartIndex">The call instruction index.</param>
         /// <param name="arguments">Receives the resolved argument display string.</param>
         /// <returns><see langword="true"/> when the arguments could be reconstructed.</returns>
         public static bool TryResolveProcessArguments(
             MethodDefinition? containingMethod,
+            MethodReference calledMethod,
             Mono.Collections.Generic.Collection<Instruction> instructions,
             int processStartIndex,
             out string arguments)
         {
             var context = new ResolverContext(containingMethod?.Module);
 
-            if (TryResolveFromStartInfoArgumentsSetter(context, containingMethod, instructions, processStartIndex,
-                    out var resolved))
+            if (TryResolveFromProcessArgumentOverload(context, containingMethod, calledMethod, instructions,
+                    processStartIndex, out var resolved) ||
+                TryResolveFromStartInfoArgumentsSetter(context, containingMethod, calledMethod, instructions,
+                    processStartIndex, out resolved) ||
+                TryResolveFromStartInfoConstructor(context, containingMethod, calledMethod, instructions,
+                    processStartIndex, out resolved))
             {
                 arguments = resolved.Display;
                 return true;
@@ -81,6 +87,95 @@ namespace MLVScan.Models.Rules.Helpers
 
             arguments = "<unknown/no-arguments>";
             return false;
+        }
+
+        private static bool TryResolveFromProcessArgumentOverload(
+            ResolverContext context,
+            MethodDefinition? containingMethod,
+            MethodReference calledMethod,
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            int processStartIndex,
+            out ResolvedValue value)
+        {
+            value = default;
+            if (!string.Equals(calledMethod.Name, "Start", StringComparison.Ordinal) ||
+                !HasCommandArgumentParameter(calledMethod))
+            {
+                return false;
+            }
+
+            if (!TryResolveCallArguments(context, containingMethod, instructions, processStartIndex,
+                    calledMethod.Parameters.Count, null, 0, out var args) || args.Count <= 1)
+            {
+                return false;
+            }
+
+            value = args[1];
+            return true;
+        }
+
+        private static bool HasCommandArgumentParameter(MethodReference calledMethod)
+        {
+            if (calledMethod.Parameters.Count == 2)
+            {
+                return calledMethod.Parameters[0].ParameterType.FullName == "System.String" &&
+                       calledMethod.Parameters[1].ParameterType.FullName == "System.String";
+            }
+
+            if (calledMethod.Parameters.Count != 5)
+                return false;
+
+            return calledMethod.Parameters[0].ParameterType.FullName == "System.String" &&
+                   calledMethod.Parameters[1].ParameterType.FullName == "System.String" &&
+                   calledMethod.Parameters[2].ParameterType.FullName == "System.String" &&
+                   calledMethod.Parameters[3].ParameterType.FullName == "System.Security.SecureString" &&
+                   calledMethod.Parameters[4].ParameterType.FullName == "System.String";
+        }
+
+        private static bool TryResolveFromStartInfoConstructor(
+            ResolverContext context,
+            MethodDefinition? containingMethod,
+            MethodReference calledMethod,
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            int processStartIndex,
+            out ResolvedValue value)
+        {
+            value = default;
+            if (!string.Equals(calledMethod.Name, "Start", StringComparison.Ordinal) ||
+                calledMethod.Parameters.Count != 1 ||
+                !string.Equals(calledMethod.Parameters[0].ParameterType.FullName,
+                    "System.Diagnostics.ProcessStartInfo", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (!TryResolveCallArgumentIdentity(calledMethod, instructions, processStartIndex, 0,
+                    out var identity) ||
+                !identity.StartsWith("new:", StringComparison.Ordinal) ||
+                !int.TryParse(identity.AsSpan(4), out int constructorIndex) ||
+                constructorIndex < 0 || constructorIndex >= instructions.Count)
+            {
+                return false;
+            }
+
+            if (instructions[constructorIndex].OpCode != OpCodes.Newobj ||
+                instructions[constructorIndex].Operand is not MethodReference constructor ||
+                constructor.DeclaringType?.FullName != "System.Diagnostics.ProcessStartInfo" ||
+                constructor.Name != ".ctor" ||
+                constructor.Parameters.Count < 2 ||
+                constructor.Parameters[1].ParameterType.FullName != "System.String")
+            {
+                return false;
+            }
+
+            if (!TryResolveCallArguments(context, containingMethod, instructions, constructorIndex,
+                    constructor.Parameters.Count, null, 0, out var args) || args.Count <= 1)
+            {
+                return false;
+            }
+
+            value = args[1];
+            return true;
         }
 
         /// <summary>
@@ -740,11 +835,19 @@ namespace MLVScan.Models.Rules.Helpers
         private static bool TryResolveFromStartInfoArgumentsSetter(
             ResolverContext context,
             MethodDefinition? containingMethod,
+            MethodReference calledMethod,
             Mono.Collections.Generic.Collection<Instruction> instructions,
             int processStartIndex,
             out ResolvedValue value)
         {
             value = default;
+            if (!string.Equals(calledMethod.Name, "Start", StringComparison.Ordinal) ||
+                calledMethod.Parameters.Count != 1 ||
+                calledMethod.Parameters[0].ParameterType.FullName != "System.Diagnostics.ProcessStartInfo")
+            {
+                return false;
+            }
+
             int searchStart = Math.Max(0, processStartIndex - 400);
 
             for (int i = processStartIndex - 1; i >= searchStart; i--)

--- a/Models/Rules/ProcessStartRule.cs
+++ b/Models/Rules/ProcessStartRule.cs
@@ -96,8 +96,20 @@ namespace MLVScan.Models.Rules
             "dotnet"
         };
 
+        private static readonly HashSet<string> DownloaderExecutables = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "curl.exe",
+            "curl",
+            "wget.exe",
+            "wget"
+        };
+
         private static readonly Regex SuspiciousArgumentPattern = new Regex(
-            @"(?i)((-|/)ep\s+bypass|(-|/)executionpolicy\s+bypass|(-|/)enc(odedcommand)?\s+[A-Za-z0-9+/=]|(-|/)nop(rofile)?\b|iex|invoke-(expression|webrequest|restmethod)|iwr\s+|irm\s+|\biwx\b|\biwe\b|downloadstring|downloadfile|start-bitstransfer|hidden|windowstyle\s+hidden|(-|/)w\s+hidden|createnowindow|net\.webclient|system\.net\.webclient|curl|wget|\bwget\b|\bcurl\b|out-file|set-content|add-content|>\s*[\w\\]|out-string|base64|frombase64string)",
+            @"(?i)((-|/)ep\s+bypass|(-|/)executionpolicy\s+bypass|(-|/)enc(odedcommand)?\s+[A-Za-z0-9+/=]|(-|/)nop(rofile)?\b|iex|invoke-(expression|webrequest|restmethod)|iwr\s+|irm\s+|\biwx\b|\biwe\b|downloadstring|downloadfile|start-bitstransfer|hidden|windowstyle\s+hidden|(-|/)w\s+hidden|createnowindow|net\.webclient|system\.net\.webclient|\b(?:curl|wget)\b|out-file|set-content|add-content|>\s*[\w\\]|out-string|base64|frombase64string)",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex ResolverPlaceholderPattern = new Regex(
+            @"<(?:arg\s+\d+|dynamic[^>]*|unknown[^>]*)>",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex TempPathPattern = new Regex(
@@ -198,7 +210,7 @@ namespace MLVScan.Models.Rules
             }
 
             var target = ExtractProcessTarget(null, method, instructions, instructionIndex);
-            var arguments = ExtractProcessArguments(null, instructions, instructionIndex);
+            var arguments = ExtractProcessArguments(null, method, instructions, instructionIndex);
 
             // Detect ProcessStartInfo evasion indicators
             var hasUseShell =
@@ -304,37 +316,31 @@ namespace MLVScan.Models.Rules
                                KnownSafeTools.Any(safe =>
                                    targetLower.EndsWith("\\" + safe) || targetLower.EndsWith("/" + safe));
 
-            bool hasSuspiciousArgs = !string.IsNullOrEmpty(argumentsLower) &&
-                                     argumentsLower != "<unknown/no-arguments>" &&
-                                     SuspiciousArgumentPattern.IsMatch(argumentsLower);
+            bool isDownloader = DownloaderExecutables.Contains(targetLower) ||
+                                DownloaderExecutables.Any(downloader =>
+                                    targetLower.EndsWith("\\" + downloader) ||
+                                    targetLower.EndsWith("/" + downloader));
 
-            bool hasResolverPlaceholderArgs = argumentsLower.Contains("<arg ") ||
-                                              argumentsLower.Contains("<dynamic") ||
-                                              argumentsLower.Contains("<unknown");
+            var literalArguments = ResolverPlaceholderPattern.Replace(argumentsLower, " ");
+            bool hasLiteralArguments = !string.IsNullOrWhiteSpace(literalArguments) &&
+                                       argumentsLower != "<unknown/no-arguments>";
+            bool hasSuspiciousArgs = hasLiteralArguments &&
+                                     SuspiciousArgumentPattern.IsMatch(literalArguments);
 
-            if (hasResolverPlaceholderArgs)
-            {
-                hasSuspiciousArgs = false;
-            }
+            bool hasDownloadUrl = hasLiteralArguments &&
+                                  DownloadPattern.IsMatch(literalArguments);
 
-            bool hasDownloadUrl = !string.IsNullOrEmpty(argumentsLower) &&
-                                  DownloadPattern.IsMatch(argumentsLower);
+            bool hasTempPath = hasLiteralArguments &&
+                               TempPathPattern.IsMatch(literalArguments);
 
-            bool hasTempPath = !string.IsNullOrEmpty(argumentsLower) &&
-                               argumentsLower != "<unknown/no-arguments>" &&
-                               TempPathPattern.IsMatch(argumentsLower);
+            bool hasScriptDropExtension = hasLiteralArguments &&
+                                          ScriptDropExtensionPattern.IsMatch(literalArguments);
 
-            bool hasScriptDropExtension = !string.IsNullOrEmpty(argumentsLower) &&
-                                          argumentsLower != "<unknown/no-arguments>" &&
-                                          ScriptDropExtensionPattern.IsMatch(argumentsLower);
+            bool hasStagedLoaderPivot = hasLiteralArguments &&
+                                        StagedLoaderPivotPattern.IsMatch(literalArguments);
 
-            bool hasStagedLoaderPivot = !string.IsNullOrEmpty(argumentsLower) &&
-                                        argumentsLower != "<unknown/no-arguments>" &&
-                                        StagedLoaderPivotPattern.IsMatch(argumentsLower);
-
-            bool hasStagedDownloadCommand = !string.IsNullOrEmpty(argumentsLower) &&
-                                            argumentsLower != "<unknown/no-arguments>" &&
-                                            StagedLoaderDownloadCommandPattern.IsMatch(argumentsLower);
+            bool hasStagedDownloadCommand = hasLiteralArguments &&
+                                            StagedLoaderDownloadCommandPattern.IsMatch(literalArguments);
 
             bool isUnknownTarget = targetLower.Contains("<unknown") || targetLower.Contains("<dynamic");
 
@@ -384,6 +390,11 @@ namespace MLVScan.Models.Rules
                 }
 
                 return (Severity.High, "Potential staged loader chain (download -> temp drop -> execute)");
+            }
+
+            if (isDownloader && hasDownloadUrl)
+            {
+                return (Severity.Critical, "Downloader executable with URL arguments");
             }
 
             if (isKnownSafe)
@@ -567,7 +578,7 @@ namespace MLVScan.Models.Rules
             int instructionIndex)
         {
             string target = ExtractProcessTarget(containingMethod, method, instructions, instructionIndex);
-            string arguments = ExtractProcessArguments(containingMethod, instructions, instructionIndex);
+            string arguments = ExtractProcessArguments(containingMethod, method, instructions, instructionIndex);
 
             // Detect ProcessStartInfo evasion indicators
             var hasUseShell = InstructionValueResolver.TryResolveUseShellExecute(containingMethod, instructions,
@@ -1122,11 +1133,12 @@ namespace MLVScan.Models.Rules
 
         private static string ExtractProcessArguments(
             MethodDefinition? containingMethod,
+            MethodReference calledMethod,
             Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
             int processStartIndex)
         {
-            if (InstructionValueResolver.TryResolveProcessArguments(containingMethod, instructions, processStartIndex,
-                    out string arguments))
+            if (InstructionValueResolver.TryResolveProcessArguments(containingMethod, calledMethod, instructions,
+                    processStartIndex, out string arguments))
             {
                 return arguments;
             }


### PR DESCRIPTION
## Summary

- preserve suspicious literal evidence when process arguments also contain unresolved values
- ignore placeholder-only content across process argument classifiers
- retain blocking severity for direct downloader executables with resolved network targets
- associate constructor arguments only with the launched process-start object
- add focused regression coverage for mixed, direct-overload, constructor, and placeholder-only cases

## Validation

- ProcessStartRule tests: 84 passed
- false-positive suite: 54 passed, 6 optional samples skipped; all present samples remain Clean with no threat-family matches
- quarantine suite: 180 passed, 1 optional sample skipped; all present samples remain KnownThreat
- full suite: 1,579 passed, 18 expected skips