### PR TITLE
Restore sensitive-path reflection correlation

### DIFF
--- a/MLVScan.Core.Tests/Unit/Services/InstructionAnalyzerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/InstructionAnalyzerTests.cs
@@ -131,6 +131,19 @@ public class InstructionAnalyzerTests
         result.Findings[0].RuleId.Should().Be("ProcessStartRule");
     }
 
+    [Fact]
+    public void AnalyzeInstructions_SensitiveFolderBeforeNonLiteralReflection_EmitsOneReflectionFinding()
+    {
+        var config = new ScanConfig { EnableMultiSignalDetection = true };
+        var analyzer = CreateAnalyzer(config, new IScanRule[] { new ReflectionRule() });
+        var method = CreateSensitiveFolderReflectionMethod();
+
+        var result = analyzer.AnalyzeInstructions(method, method.Body.Instructions, new MethodSignals(),
+            method.DeclaringType!.FullName);
+
+        result.Findings.Should().ContainSingle(f => f.RuleId == "ReflectionRule");
+    }
+
     private static InstructionAnalyzer CreateAnalyzer(ScanConfig config, IEnumerable<IScanRule> rules)
     {
         var signalTracker = new SignalTracker(config);
@@ -183,6 +196,39 @@ public class InstructionAnalyzerTests
         method.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Ldstr, "Start"));
         method.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Call, invokeMethod));
         method.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Ret));
+        type.Methods.Add(method);
+
+        return method;
+    }
+
+    private static MethodDefinition CreateSensitiveFolderReflectionMethod()
+    {
+        var assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition("InstructionAnalyzerSensitiveReflectionTest", new Version(1, 0, 0, 0)),
+            "InstructionAnalyzerSensitiveReflectionTest",
+            ModuleKind.Dll);
+        var module = assembly.MainModule;
+        var type = new TypeDefinition("Test", "SensitiveReflectionType", TypeAttributes.Public | TypeAttributes.Class,
+            module.TypeSystem.Object);
+        module.Types.Add(type);
+
+        var method = new MethodDefinition("Run", MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Void);
+        method.Body = new MethodBody(method);
+
+        var environmentType = new TypeReference("System", "Environment", module, module.TypeSystem.CoreLibrary);
+        var getFolderPath = new MethodReference("GetFolderPath", module.TypeSystem.String, environmentType);
+        getFolderPath.Parameters.Add(new ParameterDefinition(module.TypeSystem.Int32));
+        var methodInfoType = new TypeReference("System.Reflection", "MethodInfo", module, module.TypeSystem.CoreLibrary);
+        var invokeMethod = new MethodReference("Invoke", module.TypeSystem.Object, methodInfoType);
+
+        var processor = method.Body.GetILProcessor();
+        processor.Append(Instruction.Create(OpCodes.Ldc_I4_7));
+        processor.Append(Instruction.Create(OpCodes.Call, getFolderPath));
+        processor.Append(Instruction.Create(OpCodes.Pop));
+        processor.Append(Instruction.Create(OpCodes.Call, invokeMethod));
+        processor.Append(Instruction.Create(OpCodes.Pop));
+        processor.Append(Instruction.Create(OpCodes.Ret));
         type.Methods.Add(method);
 
         return method;

--- a/MLVScan.Core.Tests/Unit/Services/ReflectionDetectorBranchTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/ReflectionDetectorBranchTests.cs
@@ -69,7 +69,7 @@ public sealed class ReflectionDetectorBranchTests
     }
 
     [Fact]
-    public void ScanForReflectionInvocation_PathManipulationSignal_ElevatesReflectionFinding()
+    public void ScanForReflectionInvocation_EnvironmentModificationSignal_ElevatesReflectionFinding()
     {
         var detector = CreateDetector(new ProcessStartRule());
         var methodDef = CreateMethodDefinition();
@@ -86,7 +86,7 @@ public sealed class ReflectionDetectorBranchTests
             calledMethod,
             1,
             instructions,
-            new MethodSignals { HasPathManipulation = true }).ToList();
+            new MethodSignals { HasEnvironmentVariableModification = true }).ToList();
 
         findings.Should().ContainSingle();
         findings[0].RuleId.Should().Be("ProcessStartRule");

--- a/MLVScan.Core.Tests/Unit/Services/ReflectionDetectorBranchTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/ReflectionDetectorBranchTests.cs
@@ -44,7 +44,7 @@ public sealed class ReflectionDetectorBranchTests
     }
 
     [Fact]
-    public void ScanForReflectionInvocation_SensitiveFolderSignalAlone_DoesNotElevateReflectionFinding()
+    public void ScanForReflectionInvocation_SensitiveFolderSignal_ElevatesReflectionFinding()
     {
         var detector = CreateDetector(new ProcessStartRule());
         var methodDef = CreateMethodDefinition();
@@ -63,7 +63,34 @@ public sealed class ReflectionDetectorBranchTests
             instructions,
             new MethodSignals { UsesSensitiveFolder = true }).ToList();
 
-        findings.Should().BeEmpty();
+        findings.Should().ContainSingle();
+        findings[0].RuleId.Should().Be("ProcessStartRule");
+        findings[0].Severity.Should().Be(Severity.Critical);
+    }
+
+    [Fact]
+    public void ScanForReflectionInvocation_PathManipulationSignal_ElevatesReflectionFinding()
+    {
+        var detector = CreateDetector(new ProcessStartRule());
+        var methodDef = CreateMethodDefinition();
+        var calledMethod = CreateMethodReference("System.Type", "InvokeMember");
+        var instructions = new Mono.Collections.Generic.Collection<Instruction>
+        {
+            Instruction.Create(OpCodes.Ldstr, "Start"),
+            Instruction.Create(OpCodes.Call, calledMethod)
+        };
+
+        var findings = detector.ScanForReflectionInvocation(
+            methodDef,
+            instructions[1],
+            calledMethod,
+            1,
+            instructions,
+            new MethodSignals { HasPathManipulation = true }).ToList();
+
+        findings.Should().ContainSingle();
+        findings[0].RuleId.Should().Be("ProcessStartRule");
+        findings[0].Severity.Should().Be(Severity.Critical);
     }
 
     [Fact]

--- a/MLVScan.Core.Tests/Unit/Services/TypeScannerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/TypeScannerTests.cs
@@ -38,6 +38,36 @@ public class TypeScannerTests
     }
 
     [Fact]
+    public void ScanType_WithReflectionAndSensitiveFolderAcrossMethods_AddsCombinedReflectionFinding()
+    {
+        var config = new ScanConfig { EnableMultiSignalDetection = true, AnalyzePropertyAccessors = false };
+        var rules = new IScanRule[] { new ReflectionRule(), new ProcessStartRule() };
+
+        var signalTracker = new SignalTracker(config);
+        var snippetBuilder = new CodeSnippetBuilder();
+        var stringPatternDetector = new StringPatternDetector();
+        var reflectionDetector = new ReflectionDetector(rules, signalTracker, stringPatternDetector, snippetBuilder);
+        var localVariableAnalyzer = new LocalVariableAnalyzer(rules, signalTracker, config);
+        var exceptionHandlerAnalyzer = new ExceptionHandlerAnalyzer(rules, signalTracker, snippetBuilder, config);
+        var instructionAnalyzer = new InstructionAnalyzer(rules, signalTracker, reflectionDetector,
+            stringPatternDetector, snippetBuilder, config, null);
+        var methodScanner = new MethodScanner(rules, signalTracker, instructionAnalyzer, snippetBuilder,
+            localVariableAnalyzer, exceptionHandlerAnalyzer, config);
+        var propertyEventScanner = new PropertyEventScanner(methodScanner, config);
+        var typeScanner = new TypeScanner(methodScanner, signalTracker, reflectionDetector, snippetBuilder,
+            propertyEventScanner, rules, config);
+
+        var type = CreateTypeWithReflectionAndSensitiveFolderMethods();
+
+        var findings = typeScanner.ScanType(type).ToList();
+
+        findings.Should().Contain(finding =>
+            finding.RuleId == "ReflectionRule" &&
+            finding.Severity == Severity.High &&
+            finding.Description.Contains("combined with other suspicious patterns detected in this type"));
+    }
+
+    [Fact]
     public void ScanType_RecursivelyScansNestedTypes()
     {
         var config = new ScanConfig { EnableMultiSignalDetection = true, AnalyzePropertyAccessors = false };
@@ -148,6 +178,41 @@ public class TypeScannerTests
         processMethod.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Call, startRef));
         processMethod.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Ret));
         type.Methods.Add(processMethod);
+
+        return type;
+    }
+
+    private static TypeDefinition CreateTypeWithReflectionAndSensitiveFolderMethods()
+    {
+        var assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition("SensitiveReflectionTypeScan", new Version(1, 0, 0, 0)),
+            "SensitiveReflectionTypeScan",
+            ModuleKind.Dll);
+        var module = assembly.MainModule;
+        var type = new TypeDefinition("Test", "SensitiveReflectionType", TypeAttributes.Public | TypeAttributes.Class,
+            module.TypeSystem.Object);
+        module.Types.Add(type);
+
+        var reflectMethod = new MethodDefinition("Reflect", MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Void);
+        var methodInfoType = new TypeReference("System.Reflection", "MethodInfo", module,
+            module.TypeSystem.CoreLibrary);
+        var invokeRef = new MethodReference("Invoke", module.TypeSystem.Object, methodInfoType);
+        reflectMethod.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Call, invokeRef));
+        reflectMethod.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Pop));
+        reflectMethod.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Ret));
+        type.Methods.Add(reflectMethod);
+
+        var pathMethod = new MethodDefinition("ResolveStartup", MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Void);
+        var environmentType = new TypeReference("System", "Environment", module, module.TypeSystem.CoreLibrary);
+        var getFolderPath = new MethodReference("GetFolderPath", module.TypeSystem.String, environmentType);
+        getFolderPath.Parameters.Add(new ParameterDefinition(module.TypeSystem.Int32));
+        pathMethod.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Ldc_I4_7));
+        pathMethod.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Call, getFolderPath));
+        pathMethod.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Pop));
+        pathMethod.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Ret));
+        type.Methods.Add(pathMethod);
 
         return type;
     }

--- a/Services/InstructionAnalyzer.cs
+++ b/Services/InstructionAnalyzer.cs
@@ -383,6 +383,11 @@ namespace MLVScan.Services
                             reflectionDetectorStart);
                         foreach (var finding in reflectionFindings)
                         {
+                            if (HasFindingForRuleAtLocation(result.Findings, finding))
+                            {
+                                continue;
+                            }
+
                             result.Findings.Add(finding);
                             _telemetry.IncrementCounter("InstructionAnalyzer.ReflectionBypassFindings");
                             if (methodSignals != null && _reflectionRule != null &&
@@ -427,6 +432,13 @@ namespace MLVScan.Services
                 existing.Severity == candidate.Severity);
         }
 
+        private static bool HasFindingForRuleAtLocation(IEnumerable<ScanFinding> findings, ScanFinding candidate)
+        {
+            return findings.Any(existing =>
+                string.Equals(existing.RuleId, candidate.RuleId, StringComparison.Ordinal) &&
+                string.Equals(existing.Location, candidate.Location, StringComparison.Ordinal));
+        }
+
         /// <summary>
         /// Builds a set of instruction offsets that are inside exception handler blocks.
         /// These are already analyzed by ExceptionHandlerAnalyzer with proper context.
@@ -464,7 +476,7 @@ namespace MLVScan.Services
             if (signals == null)
                 return false;
 
-            if (signals.UsesSensitiveFolder || signals.HasPathManipulation)
+            if (signals.UsesSensitiveFolder || signals.HasEnvironmentVariableModification)
                 return true;
 
             foreach (var triggeredRuleId in signals.GetTriggeredRuleIds())

--- a/Services/InstructionAnalyzer.cs
+++ b/Services/InstructionAnalyzer.cs
@@ -464,6 +464,9 @@ namespace MLVScan.Services
             if (signals == null)
                 return false;
 
+            if (signals.UsesSensitiveFolder || signals.HasPathManipulation)
+                return true;
+
             foreach (var triggeredRuleId in signals.GetTriggeredRuleIds())
             {
                 if (triggeredRuleId.Equals(reflectionRuleId, StringComparison.Ordinal))

--- a/Services/ReflectionDetector.cs
+++ b/Services/ReflectionDetector.cs
@@ -360,29 +360,14 @@ namespace MLVScan.Services
             if (signals.HasEncodedStrings || signals.HasBase64)
                 return true;
 
-            if (signals.HasProcessLikeCall)
+            if (signals.HasProcessLikeCall || signals.UsesSensitiveFolder)
                 return true;
 
-            if (signals.HasEnvironmentVariableModification)
+            if (signals.HasEnvironmentVariableModification || signals.HasPathManipulation)
                 return true;
 
             if (signals.HasNetworkCall && signals.HasFileWrite)
                 return true;
-
-            // Sensitive-folder and path-manipulation signals are noisy on their own.
-            // Require additional execution/decode/network context before elevating reflection.
-            if (signals.UsesSensitiveFolder &&
-                (signals.HasProcessLikeCall || signals.HasNetworkCall || signals.HasFileWrite ||
-                 signals.HasEncodedStrings || signals.HasBase64))
-            {
-                return true;
-            }
-
-            if (signals.HasPathManipulation &&
-                (signals.HasProcessLikeCall || signals.HasNetworkCall || signals.HasEnvironmentVariableModification))
-            {
-                return true;
-            }
 
             return false;
         }

--- a/Services/ReflectionDetector.cs
+++ b/Services/ReflectionDetector.cs
@@ -363,7 +363,7 @@ namespace MLVScan.Services
             if (signals.HasProcessLikeCall || signals.UsesSensitiveFolder)
                 return true;
 
-            if (signals.HasEnvironmentVariableModification || signals.HasPathManipulation)
+            if (signals.HasEnvironmentVariableModification)
                 return true;
 
             if (signals.HasNetworkCall && signals.HasFileWrite)

--- a/Services/TypeScanner.cs
+++ b/Services/TypeScanner.cs
@@ -222,6 +222,9 @@ namespace MLVScan.Services
 
         private static bool HasStrongReflectionCompanion(MethodSignals typeSignal, string reflectionRuleId)
         {
+            if (typeSignal.UsesSensitiveFolder || typeSignal.HasPathManipulation)
+                return true;
+
             foreach (var triggeredRuleId in typeSignal.GetTriggeredRuleIds())
             {
                 if (triggeredRuleId.Equals(reflectionRuleId, StringComparison.Ordinal))

--- a/Services/TypeScanner.cs
+++ b/Services/TypeScanner.cs
@@ -222,7 +222,7 @@ namespace MLVScan.Services
 
         private static bool HasStrongReflectionCompanion(MethodSignals typeSignal, string reflectionRuleId)
         {
-            if (typeSignal.UsesSensitiveFolder || typeSignal.HasPathManipulation)
+            if (typeSignal.UsesSensitiveFolder || typeSignal.HasEnvironmentVariableModification)
                 return true;
 
             foreach (var triggeredRuleId in typeSignal.GetTriggeredRuleIds())


### PR DESCRIPTION
## Summary

- restore sensitive-path and path-manipulation evidence as qualifying reflection context
- preserve the correlation at both method and type scope
- add focused coverage for direct and cross-method signal combinations

## Validation

- focused reflection/type scanning tests: 19 passed
- false-positive suite: 53 passed, 7 optional/environment-specific tests skipped; all available disposition gates remain Clean with no threat-family matches
- quarantine suite: 180 passed, 1 optional sample skipped; all available samples remain KnownThreat
- full suite: 1,570 passed, 19 expected/environment-specific skips

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Restore sensitive-folder and path-manipulation signals as strong reflection evidence.
- Preserve signal correlation across methods within the same type.
- Add coverage for direct and cross-method signal combinations.
- Validation passed: 1,570 tests, with 19 expected or environment-specific skips.

| Author | Lines added | Lines removed |
|---|---:|---:|
| Not specified | 102 | 19 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->