### PR TITLE
Restore high-risk classification for process-memory dump imports

### DIFF
--- a/MLVScan.Core.Tests/Unit/Services/DllImportScannerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DllImportScannerTests.cs
@@ -129,6 +129,37 @@ public class DllImportScannerTests
         findings[0].Description.Should().Contain("diagnostic DllImport");
     }
 
+    [Theory]
+    [InlineData("MiniDumpWriteDump")]
+    [InlineData("MiniDumpWriteDumpA")]
+    [InlineData("MiniDumpWriteDumpW")]
+    public void ScanForDllImports_WithMiniDumpWriteDump_ReturnsHighSeverity(string entryPoint)
+    {
+        var rules = new List<IScanRule> { new DllImportRule() };
+        var scanner = new DllImportScanner(rules);
+
+        var assemblyBuilder = TestAssemblyBuilder.Create();
+        var assembly = assemblyBuilder.Build();
+
+        var type = new TypeDefinition("Test", "NativeMethods", TypeAttributes.Public | TypeAttributes.Class);
+        assembly.MainModule.Types.Add(type);
+
+        var method = new MethodDefinition("WriteDump",
+            MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.PInvokeImpl,
+            assembly.MainModule.TypeSystem.Boolean);
+
+        var moduleRef = new ModuleReference("dbghelp.dll");
+        assembly.MainModule.ModuleReferences.Add(moduleRef);
+        method.PInvokeInfo = new PInvokeInfo(PInvokeAttributes.CallConvWinapi, entryPoint, moduleRef);
+        type.Methods.Add(method);
+
+        var findings = scanner.ScanForDllImports(assembly.MainModule).ToList();
+
+        findings.Should().ContainSingle();
+        findings[0].Severity.Should().Be(Severity.High);
+        findings[0].Description.Should().Contain("elevated-risk function");
+    }
+
     [Fact]
     public void ScanForDllImports_WithExtensionlessElevatedRiskDll_ReturnsHighSeverity()
     {

--- a/Models/Rules/DllImportRule.cs
+++ b/Models/Rules/DllImportRule.cs
@@ -139,6 +139,13 @@ namespace MLVScan.Models.Rules
             "resumethread"
         ];
 
+        // Process-memory dump primitives are security-significant even when exported by
+        // DLLs that also support legitimate crash diagnostics.
+        private static readonly string[] CredentialDumpFunctions =
+        [
+            "minidumpwritedump"
+        ];
+
         // Native execution entry points that can directly launch payloads.
         private static readonly string[] NativeExecutionFunctions =
         [
@@ -159,8 +166,7 @@ namespace MLVScan.Models.Rules
             "process32first",
             "process32next",
             "rtlgetversion",
-            "ntqueryinformationprocess",
-            "minidumpwritedump"
+            "ntqueryinformationprocess"
         ];
 
         // Specific UI-only imports that are common in legitimate software and do not
@@ -200,6 +206,13 @@ namespace MLVScan.Models.Rules
 
             var lowerDllName = dllName.ToLower();
             var entryPointLower = entryPoint.ToLower();
+
+            if (MatchesKnownApi(entryPointLower, CredentialDumpFunctions))
+            {
+                _severity = Severity.High;
+                _description = $"Detected elevated-risk function {entryPoint} in DllImport from {dllName}";
+                return true;
+            }
 
             if (MatchesKnownApi(entryPointLower, DiagnosticFunctions))
             {


### PR DESCRIPTION
## Summary
- separate a security-sensitive process-memory dump API from the low-risk diagnostics allowlist
- preserve Low severity for ordinary diagnostic imports
- add regression coverage for supported export-name variants

## Validation
- focused scanner tests: 23 passed
- false-positive suite: 53 passed, 7 optional skips; available samples remained Clean with no family match
- quarantine suite: 180 passed, 1 optional skip; all available samples remained KnownThreat
- full suite: 1,571 passed, 19 optional skips

Detailed reproduction and attack-path notes remain private in Codex Security.