### PR TITLE
Restore suspicious download reflection correlation

### DIFF
--- a/MLVScan.Core.Tests/Unit/Services/ExceptionHandlerAnalyzerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/ExceptionHandlerAnalyzerTests.cs
@@ -72,6 +72,24 @@ public class ExceptionHandlerAnalyzerTests
         findings[0].Description.Should().Contain("exception catch block");
     }
 
+    [Fact]
+    public void AnalyzeExceptionHandlers_WithSuspiciousDownload_PropagatesReflectionCompanionSignal()
+    {
+        var config = new ScanConfig { AnalyzeExceptionHandlers = true, EnableMultiSignalDetection = true };
+        var tracker = new SignalTracker(config);
+        var analyzer = new ExceptionHandlerAnalyzer([new DataInfiltrationRule()], tracker,
+            new CodeSnippetBuilder(), config);
+        var method = CreateMethodWithCatchSuspiciousDownload();
+        var methodSignals = new MethodSignals();
+
+        var findings = analyzer.AnalyzeExceptionHandlers(method, method.Body.ExceptionHandlers,
+            methodSignals, method.DeclaringType!.FullName).ToList();
+
+        findings.Should().BeEmpty("the companion-gated download finding is not independently emitted");
+        methodSignals.HasSuspiciousNetworkDownload.Should().BeTrue();
+        tracker.GetTypeSignals(method.DeclaringType.FullName)!.HasSuspiciousNetworkDownload.Should().BeTrue();
+    }
+
     private static MethodDefinition CreateMethodWithCatchCalling(string calledType, string calledMethod)
     {
         var assembly = AssemblyDefinition.CreateAssembly(
@@ -135,6 +153,20 @@ public class ExceptionHandlerAnalyzerTests
         loadFrom.Parameters.Add(new ParameterDefinition(method.Module.TypeSystem.String));
         var il = method.Body.GetILProcessor();
         il.InsertBefore(call, il.Create(OpCodes.Ldstr, "Plugins\\OptionalDependency.dll"));
+        il.InsertAfter(call, il.Create(OpCodes.Pop));
+        return method;
+    }
+
+    private static MethodDefinition CreateMethodWithCatchSuspiciousDownload()
+    {
+        var method = CreateMethodWithCatchCalling("System.Net.WebClient", "DownloadString");
+        var call = method.Body.Instructions.Single(i =>
+            i.OpCode == OpCodes.Call && i.Operand is MethodReference reference && reference.Name == "DownloadString");
+        var downloadString = (MethodReference)call.Operand;
+        downloadString.ReturnType = method.Module.TypeSystem.String;
+        downloadString.Parameters.Add(new ParameterDefinition(method.Module.TypeSystem.String));
+        var il = method.Body.GetILProcessor();
+        il.InsertBefore(call, il.Create(OpCodes.Ldstr, "https://pastebin.com/raw/example"));
         il.InsertAfter(call, il.Create(OpCodes.Pop));
         return method;
     }

--- a/MLVScan.Core.Tests/Unit/Services/ExceptionHandlerAnalyzerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/ExceptionHandlerAnalyzerTests.cs
@@ -90,6 +90,25 @@ public class ExceptionHandlerAnalyzerTests
         tracker.GetTypeSignals(method.DeclaringType.FullName)!.HasSuspiciousNetworkDownload.Should().BeTrue();
     }
 
+    [Fact]
+    public void AnalyzeExceptionHandlers_WithTerminalSuspiciousDownload_PropagatesReflectionCompanionSignal()
+    {
+        var config = new ScanConfig { AnalyzeExceptionHandlers = true, EnableMultiSignalDetection = true };
+        var tracker = new SignalTracker(config);
+        var analyzer = new ExceptionHandlerAnalyzer([new DataInfiltrationRule()], tracker,
+            new CodeSnippetBuilder(), config);
+        var method = CreateMethodWithCatchSuspiciousDownload();
+        method.Body.ExceptionHandlers[0].HandlerEnd = null;
+        var methodSignals = new MethodSignals();
+
+        var findings = analyzer.AnalyzeExceptionHandlers(method, method.Body.ExceptionHandlers,
+            methodSignals, method.DeclaringType!.FullName).ToList();
+
+        findings.Should().BeEmpty("the companion-gated download finding is not independently emitted");
+        methodSignals.HasSuspiciousNetworkDownload.Should().BeTrue();
+        tracker.GetTypeSignals(method.DeclaringType.FullName)!.HasSuspiciousNetworkDownload.Should().BeTrue();
+    }
+
     private static MethodDefinition CreateMethodWithCatchCalling(string calledType, string calledMethod)
     {
         var assembly = AssemblyDefinition.CreateAssembly(

--- a/MLVScan.Core.Tests/Unit/Services/InstructionAnalyzerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/InstructionAnalyzerTests.cs
@@ -144,6 +144,20 @@ public class InstructionAnalyzerTests
         result.Findings.Should().ContainSingle(f => f.RuleId == "ReflectionRule");
     }
 
+    [Fact]
+    public void AnalyzeInstructions_SuspiciousDownloadBeforeNonLiteralReflection_EmitsReflectionFinding()
+    {
+        var config = new ScanConfig { EnableMultiSignalDetection = true };
+        var analyzer = CreateAnalyzer(config,
+            new IScanRule[] { new DataInfiltrationRule(), new ReflectionRule() });
+        var method = CreateSuspiciousDownloadReflectionMethod();
+
+        var result = analyzer.AnalyzeInstructions(method, method.Body.Instructions, new MethodSignals(),
+            method.DeclaringType!.FullName);
+
+        result.Findings.Should().ContainSingle(f => f.RuleId == "ReflectionRule");
+    }
+
     private static InstructionAnalyzer CreateAnalyzer(ScanConfig config, IEnumerable<IScanRule> rules)
     {
         var signalTracker = new SignalTracker(config);
@@ -225,6 +239,39 @@ public class InstructionAnalyzerTests
         var processor = method.Body.GetILProcessor();
         processor.Append(Instruction.Create(OpCodes.Ldc_I4_7));
         processor.Append(Instruction.Create(OpCodes.Call, getFolderPath));
+        processor.Append(Instruction.Create(OpCodes.Pop));
+        processor.Append(Instruction.Create(OpCodes.Call, invokeMethod));
+        processor.Append(Instruction.Create(OpCodes.Pop));
+        processor.Append(Instruction.Create(OpCodes.Ret));
+        type.Methods.Add(method);
+
+        return method;
+    }
+
+    private static MethodDefinition CreateSuspiciousDownloadReflectionMethod()
+    {
+        var assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition("InstructionAnalyzerNetworkReflectionTest", new Version(1, 0, 0, 0)),
+            "InstructionAnalyzerNetworkReflectionTest",
+            ModuleKind.Dll);
+        var module = assembly.MainModule;
+        var type = new TypeDefinition("Test", "NetworkReflectionType", TypeAttributes.Public | TypeAttributes.Class,
+            module.TypeSystem.Object);
+        module.Types.Add(type);
+
+        var method = new MethodDefinition("Run", MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Void);
+        method.Body = new MethodBody(method);
+
+        var webClientType = new TypeReference("System.Net", "WebClient", module, module.TypeSystem.CoreLibrary);
+        var downloadString = new MethodReference("DownloadString", module.TypeSystem.String, webClientType);
+        downloadString.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        var methodInfoType = new TypeReference("System.Reflection", "MethodInfo", module, module.TypeSystem.CoreLibrary);
+        var invokeMethod = new MethodReference("Invoke", module.TypeSystem.Object, methodInfoType);
+
+        var processor = method.Body.GetILProcessor();
+        processor.Append(Instruction.Create(OpCodes.Ldstr, "https://pastebin.com/raw/example"));
+        processor.Append(Instruction.Create(OpCodes.Call, downloadString));
         processor.Append(Instruction.Create(OpCodes.Pop));
         processor.Append(Instruction.Create(OpCodes.Call, invokeMethod));
         processor.Append(Instruction.Create(OpCodes.Pop));

--- a/MLVScan.Core.Tests/Unit/Services/SignalTrackerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/SignalTrackerTests.cs
@@ -254,6 +254,18 @@ public class SignalTrackerTests
     }
 
     [Fact]
+    public void MarkSuspiciousNetworkDownload_SetsFlag()
+    {
+        var config = new ScanConfig { EnableMultiSignalDetection = true };
+        var tracker = new SignalTracker(config);
+        var signals = new MethodSignals();
+
+        tracker.MarkSuspiciousNetworkDownload(signals, null);
+
+        signals.HasSuspiciousNetworkDownload.Should().BeTrue();
+    }
+
+    [Fact]
     public void MarkRuleTriggered_AddsRuleIdToSignals()
     {
         var config = new ScanConfig { EnableMultiSignalDetection = true };

--- a/MLVScan.Core.Tests/Unit/Services/TypeScannerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/TypeScannerTests.cs
@@ -68,6 +68,36 @@ public class TypeScannerTests
     }
 
     [Fact]
+    public void ScanType_WithReflectionAndSuspiciousDownloadAcrossMethods_AddsCombinedReflectionFinding()
+    {
+        var config = new ScanConfig { EnableMultiSignalDetection = true, AnalyzePropertyAccessors = false };
+        var rules = new IScanRule[] { new DataInfiltrationRule(), new ReflectionRule() };
+
+        var signalTracker = new SignalTracker(config);
+        var snippetBuilder = new CodeSnippetBuilder();
+        var stringPatternDetector = new StringPatternDetector();
+        var reflectionDetector = new ReflectionDetector(rules, signalTracker, stringPatternDetector, snippetBuilder);
+        var localVariableAnalyzer = new LocalVariableAnalyzer(rules, signalTracker, config);
+        var exceptionHandlerAnalyzer = new ExceptionHandlerAnalyzer(rules, signalTracker, snippetBuilder, config);
+        var instructionAnalyzer = new InstructionAnalyzer(rules, signalTracker, reflectionDetector,
+            stringPatternDetector, snippetBuilder, config, null);
+        var methodScanner = new MethodScanner(rules, signalTracker, instructionAnalyzer, snippetBuilder,
+            localVariableAnalyzer, exceptionHandlerAnalyzer, config);
+        var propertyEventScanner = new PropertyEventScanner(methodScanner, config);
+        var typeScanner = new TypeScanner(methodScanner, signalTracker, reflectionDetector, snippetBuilder,
+            propertyEventScanner, rules, config);
+
+        var type = CreateTypeWithReflectionAndSuspiciousDownloadMethods();
+
+        var findings = typeScanner.ScanType(type).ToList();
+
+        findings.Should().Contain(finding =>
+            finding.RuleId == "ReflectionRule" &&
+            finding.Severity == Severity.High &&
+            finding.Description.Contains("combined with other suspicious patterns detected in this type"));
+    }
+
+    [Fact]
     public void ScanType_RecursivelyScansNestedTypes()
     {
         var config = new ScanConfig { EnableMultiSignalDetection = true, AnalyzePropertyAccessors = false };
@@ -213,6 +243,42 @@ public class TypeScannerTests
         pathMethod.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Pop));
         pathMethod.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Ret));
         type.Methods.Add(pathMethod);
+
+        return type;
+    }
+
+    private static TypeDefinition CreateTypeWithReflectionAndSuspiciousDownloadMethods()
+    {
+        var assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition("NetworkReflectionTypeScan", new Version(1, 0, 0, 0)),
+            "NetworkReflectionTypeScan",
+            ModuleKind.Dll);
+        var module = assembly.MainModule;
+        var type = new TypeDefinition("Test", "NetworkReflectionType", TypeAttributes.Public | TypeAttributes.Class,
+            module.TypeSystem.Object);
+        module.Types.Add(type);
+
+        var reflectMethod = new MethodDefinition("Reflect", MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Void);
+        var methodInfoType = new TypeReference("System.Reflection", "MethodInfo", module,
+            module.TypeSystem.CoreLibrary);
+        var invokeRef = new MethodReference("Invoke", module.TypeSystem.Object, methodInfoType);
+        reflectMethod.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Call, invokeRef));
+        reflectMethod.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Pop));
+        reflectMethod.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Ret));
+        type.Methods.Add(reflectMethod);
+
+        var downloadMethod = new MethodDefinition("Download", MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Void);
+        var webClientType = new TypeReference("System.Net", "WebClient", module, module.TypeSystem.CoreLibrary);
+        var downloadString = new MethodReference("DownloadString", module.TypeSystem.String, webClientType);
+        downloadString.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        downloadMethod.Body.GetILProcessor().Append(
+            Instruction.Create(OpCodes.Ldstr, "https://pastebin.com/raw/example"));
+        downloadMethod.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Call, downloadString));
+        downloadMethod.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Pop));
+        downloadMethod.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Ret));
+        type.Methods.Add(downloadMethod);
 
         return type;
     }

--- a/Models/MethodSignals.cs
+++ b/Models/MethodSignals.cs
@@ -37,6 +37,11 @@ namespace MLVScan.Models
         public bool HasNetworkCall { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether a download rule matched a suspicious endpoint or payload source.
+        /// </summary>
+        public bool HasSuspiciousNetworkDownload { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether the method writes data to disk.
         /// </summary>
         public bool HasFileWrite { get; set; }

--- a/Services/ExceptionHandlerAnalyzer.cs
+++ b/Services/ExceptionHandlerAnalyzer.cs
@@ -88,6 +88,9 @@ namespace MLVScan.Services
                         // Check if any rule considers this method suspicious
                         foreach (var rule in _rules)
                         {
+                            TrackSuspiciousDownloadSignal(method, calledMethod, allInstructions,
+                                allInstructions.IndexOf(instruction), methodSignals, rule);
+
                             if (rule.IsSuspicious(calledMethod))
                             {
                                 var instructionIndex = allInstructions.IndexOf(instruction);
@@ -180,6 +183,30 @@ namespace MLVScan.Services
             }
 
             return findings;
+        }
+
+        private void TrackSuspiciousDownloadSignal(
+            MethodDefinition method,
+            MethodReference calledMethod,
+            Mono.Collections.Generic.Collection<Instruction> allInstructions,
+            int instructionIndex,
+            MethodSignals? methodSignals,
+            IScanRule rule)
+        {
+            if (instructionIndex < 0 || methodSignals == null ||
+                !rule.RuleId.Equals("DataInfiltrationRule", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            foreach (var finding in rule.AnalyzeContextualPattern(
+                         calledMethod, allInstructions, instructionIndex, methodSignals))
+            {
+                if (finding.Severity is Severity.High or Severity.Critical)
+                {
+                    _signalTracker.MarkSuspiciousNetworkDownload(methodSignals, method.DeclaringType);
+                }
+            }
         }
 
         private static List<Instruction> GetInstructionsInRange(

--- a/Services/ExceptionHandlerAnalyzer.cs
+++ b/Services/ExceptionHandlerAnalyzer.cs
@@ -40,7 +40,7 @@ namespace MLVScan.Services
                 foreach (var handler in exceptionHandlers)
                 {
                     // Analyze handler block (catch/finally/filter)
-                    if (handler.HandlerStart != null && handler.HandlerEnd != null)
+                    if (handler.HandlerStart != null)
                     {
                         var handlerFindings = AnalyzeHandlerBlock(
                             method,

--- a/Services/InstructionAnalyzer.cs
+++ b/Services/InstructionAnalyzer.cs
@@ -210,6 +210,14 @@ namespace MLVScan.Services
                                     contextualRuleStart);
                                 foreach (var finding in ruleFindings)
                                 {
+                                    if (methodSignals != null &&
+                                        rule.RuleId.Equals("DataInfiltrationRule", StringComparison.Ordinal) &&
+                                        finding.Severity is Severity.High or Severity.Critical)
+                                    {
+                                        _signalTracker.MarkSuspiciousNetworkDownload(methodSignals,
+                                            method.DeclaringType);
+                                    }
+
                                     // If rule requires companion finding, check if other rules have been triggered
                                     // Exception: Low severity findings are always allowed (e.g., legitimate update checkers)
                                     // Exception: Findings with BypassCompanionCheck are always allowed (high-confidence scored findings)
@@ -476,7 +484,8 @@ namespace MLVScan.Services
             if (signals == null)
                 return false;
 
-            if (signals.UsesSensitiveFolder || signals.HasEnvironmentVariableModification)
+            if (signals.UsesSensitiveFolder || signals.HasEnvironmentVariableModification ||
+                signals.HasSuspiciousNetworkDownload)
                 return true;
 
             foreach (var triggeredRuleId in signals.GetTriggeredRuleIds())

--- a/Services/ReflectionDetector.cs
+++ b/Services/ReflectionDetector.cs
@@ -366,6 +366,9 @@ namespace MLVScan.Services
             if (signals.HasEnvironmentVariableModification)
                 return true;
 
+            if (signals.HasSuspiciousNetworkDownload)
+                return true;
+
             if (signals.HasNetworkCall && signals.HasFileWrite)
                 return true;
 

--- a/Services/SignalTracker.cs
+++ b/Services/SignalTracker.cs
@@ -218,6 +218,27 @@ namespace MLVScan.Services
         }
 
         /// <summary>
+        /// Marks the current method and declaring type as containing a rule-confirmed suspicious download.
+        /// </summary>
+        /// <param name="methodSignals">The method-level signal bag to update.</param>
+        /// <param name="declaringType">The declaring type used for type-level aggregation, if available.</param>
+        public void MarkSuspiciousNetworkDownload(MethodSignals? methodSignals, TypeDefinition? declaringType)
+        {
+            if (methodSignals == null)
+                return;
+
+            methodSignals.HasSuspiciousNetworkDownload = true;
+            if (declaringType != null)
+            {
+                var typeSignal = GetOrCreateTypeSignals(declaringType.FullName);
+                if (typeSignal != null)
+                {
+                    typeSignal.HasSuspiciousNetworkDownload = true;
+                }
+            }
+        }
+
+        /// <summary>
         /// Marks the current method and declaring type as using suspicious local variables.
         /// </summary>
         /// <param name="methodSignals">The method-level signal bag to update.</param>

--- a/Services/TypeScanner.cs
+++ b/Services/TypeScanner.cs
@@ -222,7 +222,8 @@ namespace MLVScan.Services
 
         private static bool HasStrongReflectionCompanion(MethodSignals typeSignal, string reflectionRuleId)
         {
-            if (typeSignal.UsesSensitiveFolder || typeSignal.HasEnvironmentVariableModification)
+            if (typeSignal.UsesSensitiveFolder || typeSignal.HasEnvironmentVariableModification ||
+                typeSignal.HasSuspiciousNetworkDownload)
                 return true;
 
             foreach (var triggeredRuleId in typeSignal.GetTriggeredRuleIds())


### PR DESCRIPTION
## Summary
- distinguish rule-confirmed suspicious downloads from ordinary network activity
- preserve that signal at method and type scope for reflection correlation
- cover same-method and cross-method reflective execution paths

## Validation
- focused correlation tests: 47 passed
- false-positive suite: 53 passed, 7 optional skips; available samples remained Clean with no family match
- quarantine suite: 180 passed, 1 optional skip; all available samples remained KnownThreat
- full suite: 1,574 passed, 19 optional skips

Detailed reproduction and attack-path notes remain private in Codex Security.