### PR TITLE
Bind Process.Start suppressions to launched values

### DIFF
--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -1919,6 +1919,44 @@ public class ProcessStartRuleTests
     }
 
     [Fact]
+    public void ShouldSuppressFinding_SameModuleTypesSpoofCurrentProcessChain_ReturnsFalse()
+    {
+        using var module = ModuleDefinition.CreateModule("SpoofedProcessTypes", ModuleKind.Dll);
+        var voidType = module.TypeSystem.Void;
+        var stringType = module.TypeSystem.String;
+        var fakeProcess = new TypeDefinition("System.Diagnostics", "Process",
+            TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        var fakeProcessModule = new TypeDefinition("System.Diagnostics", "ProcessModule",
+            TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        var host = new TypeDefinition("Tests", "Host", TypeAttributes.Public | TypeAttributes.Class,
+            module.TypeSystem.Object);
+        module.Types.Add(fakeProcess);
+        module.Types.Add(fakeProcessModule);
+        module.Types.Add(host);
+
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static, voidType);
+        host.Methods.Add(method);
+        var getCurrentProcess = new MethodReference("GetCurrentProcess", fakeProcess, fakeProcess);
+        var getMainModule = new MethodReference("get_MainModule", fakeProcessModule, fakeProcess) { HasThis = true };
+        var getFileName = new MethodReference("get_FileName", stringType, fakeProcessModule) { HasThis = true };
+        var frameworkScope = new AssemblyNameReference("System.Diagnostics.Process", new Version(8, 0, 0, 0));
+        var frameworkProcess = new TypeReference("System.Diagnostics", "Process", module, frameworkScope);
+        var processStart = new MethodReference("Start", frameworkProcess, frameworkProcess);
+        processStart.Parameters.Add(new ParameterDefinition(stringType));
+
+        var processor = method.Body.GetILProcessor();
+        processor.Emit(OpCodes.Call, getCurrentProcess);
+        processor.Emit(OpCodes.Callvirt, getMainModule);
+        processor.Emit(OpCodes.Callvirt, getFileName);
+        processor.Emit(OpCodes.Call, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
     public void ShouldSuppressFinding_RestartTargetOverwrittenInFinally_ReturnsFalse()
     {
         var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -2198,6 +2198,46 @@ public class ProcessStartRuleTests
     }
 
     [Fact]
+    public void ShouldSuppressFinding_FileNameOverwrittenAfterLaunchOnLoopBackedge_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var startInfo = new VariableDefinition(startInfoType);
+        method.Body.Variables.Add(startInfo);
+        var constructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var processStart = CreateProcessStart(startInfoType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stloc, startInfo);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt, setFileName);
+        var loopStart = Instruction.Create(OpCodes.Ldloc, startInfo);
+        il.Append(loopStart);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Ldstr, "arbitrary.exe");
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Emit(OpCodes.Br, loopStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
     public void RestartAnalysisBudget_ManyStartsAndCompetingWrites_ReturnsFalse()
     {
         var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -1264,6 +1264,120 @@ public class ProcessStartRuleTests
     }
 
     [Fact]
+    public void ShouldSuppressFinding_ConditionalExplorerLocalOverwrite_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        method.Parameters.Add(new ParameterDefinition(new TypeReference("System", "Boolean", null, null)));
+        var stringType = new TypeReference("System", "String", null, null);
+        var targetLocal = new VariableDefinition(stringType);
+        method.Body.Variables.Add(targetLocal);
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Ldstr, "arbitrary.exe");
+        il.Emit(OpCodes.Stloc, targetLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        var launch = Instruction.Create(OpCodes.Ldloc, targetLocal);
+        il.Emit(OpCodes.Brfalse, launch);
+        il.Emit(OpCodes.Ldstr, "explorer.exe");
+        il.Emit(OpCodes.Stloc, targetLocal);
+        il.Append(launch);
+        il.Emit(OpCodes.Call, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_ConstructorRestartWithConditionalLaterOverwrite_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        method.Parameters.Add(new ParameterDefinition(new TypeReference("System", "Boolean", null, null)));
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var stringType = new TypeReference("System", "String", null, null);
+        var startInfoLocal = new VariableDefinition(startInfoType);
+        method.Body.Variables.Add(startInfoLocal);
+        var constructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        constructor.Parameters.Add(new ParameterDefinition(stringType));
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var processStart = new MethodReference("Start", processType, processType);
+        processStart.Parameters.Add(new ParameterDefinition(startInfoType));
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stloc, startInfoLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        var launch = Instruction.Create(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Brfalse, launch);
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Ldstr, "arbitrary.exe");
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Append(launch);
+        il.Emit(OpCodes.Call, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_CurrentProcessReceiverBypassedByException_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var stringType = new TypeReference("System", "String", null, null);
+        var processLocal = new VariableDefinition(processType);
+        method.Body.Variables.Add(processLocal);
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Newobj, new MethodReference(".ctor", method.ReturnType, processType) { HasThis = true });
+        il.Emit(OpCodes.Stloc, processLocal);
+        var tryStart = Instruction.Create(OpCodes.Call,
+            new MethodReference("MayThrow", method.ReturnType, new TypeReference("Test", "Helpers", null, null)));
+        il.Append(tryStart);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Stloc, processLocal);
+        var launch = Instruction.Create(OpCodes.Ldloc, processLocal);
+        il.Emit(OpCodes.Leave, launch);
+        var handlerStart = Instruction.Create(OpCodes.Pop);
+        il.Append(handlerStart);
+        il.Emit(OpCodes.Leave, launch);
+        il.Append(launch);
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Call, processStart);
+        method.Body.ExceptionHandlers.Add(new ExceptionHandler(ExceptionHandlerType.Catch)
+        {
+            TryStart = tryStart,
+            TryEnd = handlerStart,
+            HandlerStart = handlerStart,
+            HandlerEnd = launch,
+            CatchType = new TypeReference("System", "Exception", null, null)
+        });
+        var signals = new MethodSignals { ExceptionHandlers = method.Body.ExceptionHandlers.ToArray() };
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, signals);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
     public void ShouldSuppressFinding_SavedRestartBeforeUnrelatedFileNameLookup_ReturnsTrue()
     {
         var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -2277,6 +2277,24 @@ public class ProcessStartRuleTests
     }
 
     [Fact]
+    public void RestartAnalysisBudget_ManyUnrelatedCalls_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processStart = CreateProcessStart(stringType);
+        var unrelated = new MethodReference("Tick", method.ReturnType,
+            new TypeReference("Test", "Helpers", null, null));
+        var il = method.Body.GetILProcessor();
+        for (int i = 0; i < 512; i++)
+            il.Emit(OpCodes.Call, unrelated);
+        il.Emit(OpCodes.Ldstr, "explorer.exe");
+        il.Emit(OpCodes.Call, processStart);
+
+        ProcessStartRule.IsRestartAnalysisWithinBudget(method.Body.Instructions).Should().BeFalse();
+    }
+
+    [Fact]
     public void ExplorerAnalysisBudget_ManyLocalBackedStarts_ReturnsFalse()
     {
         var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
@@ -2696,6 +2714,82 @@ public class ProcessStartRuleTests
             method.Body.Instructions.IndexOf(launch), new MethodSignals());
 
         result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_ProcessStartInfoEscapedToField_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var startInfo = new VariableDefinition(startInfoType);
+        method.Body.Variables.Add(startInfo);
+        var field = new FieldReference("GlobalStartInfo", startInfoType,
+            new TypeReference("Test", "State", null, null));
+        var constructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var processStart = CreateProcessStart(startInfoType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stloc, startInfo);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Stsfld, field);
+        il.Emit(OpCodes.Call, new MethodReference("RewriteGlobal", method.ReturnType,
+            new TypeReference("Test", "Helpers", null, null)));
+        il.Emit(OpCodes.Ldloc, startInfo);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_FieldBackedProcessStartInfoRestart_ReturnsTrue()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var field = new FieldReference("StartInfo", startInfoType,
+            new TypeReference("Test", "State", null, null));
+        var constructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var processStart = CreateProcessStart(startInfoType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stsfld, field);
+        il.Emit(OpCodes.Ldsfld, field);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Emit(OpCodes.Ldsfld, field);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeTrue();
     }
 
     [Fact]

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -2957,6 +2957,89 @@ public class ProcessStartRuleTests
     }
 
     [Fact]
+    public void ShouldSuppressFinding_ParameterBackedProcessStateCrossesUnknownCall_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var startInfo = new ParameterDefinition("startInfo", ParameterAttributes.None, startInfoType);
+        method.Parameters.Add(startInfo);
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var processStart = CreateProcessStart(startInfoType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Ldarg, startInfo);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Emit(OpCodes.Call, new MethodReference("RewriteGlobal", method.ReturnType,
+            new TypeReference("Test", "Helpers", null, null)));
+        il.Emit(OpCodes.Ldarg, startInfo);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_EquivalentRestartSettersOnBothBranches_ReturnsTrue()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var condition = new ParameterDefinition("condition", ParameterAttributes.None,
+            new TypeReference("System", "Boolean", null, null));
+        method.Parameters.Add(condition);
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var startInfo = new VariableDefinition(startInfoType);
+        method.Body.Variables.Add(startInfo);
+        var constructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var getCurrentProcess = new MethodReference("GetCurrentProcess", processType, processType);
+        var getMainModule = new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true };
+        var getFileName = new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true };
+        var processStart = CreateProcessStart(startInfoType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stloc, startInfo);
+        il.Emit(OpCodes.Ldarg, condition);
+        var falseBranch = Instruction.Create(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Brfalse, falseBranch);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Call, getCurrentProcess);
+        il.Emit(OpCodes.Callvirt, getMainModule);
+        il.Emit(OpCodes.Callvirt, getFileName);
+        il.Emit(OpCodes.Callvirt, setFileName);
+        var launchLoad = Instruction.Create(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Br, launchLoad);
+        il.Append(falseBranch);
+        il.Emit(OpCodes.Call, getCurrentProcess);
+        il.Emit(OpCodes.Callvirt, getMainModule);
+        il.Emit(OpCodes.Callvirt, getFileName);
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Append(launchLoad);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
     public void ShouldSuppressFinding_ManyLoopingNopsAfterRestartLaunch_ReturnsTrue()
     {
         var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -870,6 +870,114 @@ public class ProcessStartRuleTests
     }
 
     [Fact]
+    public void ShouldSuppressFinding_GetterBackedRestartWithSecondProperty_ReturnsTrue()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var stringType = new TypeReference("System", "String", null, null);
+        var processLocal = new VariableDefinition(processType);
+        method.Body.Variables.Add(processLocal);
+        var processConstructor = new MethodReference(".ctor", method.ReturnType, processType) { HasThis = true };
+        var getStartInfo = new MethodReference("get_StartInfo", startInfoType, processType) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var setUseShellExecute = new MethodReference("set_UseShellExecute", method.ReturnType, startInfoType)
+            { HasThis = true };
+        setUseShellExecute.Parameters.Add(new ParameterDefinition(new TypeReference("System", "Boolean", null, null)));
+        var getCurrentProcess = new MethodReference("GetCurrentProcess", processType, processType);
+        var getMainModule = new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true };
+        var getFileName = new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true };
+        var processStart = new MethodReference("Start", new TypeReference("System", "Boolean", null, null),
+            processType) { HasThis = true };
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Newobj, processConstructor);
+        il.Emit(OpCodes.Stloc, processLocal);
+        il.Emit(OpCodes.Ldloc, processLocal);
+        il.Emit(OpCodes.Callvirt, getStartInfo);
+        il.Emit(OpCodes.Call, getCurrentProcess);
+        il.Emit(OpCodes.Callvirt, getMainModule);
+        il.Emit(OpCodes.Callvirt, getFileName);
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Emit(OpCodes.Ldloc, processLocal);
+        il.Emit(OpCodes.Callvirt, getStartInfo);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Callvirt, setUseShellExecute);
+        il.Emit(OpCodes.Ldloc, processLocal);
+        il.Emit(OpCodes.Callvirt, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_SavedRestartAcrossUnrelatedBranch_ReturnsTrue()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var stringType = new TypeReference("System", "String", null, null);
+        var targetLocal = new VariableDefinition(stringType);
+        method.Body.Variables.Add(targetLocal);
+        var processStart = CreateProcessStart(stringType);
+        var branchTarget = Instruction.Create(OpCodes.Ldloc, targetLocal);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Stloc, targetLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Brfalse_S, branchTarget);
+        il.Emit(OpCodes.Nop);
+        il.Append(branchTarget);
+        il.Emit(OpCodes.Call, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_SavedRestartWithConditionalOverwrite_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var stringType = new TypeReference("System", "String", null, null);
+        var targetLocal = new VariableDefinition(stringType);
+        method.Body.Variables.Add(targetLocal);
+        var processStart = CreateProcessStart(stringType);
+        var branchTarget = Instruction.Create(OpCodes.Ldloc, targetLocal);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Stloc, targetLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Brfalse_S, branchTarget);
+        il.Emit(OpCodes.Ldstr, "arbitrary.exe");
+        il.Emit(OpCodes.Stloc, targetLocal);
+        il.Append(branchTarget);
+        il.Emit(OpCodes.Call, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
     public void ShouldSuppressFinding_SavedRestartBeforeUnrelatedFileNameLookup_ReturnsTrue()
     {
         var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -2796,6 +2796,77 @@ public class ProcessStartRuleTests
     }
 
     [Fact]
+    public void ShouldSuppressFinding_ProcessStartInfoEscapedBeforeSafeAssignment_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var startInfo = new VariableDefinition(startInfoType);
+        method.Body.Variables.Add(startInfo);
+        var field = new FieldReference("GlobalStartInfo", startInfoType,
+            new TypeReference("Test", "State", null, null));
+        var constructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var processStart = CreateProcessStart(startInfoType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stloc, startInfo);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Stsfld, field);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Emit(OpCodes.Call, new MethodReference("RewriteGlobal", method.ReturnType,
+            new TypeReference("Test", "Helpers", null, null)));
+        il.Emit(OpCodes.Ldloc, startInfo);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_ManyLoopingNopsAfterRestartLaunch_ReturnsTrue()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        var loopStart = Instruction.Create(OpCodes.Call,
+            new MethodReference("GetCurrentProcess", processType, processType));
+        il.Append(loopStart);
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+        il.Emit(OpCodes.Pop);
+        for (int i = 0; i < 5_000; i++)
+            il.Emit(OpCodes.Nop);
+        il.Emit(OpCodes.Br, loopStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
     public void ShouldSuppressFinding_FieldBackedProcessStartInfoRestart_ReturnsTrue()
     {
         var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -2379,6 +2379,79 @@ public class ProcessStartRuleTests
     }
 
     [Fact]
+    public void ShouldSuppressFinding_ProcessStartInfoPassedToHelper_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var startInfo = new VariableDefinition(startInfoType);
+        method.Body.Variables.Add(startInfo);
+        var constructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var rewrite = new MethodReference("RewriteTarget", method.ReturnType,
+            new TypeReference("Test", "Helpers", null, null));
+        rewrite.Parameters.Add(new ParameterDefinition(startInfoType));
+        var processStart = CreateProcessStart(startInfoType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stloc, startInfo);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Call, rewrite);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_CurrentProcessLocalPassedByReference_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var target = new VariableDefinition(stringType);
+        method.Body.Variables.Add(target);
+        var rewrite = new MethodReference("Rewrite", method.ReturnType,
+            new TypeReference("Test", "Helpers", null, null));
+        rewrite.Parameters.Add(new ParameterDefinition(new ByReferenceType(stringType)));
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Stloc, target);
+        il.Emit(OpCodes.Ldloca, target);
+        il.Emit(OpCodes.Call, rewrite);
+        il.Emit(OpCodes.Ldloc, target);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
     public void ShouldSuppressFinding_InstanceFieldBackedRestart_ReturnsTrue()
     {
         var declaringType = new TypeReference("Test", "State", null, null);

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -832,6 +832,48 @@ public class ProcessStartRuleTests
     }
 
     [Fact]
+    public void ShouldSuppressFinding_ConditionalRestartOverrideOfOtherTarget_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var stringType = new TypeReference("System", "String", null, null);
+        method.Parameters.Add(new ParameterDefinition(
+            new TypeReference("System", "Boolean", null, null)));
+        var startInfoLocal = new VariableDefinition(startInfoType);
+        method.Body.Variables.Add(startInfoLocal);
+        var constructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        constructor.Parameters.Add(new ParameterDefinition(stringType));
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var getCurrentProcess = new MethodReference("GetCurrentProcess", processType, processType);
+        var getMainModule = new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true };
+        var getFileName = new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true };
+        var processStart = CreateProcessStart(startInfoType);
+        var launch = Instruction.Create(OpCodes.Ldloc, startInfoLocal);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Ldstr, "other.exe");
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stloc, startInfoLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Brfalse_S, launch);
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Call, getCurrentProcess);
+        il.Emit(OpCodes.Callvirt, getMainModule);
+        il.Emit(OpCodes.Callvirt, getFileName);
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Append(launch);
+        il.Emit(OpCodes.Call, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
     public void ShouldSuppressFinding_GetterBackedProcessStartInfoRestart_ReturnsTrue()
     {
         var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -892,7 +892,8 @@ public class ProcessStartRuleTests
         var getMainModule = new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true };
         var getFileName = new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true };
         var processStart = new MethodReference("Start", new TypeReference("System", "Boolean", null, null),
-            processType) { HasThis = true };
+            processType)
+        { HasThis = true };
         var il = method.Body.GetILProcessor();
         il.Emit(OpCodes.Newobj, processConstructor);
         il.Emit(OpCodes.Stloc, processLocal);
@@ -927,13 +928,14 @@ public class ProcessStartRuleTests
         var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
         setFileName.Parameters.Add(new ParameterDefinition(stringType));
         var setUseShellExecute = new MethodReference("set_UseShellExecute", method.ReturnType, startInfoType)
-            { HasThis = true };
+        { HasThis = true };
         setUseShellExecute.Parameters.Add(new ParameterDefinition(new TypeReference("System", "Boolean", null, null)));
         var getCurrentProcess = new MethodReference("GetCurrentProcess", processType, processType);
         var getMainModule = new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true };
         var getFileName = new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true };
         var processStart = new MethodReference("Start", new TypeReference("System", "Boolean", null, null),
-            processType) { HasThis = true };
+            processType)
+        { HasThis = true };
         var il = method.Body.GetILProcessor();
         il.Emit(OpCodes.Newobj, processConstructor);
         il.Emit(OpCodes.Stloc, processLocal);
@@ -1077,6 +1079,186 @@ public class ProcessStartRuleTests
 
         var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
             method.Body.Instructions.Count - 1, signals);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_StringRestartStoreBypassedByException_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var stringType = new TypeReference("System", "String", null, null);
+        var targetLocal = new VariableDefinition(stringType);
+        method.Body.Variables.Add(targetLocal);
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Ldstr, "arbitrary.exe");
+        il.Emit(OpCodes.Stloc, targetLocal);
+        var tryStart = Instruction.Create(OpCodes.Call,
+            new MethodReference("MayThrow", method.ReturnType, new TypeReference("Test", "Helpers", null, null)));
+        il.Append(tryStart);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Stloc, targetLocal);
+        var launch = Instruction.Create(OpCodes.Ldloc, targetLocal);
+        il.Emit(OpCodes.Leave, launch);
+        var handlerStart = Instruction.Create(OpCodes.Pop);
+        il.Append(handlerStart);
+        il.Emit(OpCodes.Leave, launch);
+        il.Append(launch);
+        il.Emit(OpCodes.Call, processStart);
+        method.Body.ExceptionHandlers.Add(new ExceptionHandler(ExceptionHandlerType.Catch)
+        {
+            TryStart = tryStart,
+            TryEnd = handlerStart,
+            HandlerStart = handlerStart,
+            HandlerEnd = launch,
+            CatchType = new TypeReference("System", "Exception", null, null)
+        });
+        var signals = new MethodSignals { ExceptionHandlers = method.Body.ExceptionHandlers.ToArray() };
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, signals);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_SafeFileNameWithConditionalLaterOverwrite_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        method.Parameters.Add(new ParameterDefinition(new TypeReference("System", "Boolean", null, null)));
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var stringType = new TypeReference("System", "String", null, null);
+        var startInfoLocal = new VariableDefinition(startInfoType);
+        method.Body.Variables.Add(startInfoLocal);
+        var constructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var processStart = new MethodReference("Start", processType, processType);
+        processStart.Parameters.Add(new ParameterDefinition(startInfoType));
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stloc, startInfoLocal);
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Emit(OpCodes.Ldarg_0);
+        var launch = Instruction.Create(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Brfalse, launch);
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Ldstr, "arbitrary.exe");
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Append(launch);
+        il.Emit(OpCodes.Call, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_ConditionalSafeStartInfoAssignment_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        method.Parameters.Add(new ParameterDefinition(new TypeReference("System", "Boolean", null, null)));
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var stringType = new TypeReference("System", "String", null, null);
+        var processLocal = new VariableDefinition(processType);
+        var maliciousStartInfo = new VariableDefinition(startInfoType);
+        var safeStartInfo = new VariableDefinition(startInfoType);
+        method.Body.Variables.Add(processLocal);
+        method.Body.Variables.Add(maliciousStartInfo);
+        method.Body.Variables.Add(safeStartInfo);
+        var processConstructor = new MethodReference(".ctor", method.ReturnType, processType) { HasThis = true };
+        var startInfoConstructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        startInfoConstructor.Parameters.Add(new ParameterDefinition(stringType));
+        var setStartInfo = new MethodReference("set_StartInfo", method.ReturnType, processType) { HasThis = true };
+        setStartInfo.Parameters.Add(new ParameterDefinition(startInfoType));
+        var processStart = new MethodReference("Start", new TypeReference("System", "Boolean", null, null),
+            processType)
+        { HasThis = true };
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Newobj, processConstructor);
+        il.Emit(OpCodes.Stloc, processLocal);
+        il.Emit(OpCodes.Ldstr, "arbitrary.exe");
+        il.Emit(OpCodes.Newobj, startInfoConstructor);
+        il.Emit(OpCodes.Stloc, maliciousStartInfo);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Newobj, startInfoConstructor);
+        il.Emit(OpCodes.Stloc, safeStartInfo);
+        il.Emit(OpCodes.Ldloc, processLocal);
+        il.Emit(OpCodes.Ldloc, maliciousStartInfo);
+        il.Emit(OpCodes.Callvirt, setStartInfo);
+        il.Emit(OpCodes.Ldarg_0);
+        var launch = Instruction.Create(OpCodes.Ldloc, processLocal);
+        il.Emit(OpCodes.Brfalse, launch);
+        il.Emit(OpCodes.Ldloc, processLocal);
+        il.Emit(OpCodes.Ldloc, safeStartInfo);
+        il.Emit(OpCodes.Callvirt, setStartInfo);
+        il.Append(launch);
+        il.Emit(OpCodes.Callvirt, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_ReassignedStartInfoParameter_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var stringType = new TypeReference("System", "String", null, null);
+        var startInfoParameter = new ParameterDefinition(startInfoType);
+        method.Parameters.Add(startInfoParameter);
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var constructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        constructor.Parameters.Add(new ParameterDefinition(stringType));
+        var processStart = new MethodReference("Start", processType, processType);
+        processStart.Parameters.Add(new ParameterDefinition(startInfoType));
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Ldarg, startInfoParameter);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Emit(OpCodes.Ldstr, "arbitrary.exe");
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Starg, startInfoParameter);
+        il.Emit(OpCodes.Ldarg, startInfoParameter);
+        il.Emit(OpCodes.Call, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
 
         result.Should().BeFalse();
     }
@@ -1571,15 +1753,18 @@ public class ProcessStartRuleTests
         var startInfoConstructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
         var getCurrentProcess = new MethodReference("GetCurrentProcess", processType, processType);
         var getMainModule = new MethodReference("get_MainModule",
-            new TypeReference("System.Diagnostics", "ProcessModule", null, null), processType) { HasThis = true };
+            new TypeReference("System.Diagnostics", "ProcessModule", null, null), processType)
+        { HasThis = true };
         var getFileName = new MethodReference("get_FileName",
-            new TypeReference("System", "String", null, null), getMainModule.ReturnType) { HasThis = true };
+            new TypeReference("System", "String", null, null), getMainModule.ReturnType)
+        { HasThis = true };
         var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
         setFileName.Parameters.Add(new ParameterDefinition(getFileName.ReturnType));
         var setStartInfo = new MethodReference("set_StartInfo", method.ReturnType, processType) { HasThis = true };
         setStartInfo.Parameters.Add(new ParameterDefinition(startInfoType));
         var processStart = new MethodReference("Start", new TypeReference("System", "Boolean", null, null),
-            processType) { HasThis = true };
+            processType)
+        { HasThis = true };
 
         var il = method.Body.GetILProcessor();
         il.Emit(OpCodes.Newobj, processConstructor);

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -652,6 +652,31 @@ public class ProcessStartRuleTests
     }
 
     [Fact]
+    public void ShouldSuppressFinding_UnrelatedPathOperationBeforeExplorer_ReturnsTrue()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var pathCombine = new MethodReference("Combine", stringType,
+            new TypeReference("System.IO", "Path", null, null));
+        pathCombine.Parameters.Add(new ParameterDefinition(stringType));
+        pathCombine.Parameters.Add(new ParameterDefinition(stringType));
+        var processStart = CreateProcessStart(stringType);
+        var processor = method.Body.GetILProcessor();
+        processor.Emit(OpCodes.Ldstr, "unrelated");
+        processor.Emit(OpCodes.Ldstr, "path");
+        processor.Emit(OpCodes.Call, pathCombine);
+        processor.Emit(OpCodes.Pop);
+        processor.Emit(OpCodes.Ldstr, "explorer.exe");
+        processor.Emit(OpCodes.Call, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
     public void ShouldSuppressFinding_ExplorerExeWithPath_ReturnsFalse()
     {
         // Arrange: Build IL for "C:\\Windows\\explorer.exe" (should NOT suppress)
@@ -776,6 +801,67 @@ public class ProcessStartRuleTests
             scenario.ProcessStartIndex, new MethodSignals());
 
         result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_ProcessStartInfoConstructorRestart_ReturnsTrue()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var stringType = new TypeReference("System", "String", null, null);
+        var getCurrentProcess = new MethodReference("GetCurrentProcess", processType, processType);
+        var getMainModule = new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true };
+        var getFileName = new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true };
+        var constructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        constructor.Parameters.Add(new ParameterDefinition(stringType));
+        var processStart = CreateProcessStart(startInfoType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Call, getCurrentProcess);
+        il.Emit(OpCodes.Callvirt, getMainModule);
+        il.Emit(OpCodes.Callvirt, getFileName);
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Call, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_SavedRestartBeforeUnrelatedFileNameLookup_ReturnsTrue()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var stringType = new TypeReference("System", "String", null, null);
+        var targetLocal = new VariableDefinition(stringType);
+        method.Body.Variables.Add(targetLocal);
+        var getCurrentProcess = new MethodReference("GetCurrentProcess", processType, processType);
+        var getMainModule = new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true };
+        var getFileName = new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true };
+        var processConstructor = new MethodReference(".ctor", method.ReturnType, processType) { HasThis = true };
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Call, getCurrentProcess);
+        il.Emit(OpCodes.Callvirt, getMainModule);
+        il.Emit(OpCodes.Callvirt, getFileName);
+        il.Emit(OpCodes.Stloc, targetLocal);
+        il.Emit(OpCodes.Newobj, processConstructor);
+        il.Emit(OpCodes.Callvirt, getMainModule);
+        il.Emit(OpCodes.Callvirt, getFileName);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldloc, targetLocal);
+        il.Emit(OpCodes.Call, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
+
+        result.Should().BeTrue();
     }
 
     [Fact]

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -2257,6 +2257,25 @@ public class ProcessStartRuleTests
     }
 
     [Fact]
+    public void ExplorerAnalysisBudget_ManyLocalBackedStarts_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var target = new VariableDefinition(stringType);
+        method.Body.Variables.Add(target);
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        for (int i = 0; i < 2_048; i++)
+        {
+            il.Emit(OpCodes.Ldloc, target);
+            il.Emit(OpCodes.Call, processStart);
+        }
+
+        ProcessStartRule.IsExplorerAnalysisWithinBudget(method.Body.Instructions).Should().BeFalse();
+    }
+
+    [Fact]
     public void ShouldSuppressFinding_StaticFieldBackedRestart_ReturnsTrue()
     {
         var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
@@ -2423,6 +2442,39 @@ public class ProcessStartRuleTests
         il.Emit(OpCodes.Stloc, target);
         il.Append(launchTarget);
         var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_EquivalentCurrentProcessStackValuesAcrossBranch_ReturnsTrue()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        method.Parameters.Add(new ParameterDefinition(new TypeReference("System", "Boolean", null, null)));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var getCurrentProcess = new MethodReference("GetCurrentProcess", processType, processType);
+        var getMainModule = new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true };
+        var getFileName = new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true };
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        var falseBranch = Instruction.Create(OpCodes.Call, getCurrentProcess);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Brfalse, falseBranch);
+        il.Emit(OpCodes.Call, getCurrentProcess);
+        il.Emit(OpCodes.Callvirt, getMainModule);
+        il.Emit(OpCodes.Callvirt, getFileName);
+        il.Emit(OpCodes.Br, launch);
+        il.Append(falseBranch);
+        il.Emit(OpCodes.Callvirt, getMainModule);
+        il.Emit(OpCodes.Callvirt, getFileName);
         il.Append(launch);
 
         var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -2755,6 +2755,39 @@ public class ProcessStartRuleTests
     }
 
     [Fact]
+    public void ShouldSuppressFinding_ArgumentAddressEscapesAfterReassignment_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var target = new ParameterDefinition("target", ParameterAttributes.None, stringType);
+        method.Parameters.Add(target);
+        var rewrite = new MethodReference("Rewrite", method.ReturnType,
+            new TypeReference("Test", "Helpers", null, null));
+        rewrite.Parameters.Add(new ParameterDefinition(new ByReferenceType(stringType)));
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Starg, target);
+        il.Emit(OpCodes.Ldarga, target);
+        il.Emit(OpCodes.Call, rewrite);
+        il.Emit(OpCodes.Ldarg, target);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
     public void ShouldSuppressFinding_ProcessStartInfoEscapedToField_ReturnsFalse()
     {
         var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -1020,6 +1020,68 @@ public class ProcessStartRuleTests
     }
 
     [Fact]
+    public void ShouldSuppressFinding_RestartSetterBypassedByException_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var stringType = new TypeReference("System", "String", null, null);
+        var startInfoLocal = new VariableDefinition(startInfoType);
+        method.Body.Variables.Add(startInfoLocal);
+
+        var constructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        constructor.Parameters.Add(new ParameterDefinition(stringType));
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var getCurrentProcess = new MethodReference("GetCurrentProcess", processType, processType);
+        var getMainModule = new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true };
+        var getFileName = new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true };
+        var mayThrow = new MethodReference("MayThrow", method.ReturnType,
+            new TypeReference("Test", "Helpers", null, null));
+        var processStart = new MethodReference("Start", processType, processType);
+        processStart.Parameters.Add(new ParameterDefinition(startInfoType));
+
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Ldstr, "arbitrary.exe");
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stloc, startInfoLocal);
+        var tryStart = Instruction.Create(OpCodes.Call, mayThrow);
+        il.Append(tryStart);
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Call, getCurrentProcess);
+        il.Emit(OpCodes.Callvirt, getMainModule);
+        il.Emit(OpCodes.Callvirt, getFileName);
+        il.Emit(OpCodes.Callvirt, setFileName);
+        var afterHandler = Instruction.Create(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Leave, afterHandler);
+        var handlerStart = Instruction.Create(OpCodes.Pop);
+        il.Append(handlerStart);
+        il.Emit(OpCodes.Leave, afterHandler);
+        il.Append(afterHandler);
+        il.Emit(OpCodes.Call, processStart);
+
+        method.Body.ExceptionHandlers.Add(new ExceptionHandler(ExceptionHandlerType.Catch)
+        {
+            TryStart = tryStart,
+            TryEnd = handlerStart,
+            HandlerStart = handlerStart,
+            HandlerEnd = afterHandler,
+            CatchType = new TypeReference("System", "Exception", null, null)
+        });
+        var signals = new MethodSignals
+        {
+            ExceptionHandlers = method.Body.ExceptionHandlers.ToArray()
+        };
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, signals);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
     public void ShouldSuppressFinding_SavedRestartBeforeUnrelatedFileNameLookup_ReturnsTrue()
     {
         var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -1812,6 +1812,497 @@ public class ProcessStartRuleTests
     }
 
     [Fact]
+    public void ShouldSuppressFinding_ExplorerWithExecutableArgument_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processStart = CreateProcessStart(stringType, stringType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Ldstr, "explorer.exe");
+        il.Emit(OpCodes.Ldstr, @"C:\temp\payload.exe");
+        il.Emit(OpCodes.Call, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_ExplorerWithShortcutArgument_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processStart = CreateProcessStart(stringType, stringType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Ldstr, "explorer.exe");
+        il.Emit(OpCodes.Ldstr, @"C:\temp\folder.lnk");
+        il.Emit(OpCodes.Call, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_RestartTargetOverwrittenInFinally_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var targetLocal = new VariableDefinition(stringType);
+        method.Body.Variables.Add(targetLocal);
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        var tryStart = Instruction.Create(OpCodes.Call,
+            new MethodReference("GetCurrentProcess", processType, processType));
+        il.Append(tryStart);
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Stloc, targetLocal);
+        var launch = Instruction.Create(OpCodes.Ldloc, targetLocal);
+        var handlerStart = Instruction.Create(OpCodes.Ldstr, "arbitrary.exe");
+        il.Emit(OpCodes.Leave, launch);
+        il.Append(handlerStart);
+        il.Emit(OpCodes.Stloc, targetLocal);
+        il.Emit(OpCodes.Endfinally);
+        il.Append(launch);
+        il.Emit(OpCodes.Call, processStart);
+        method.Body.ExceptionHandlers.Add(new ExceptionHandler(ExceptionHandlerType.Finally)
+        {
+            TryStart = tryStart,
+            TryEnd = handlerStart,
+            HandlerStart = handlerStart,
+            HandlerEnd = launch
+        });
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1,
+            new MethodSignals { ExceptionHandlers = method.Body.ExceptionHandlers.ToArray() });
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_RestartInsideUnrelatedFinallyProtectedRegion_ReturnsTrue()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var targetLocal = new VariableDefinition(stringType);
+        method.Body.Variables.Add(targetLocal);
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        var tryStart = Instruction.Create(OpCodes.Call,
+            new MethodReference("GetCurrentProcess", processType, processType));
+        il.Append(tryStart);
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Stloc, targetLocal);
+        il.Emit(OpCodes.Ldloc, targetLocal);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+        var afterHandler = Instruction.Create(OpCodes.Ret);
+        var handlerStart = Instruction.Create(OpCodes.Nop);
+        il.Emit(OpCodes.Leave, afterHandler);
+        il.Append(handlerStart);
+        il.Emit(OpCodes.Endfinally);
+        il.Append(afterHandler);
+        method.Body.ExceptionHandlers.Add(new ExceptionHandler(ExceptionHandlerType.Finally)
+        {
+            TryStart = tryStart,
+            TryEnd = handlerStart,
+            HandlerStart = handlerStart,
+            HandlerEnd = afterHandler
+        });
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch),
+            new MethodSignals { ExceptionHandlers = method.Body.ExceptionHandlers.ToArray() });
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_BareExplorerInsideCatch_ReturnsTrue()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        var tryStart = Instruction.Create(OpCodes.Nop);
+        var handlerStart = Instruction.Create(OpCodes.Pop);
+        var afterHandler = Instruction.Create(OpCodes.Ret);
+        il.Append(tryStart);
+        il.Emit(OpCodes.Leave, afterHandler);
+        il.Append(handlerStart);
+        il.Emit(OpCodes.Ldstr, "explorer.exe");
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+        il.Emit(OpCodes.Leave, afterHandler);
+        il.Append(afterHandler);
+        method.Body.ExceptionHandlers.Add(new ExceptionHandler(ExceptionHandlerType.Catch)
+        {
+            TryStart = tryStart,
+            TryEnd = handlerStart,
+            HandlerStart = handlerStart,
+            HandlerEnd = afterHandler,
+            CatchType = new TypeReference("System", "Exception", null, null)
+        });
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch),
+            new MethodSignals { ExceptionHandlers = method.Body.ExceptionHandlers.ToArray() });
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_CurrentProcessRestartInsideCatch_ReturnsTrue()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var restartPath = new VariableDefinition(stringType);
+        method.Body.Variables.Add(restartPath);
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        var tryStart = Instruction.Create(OpCodes.Nop);
+        var handlerStart = Instruction.Create(OpCodes.Pop);
+        var afterHandler = Instruction.Create(OpCodes.Ret);
+        il.Append(tryStart);
+        il.Emit(OpCodes.Leave, afterHandler);
+        il.Append(handlerStart);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Stloc, restartPath);
+        il.Emit(OpCodes.Ldloc, restartPath);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+        il.Emit(OpCodes.Leave, afterHandler);
+        il.Append(afterHandler);
+        method.Body.ExceptionHandlers.Add(new ExceptionHandler(ExceptionHandlerType.Catch)
+        {
+            TryStart = tryStart,
+            TryEnd = handlerStart,
+            HandlerStart = handlerStart,
+            HandlerEnd = afterHandler,
+            CatchType = new TypeReference("System", "Exception", null, null)
+        });
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch),
+            new MethodSignals { ExceptionHandlers = method.Body.ExceptionHandlers.ToArray() });
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_CurrentProcessRestartInsideFinally_ReturnsTrue()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var restartPath = new VariableDefinition(stringType);
+        method.Body.Variables.Add(restartPath);
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        var tryStart = Instruction.Create(OpCodes.Nop);
+        var handlerStart = Instruction.Create(OpCodes.Call,
+            new MethodReference("GetCurrentProcess", processType, processType));
+        var afterHandler = Instruction.Create(OpCodes.Ret);
+        il.Append(tryStart);
+        il.Emit(OpCodes.Leave, afterHandler);
+        il.Append(handlerStart);
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Stloc, restartPath);
+        il.Emit(OpCodes.Ldloc, restartPath);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+        il.Emit(OpCodes.Endfinally);
+        il.Append(afterHandler);
+        method.Body.ExceptionHandlers.Add(new ExceptionHandler(ExceptionHandlerType.Finally)
+        {
+            TryStart = tryStart,
+            TryEnd = handlerStart,
+            HandlerStart = handlerStart,
+            HandlerEnd = afterHandler
+        });
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch),
+            new MethodSignals { ExceptionHandlers = method.Body.ExceptionHandlers.ToArray() });
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RestartAnalysisBudget_ManyStartsAndCompetingWrites_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        for (int i = 0; i < 64; i++)
+            il.Emit(OpCodes.Callvirt, setFileName);
+        for (int i = 0; i < 64; i++)
+            il.Emit(OpCodes.Call, processStart);
+
+        ProcessStartRule.IsRestartAnalysisWithinBudget(method.Body.Instructions).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_StaticFieldBackedRestart_ReturnsTrue()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var field = new FieldReference("RestartPath", stringType,
+            new TypeReference("Test", "State", null, null));
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Stsfld, field);
+        il.Emit(OpCodes.Ldsfld, field);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_FieldBackedRestartAcrossMutatingCall_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var stateType = new TypeReference("Test", "State", null, null);
+        var field = new FieldReference("RestartPath", stringType, stateType);
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Stsfld, field);
+        il.Emit(OpCodes.Call, new MethodReference("ChangeRestartPath", method.ReturnType, stateType));
+        il.Emit(OpCodes.Ldsfld, field);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_InstanceFieldBackedRestart_ReturnsTrue()
+    {
+        var declaringType = new TypeReference("Test", "State", null, null);
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public,
+            new TypeReference("System", "Void", null, null));
+        method.DeclaringType = new TypeDefinition("Test", "State", TypeAttributes.Public, null);
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var field = new FieldReference("RestartPath", stringType, declaringType);
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Stfld, field);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, field);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_EquivalentRestartDefinitionsAcrossBranch_ReturnsTrue()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        method.Parameters.Add(new ParameterDefinition(new TypeReference("System", "Boolean", null, null)));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var target = new VariableDefinition(stringType);
+        method.Body.Variables.Add(target);
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        var falseBranch = Instruction.Create(OpCodes.Call,
+            new MethodReference("GetCurrentProcess", processType, processType));
+        var launchTarget = Instruction.Create(OpCodes.Ldloc, target);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Brfalse, falseBranch);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Stloc, target);
+        il.Emit(OpCodes.Br, launchTarget);
+        il.Append(falseBranch);
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Stloc, target);
+        il.Append(launchTarget);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_ConditionalAliasOverwrite_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        method.Parameters.Add(new ParameterDefinition(new TypeReference("System", "Boolean", null, null)));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var launched = new VariableDefinition(startInfoType);
+        var other = new VariableDefinition(startInfoType);
+        var alias = new VariableDefinition(startInfoType);
+        method.Body.Variables.Add(launched);
+        method.Body.Variables.Add(other);
+        method.Body.Variables.Add(alias);
+        var constructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var processStart = CreateProcessStart(startInfoType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stloc, launched);
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stloc, other);
+        il.Emit(OpCodes.Ldloc, launched);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Emit(OpCodes.Ldloc, other);
+        il.Emit(OpCodes.Stloc, alias);
+        il.Emit(OpCodes.Ldarg_0);
+        var useAlias = Instruction.Create(OpCodes.Ldloc, alias);
+        il.Emit(OpCodes.Brfalse, useAlias);
+        il.Emit(OpCodes.Ldloc, launched);
+        il.Emit(OpCodes.Stloc, alias);
+        il.Append(useAlias);
+        il.Emit(OpCodes.Ldstr, "arbitrary.exe");
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Emit(OpCodes.Ldloc, launched);
+        il.Emit(OpCodes.Call, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_LowerIndexLoopOverwrite_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        method.Parameters.Add(new ParameterDefinition(new TypeReference("System", "Boolean", null, null)));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var startInfo = new VariableDefinition(startInfoType);
+        method.Body.Variables.Add(startInfo);
+        var constructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var processStart = CreateProcessStart(startInfoType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stloc, startInfo);
+        var safeAssignment = Instruction.Create(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Br, safeAssignment);
+        var competingAssignment = Instruction.Create(OpCodes.Ldloc, startInfo);
+        il.Append(competingAssignment);
+        il.Emit(OpCodes.Ldstr, "arbitrary.exe");
+        il.Emit(OpCodes.Callvirt, setFileName);
+        var launch = Instruction.Create(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Br, launch);
+        il.Append(safeAssignment);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Brtrue, competingAssignment);
+        il.Append(launch);
+        il.Emit(OpCodes.Call, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
     public void ShouldSuppressFinding_CrossMethodFileWrite_ReturnsFalse()
     {
         // SECURITY TEST: Cross-method attack

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -832,6 +832,44 @@ public class ProcessStartRuleTests
     }
 
     [Fact]
+    public void ShouldSuppressFinding_GetterBackedProcessStartInfoRestart_ReturnsTrue()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var stringType = new TypeReference("System", "String", null, null);
+        var processLocal = new VariableDefinition(processType);
+        method.Body.Variables.Add(processLocal);
+        var processConstructor = new MethodReference(".ctor", method.ReturnType, processType) { HasThis = true };
+        var getStartInfo = new MethodReference("get_StartInfo", startInfoType, processType) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var getCurrentProcess = new MethodReference("GetCurrentProcess", processType, processType);
+        var getMainModule = new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true };
+        var getFileName = new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true };
+        var processStart = new MethodReference("Start", new TypeReference("System", "Boolean", null, null),
+            processType) { HasThis = true };
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Newobj, processConstructor);
+        il.Emit(OpCodes.Stloc, processLocal);
+        il.Emit(OpCodes.Ldloc, processLocal);
+        il.Emit(OpCodes.Callvirt, getStartInfo);
+        il.Emit(OpCodes.Call, getCurrentProcess);
+        il.Emit(OpCodes.Callvirt, getMainModule);
+        il.Emit(OpCodes.Callvirt, getFileName);
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Emit(OpCodes.Ldloc, processLocal);
+        il.Emit(OpCodes.Callvirt, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
     public void ShouldSuppressFinding_SavedRestartBeforeUnrelatedFileNameLookup_ReturnsTrue()
     {
         var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -2223,6 +2223,52 @@ public class ProcessStartRuleTests
     }
 
     [Fact]
+    public void ShouldSuppressFinding_FieldBackedRestartAcrossThrowingMutatingCall_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var stateType = new TypeReference("Test", "State", null, null);
+        var field = new FieldReference("RestartPath", stringType, stateType);
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Stsfld, field);
+        var tryStart = Instruction.Create(OpCodes.Call,
+            new MethodReference("ChangeRestartPathAndThrow", method.ReturnType, stateType));
+        var handlerStart = Instruction.Create(OpCodes.Pop);
+        var afterHandler = Instruction.Create(OpCodes.Ret);
+        il.Append(tryStart);
+        il.Emit(OpCodes.Leave, afterHandler);
+        il.Append(handlerStart);
+        il.Emit(OpCodes.Ldsfld, field);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+        il.Emit(OpCodes.Leave, afterHandler);
+        il.Append(afterHandler);
+        method.Body.ExceptionHandlers.Add(new ExceptionHandler(ExceptionHandlerType.Catch)
+        {
+            TryStart = tryStart,
+            TryEnd = handlerStart,
+            HandlerStart = handlerStart,
+            HandlerEnd = afterHandler,
+            CatchType = new TypeReference("System", "Exception", null, null)
+        });
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch),
+            new MethodSignals { ExceptionHandlers = method.Body.ExceptionHandlers.ToArray() });
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
     public void ShouldSuppressFinding_InstanceFieldBackedRestart_ReturnsTrue()
     {
         var declaringType = new TypeReference("Test", "State", null, null);

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -618,18 +618,37 @@ public class ProcessStartRuleTests
         var method = new MethodDefinition("TestMethod", MethodAttributes.Public, new TypeReference("", "Void", null, null));
         var processor = method.Body.GetILProcessor();
 
+        var processStart = CreateProcessStart(new TypeReference("System", "String", null, null));
         processor.Emit(OpCodes.Ldstr, "explorer.exe");
-        processor.Emit(OpCodes.Ldstr, "C:\\Some\\Path");
-        processor.Emit(OpCodes.Call, new MethodReference("Start", new TypeReference("", "Process", null, null), new TypeReference("System.Diagnostics", "Process", null, null)));
+        processor.Emit(OpCodes.Call, processStart);
 
         var instructions = method.Body.Instructions;
         var callIndex = instructions.Count - 1;
 
         // Act
-        var result = _rule.ShouldSuppressFinding(null!, instructions, callIndex, new MethodSignals());
+        var result = _rule.ShouldSuppressFinding(processStart, instructions, callIndex, new MethodSignals());
 
         // Assert
         result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_UnrelatedExplorerArgument_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("", "Void", null, null));
+        var processStart = CreateProcessStart(
+            new TypeReference("System", "String", null, null),
+            new TypeReference("System", "String", null, null));
+        var processor = method.Body.GetILProcessor();
+        processor.Emit(OpCodes.Ldstr, "arbitrary.exe");
+        processor.Emit(OpCodes.Ldstr, "explorer.exe");
+        processor.Emit(OpCodes.Call, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
+
+        result.Should().BeFalse();
     }
 
     [Fact]
@@ -701,19 +720,62 @@ public class ProcessStartRuleTests
         var method = new MethodDefinition("TestMethod", MethodAttributes.Public, new TypeReference("", "Void", null, null));
         var processor = method.Body.GetILProcessor();
 
+        var processStart = CreateProcessStart(new TypeReference("System", "String", null, null));
         processor.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", new TypeReference("", "Process", null, null), new TypeReference("System.Diagnostics", "Process", null, null)));
-        processor.Emit(OpCodes.Callvirt, new MethodReference("get_MainModule", new TypeReference("", "ProcessModule", null, null), new TypeReference("System.Diagnostics", "Process", null, null)));
-        processor.Emit(OpCodes.Callvirt, new MethodReference("get_FileName", new TypeReference("", "String", null, null), new TypeReference("System.Diagnostics", "ProcessModule", null, null)));
-        processor.Emit(OpCodes.Call, new MethodReference("Start", new TypeReference("", "Process", null, null), new TypeReference("System.Diagnostics", "Process", null, null)));
+        processor.Emit(OpCodes.Callvirt, new MethodReference("get_MainModule", new TypeReference("", "ProcessModule", null, null), new TypeReference("System.Diagnostics", "Process", null, null)) { HasThis = true });
+        processor.Emit(OpCodes.Callvirt, new MethodReference("get_FileName", new TypeReference("", "String", null, null), new TypeReference("System.Diagnostics", "ProcessModule", null, null)) { HasThis = true });
+        processor.Emit(OpCodes.Call, processStart);
 
         var instructions = method.Body.Instructions;
         var callIndex = instructions.Count - 1;
 
         // Act
-        var result = _rule.ShouldSuppressFinding(null!, instructions, callIndex, new MethodSignals());
+        var result = _rule.ShouldSuppressFinding(processStart, instructions, callIndex, new MethodSignals());
 
         // Assert
         result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_DiscardedRestartChainBeforeArbitraryLaunch_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("", "Void", null, null));
+        var processStart = CreateProcessStart(new TypeReference("System", "String", null, null));
+        var processor = method.Body.GetILProcessor();
+        processor.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", new TypeReference("", "Process", null, null), new TypeReference("System.Diagnostics", "Process", null, null)));
+        processor.Emit(OpCodes.Callvirt, new MethodReference("get_MainModule", new TypeReference("", "ProcessModule", null, null), new TypeReference("System.Diagnostics", "Process", null, null)) { HasThis = true });
+        processor.Emit(OpCodes.Callvirt, new MethodReference("get_FileName", new TypeReference("", "String", null, null), new TypeReference("System.Diagnostics", "ProcessModule", null, null)) { HasThis = true });
+        processor.Emit(OpCodes.Pop);
+        processor.Emit(OpCodes.Ldstr, "arbitrary.exe");
+        processor.Emit(OpCodes.Call, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_BoundProcessStartInfoRestart_ReturnsTrue()
+    {
+        var scenario = BuildProcessStartInfoRestartScenario(useRestartTarget: true);
+
+        var result = _rule.ShouldSuppressFinding(scenario.ProcessStart, scenario.Instructions,
+            scenario.ProcessStartIndex, new MethodSignals());
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_UnrelatedRestartChainBeforeProcessStartInfoLaunch_ReturnsFalse()
+    {
+        var scenario = BuildProcessStartInfoRestartScenario(useRestartTarget: false);
+
+        var result = _rule.ShouldSuppressFinding(scenario.ProcessStart, scenario.Instructions,
+            scenario.ProcessStartIndex, new MethodSignals());
+
+        result.Should().BeFalse();
     }
 
     [Fact]
@@ -969,15 +1031,16 @@ public class ProcessStartRuleTests
         // Arrange: Build IL with mixed case "Explorer.EXE"
         var method = new MethodDefinition("TestMethod", MethodAttributes.Public, new TypeReference("", "Void", null, null));
         var processor = method.Body.GetILProcessor();
+        var processStart = CreateProcessStart(new TypeReference("System", "String", null, null));
 
         processor.Emit(OpCodes.Ldstr, "Explorer.EXE");
-        processor.Emit(OpCodes.Call, new MethodReference("Start", new TypeReference("", "Process", null, null), new TypeReference("System.Diagnostics", "Process", null, null)));
+        processor.Emit(OpCodes.Call, processStart);
 
         var instructions = method.Body.Instructions;
         var callIndex = instructions.Count - 1;
 
         // Act
-        var result = _rule.ShouldSuppressFinding(null!, instructions, callIndex, new MethodSignals());
+        var result = _rule.ShouldSuppressFinding(processStart, instructions, callIndex, new MethodSignals());
 
         // Assert
         result.Should().BeTrue();
@@ -1028,10 +1091,13 @@ public class ProcessStartRuleTests
         // Arrange: Normal explorer.exe call without PATH manipulation
         var method = new MethodDefinition("TestMethod", MethodAttributes.Public, new TypeReference("", "Void", null, null));
         var processor = method.Body.GetILProcessor();
+        var processStart = CreateProcessStart(
+            new TypeReference("System", "String", null, null),
+            new TypeReference("System", "String", null, null));
 
         processor.Emit(OpCodes.Ldstr, "explorer.exe");
         processor.Emit(OpCodes.Ldstr, "C:\\SomePath");
-        processor.Emit(OpCodes.Call, new MethodReference("Start", new TypeReference("", "Process", null, null), new TypeReference("System.Diagnostics", "Process", null, null)));
+        processor.Emit(OpCodes.Call, processStart);
 
         var instructions = method.Body.Instructions;
         var callIndex = instructions.Count - 1;
@@ -1040,7 +1106,7 @@ public class ProcessStartRuleTests
         var signals = new MethodSignals { HasEnvironmentVariableModification = false };
 
         // Act
-        var result = _rule.ShouldSuppressFinding(null!, instructions, callIndex, signals);
+        var result = _rule.ShouldSuppressFinding(processStart, instructions, callIndex, signals);
 
         // Assert - Should suppress because no PATH manipulation
         result.Should().BeTrue("Process.Start should be suppressed when no environment modification detected");
@@ -1092,10 +1158,13 @@ public class ProcessStartRuleTests
         // Arrange: Normal explorer.exe call without file writes
         var method = new MethodDefinition("TestMethod", MethodAttributes.Public, new TypeReference("", "Void", null, null));
         var processor = method.Body.GetILProcessor();
+        var processStart = CreateProcessStart(
+            new TypeReference("System", "String", null, null),
+            new TypeReference("System", "String", null, null));
 
         processor.Emit(OpCodes.Ldstr, "explorer.exe");
         processor.Emit(OpCodes.Ldstr, "C:\\SomePath");
-        processor.Emit(OpCodes.Call, new MethodReference("Start", new TypeReference("", "Process", null, null), new TypeReference("System.Diagnostics", "Process", null, null)));
+        processor.Emit(OpCodes.Call, processStart);
 
         var instructions = method.Body.Instructions;
         var callIndex = instructions.Count - 1;
@@ -1104,7 +1173,7 @@ public class ProcessStartRuleTests
         var signals = new MethodSignals { HasFileWrite = false };
 
         // Act
-        var result = _rule.ShouldSuppressFinding(null!, instructions, callIndex, signals);
+        var result = _rule.ShouldSuppressFinding(processStart, instructions, callIndex, signals);
 
         // Assert - Should suppress because no file writes detected
         result.Should().BeTrue("Process.Start should be suppressed when no file writes detected");
@@ -1134,6 +1203,70 @@ public class ProcessStartRuleTests
 
         // Assert - Should NOT suppress because type has file writes (cross-method attack)
         result.Should().BeFalse("Process.Start should NOT be suppressed when type has file writes in other methods");
+    }
+
+    private static MethodReference CreateProcessStart(params TypeReference[] parameterTypes)
+    {
+        var processStart = new MethodReference(
+            "Start",
+            new TypeReference("System.Diagnostics", "Process", null, null),
+            new TypeReference("System.Diagnostics", "Process", null, null));
+        foreach (var parameterType in parameterTypes)
+        {
+            processStart.Parameters.Add(new ParameterDefinition(parameterType));
+        }
+
+        return processStart;
+    }
+
+    private static (MethodReference ProcessStart, InstructionCollection Instructions, int ProcessStartIndex)
+        BuildProcessStartInfoRestartScenario(bool useRestartTarget)
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var processLocal = new VariableDefinition(processType);
+        var startInfoLocal = new VariableDefinition(startInfoType);
+        method.Body.Variables.Add(processLocal);
+        method.Body.Variables.Add(startInfoLocal);
+
+        var processConstructor = new MethodReference(".ctor", method.ReturnType, processType) { HasThis = true };
+        var startInfoConstructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        var getCurrentProcess = new MethodReference("GetCurrentProcess", processType, processType);
+        var getMainModule = new MethodReference("get_MainModule",
+            new TypeReference("System.Diagnostics", "ProcessModule", null, null), processType) { HasThis = true };
+        var getFileName = new MethodReference("get_FileName",
+            new TypeReference("System", "String", null, null), getMainModule.ReturnType) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(getFileName.ReturnType));
+        var setStartInfo = new MethodReference("set_StartInfo", method.ReturnType, processType) { HasThis = true };
+        setStartInfo.Parameters.Add(new ParameterDefinition(startInfoType));
+        var processStart = new MethodReference("Start", new TypeReference("System", "Boolean", null, null),
+            processType) { HasThis = true };
+
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Newobj, processConstructor);
+        il.Emit(OpCodes.Stloc, processLocal);
+        il.Emit(OpCodes.Newobj, startInfoConstructor);
+        il.Emit(OpCodes.Stloc, startInfoLocal);
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Call, getCurrentProcess);
+        il.Emit(OpCodes.Callvirt, getMainModule);
+        il.Emit(OpCodes.Callvirt, getFileName);
+        if (!useRestartTarget)
+        {
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Ldstr, "arbitrary.exe");
+        }
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Emit(OpCodes.Ldloc, processLocal);
+        il.Emit(OpCodes.Ldloc, startInfoLocal);
+        il.Emit(OpCodes.Callvirt, setStartInfo);
+        il.Emit(OpCodes.Ldloc, processLocal);
+        il.Emit(OpCodes.Callvirt, processStart);
+
+        return (processStart, method.Body.Instructions, method.Body.Instructions.Count - 1);
     }
 
     private static (MethodReference ProcessStart, InstructionCollection Instructions, int ProcessStartIndex)

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -2059,6 +2059,94 @@ public class ProcessStartRuleTests
     }
 
     [Fact]
+    public void ShouldSuppressFinding_ProcessStartInfoRestartInsideFinally_ReturnsTrue()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var startInfo = new VariableDefinition(startInfoType);
+        method.Body.Variables.Add(startInfo);
+        var constructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var processStart = CreateProcessStart(startInfoType);
+        var il = method.Body.GetILProcessor();
+        var tryStart = Instruction.Create(OpCodes.Nop);
+        var handlerStart = Instruction.Create(OpCodes.Newobj, constructor);
+        var afterHandler = Instruction.Create(OpCodes.Ret);
+        il.Append(tryStart);
+        il.Emit(OpCodes.Leave, afterHandler);
+        il.Append(handlerStart);
+        il.Emit(OpCodes.Stloc, startInfo);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+        il.Emit(OpCodes.Endfinally);
+        il.Append(afterHandler);
+        method.Body.ExceptionHandlers.Add(new ExceptionHandler(ExceptionHandlerType.Finally)
+        {
+            TryStart = tryStart,
+            TryEnd = handlerStart,
+            HandlerStart = handlerStart,
+            HandlerEnd = afterHandler
+        });
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch),
+            new MethodSignals { ExceptionHandlers = method.Body.ExceptionHandlers.ToArray() });
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_ArgumentReassignedOnLoopBackedge_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var restartInfo = new ParameterDefinition("restartInfo", ParameterAttributes.None, startInfoType);
+        var replacementInfo = new ParameterDefinition("replacementInfo", ParameterAttributes.None, startInfoType);
+        method.Parameters.Add(restartInfo);
+        method.Parameters.Add(replacementInfo);
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var processStart = CreateProcessStart(startInfoType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Ldarg, restartInfo);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt, setFileName);
+        var loopStart = Instruction.Create(OpCodes.Ldarg, restartInfo);
+        il.Append(loopStart);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+        il.Emit(OpCodes.Ldarg, replacementInfo);
+        il.Emit(OpCodes.Starg, restartInfo);
+        il.Emit(OpCodes.Br, loopStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
     public void RestartAnalysisBudget_ManyStartsAndCompetingWrites_ReturnsFalse()
     {
         var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -1871,6 +1871,7 @@ public class ProcessStartRuleTests
     [Theory]
     [InlineData(@"C:\temp\payload.application")]
     [InlineData(@"C:\temp\payload.appref-ms")]
+    [InlineData(@"C:\temp\payload.pif")]
     public void ShouldSuppressFinding_ExplorerWithClickOnceArgument_ReturnsFalse(string argument)
     {
         var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
@@ -2867,6 +2868,92 @@ public class ProcessStartRuleTests
             method.Body.Instructions.IndexOf(launch), new MethodSignals());
 
         result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_ProcessStartInfoAssignedToAnotherProcess_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var startInfo = new VariableDefinition(startInfoType);
+        var holder = new VariableDefinition(processType);
+        method.Body.Variables.Add(startInfo);
+        method.Body.Variables.Add(holder);
+        var startInfoConstructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        var processConstructor = new MethodReference(".ctor", method.ReturnType, processType) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var setStartInfo = new MethodReference("set_StartInfo", method.ReturnType, processType) { HasThis = true };
+        setStartInfo.Parameters.Add(new ParameterDefinition(startInfoType));
+        var rewrite = new MethodReference("RewriteHolder", method.ReturnType,
+            new TypeReference("Test", "Helpers", null, null));
+        var processStart = CreateProcessStart(startInfoType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Newobj, startInfoConstructor);
+        il.Emit(OpCodes.Stloc, startInfo);
+        il.Emit(OpCodes.Newobj, processConstructor);
+        il.Emit(OpCodes.Stloc, holder);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Emit(OpCodes.Ldloc, holder);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Callvirt, setStartInfo);
+        il.Emit(OpCodes.Call, rewrite);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_StaticLaunchFromRepeatedStartInfoGetter_ReturnsTrue()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var process = new VariableDefinition(processType);
+        method.Body.Variables.Add(process);
+        var processConstructor = new MethodReference(".ctor", method.ReturnType, processType) { HasThis = true };
+        var getStartInfo = new MethodReference("get_StartInfo", startInfoType, processType) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var processStart = CreateProcessStart(startInfoType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Newobj, processConstructor);
+        il.Emit(OpCodes.Stloc, process);
+        il.Emit(OpCodes.Ldloc, process);
+        il.Emit(OpCodes.Callvirt, getStartInfo);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Emit(OpCodes.Ldloc, process);
+        il.Emit(OpCodes.Callvirt, getStartInfo);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeTrue();
     }
 
     [Fact]

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -2480,6 +2480,60 @@ public class ProcessStartRuleTests
     }
 
     [Fact]
+    public void ShouldSuppressFinding_AmbiguousHelperAlias_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        method.Parameters.Add(new ParameterDefinition(new TypeReference("System", "Boolean", null, null)));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var startInfo = new VariableDefinition(startInfoType);
+        var other = new VariableDefinition(startInfoType);
+        var alias = new VariableDefinition(startInfoType);
+        method.Body.Variables.Add(startInfo);
+        method.Body.Variables.Add(other);
+        method.Body.Variables.Add(alias);
+        var constructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var rewrite = new MethodReference("RewriteTarget", method.ReturnType,
+            new TypeReference("Test", "Helpers", null, null));
+        rewrite.Parameters.Add(new ParameterDefinition(startInfoType));
+        var processStart = CreateProcessStart(startInfoType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stloc, startInfo);
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stloc, other);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Emit(OpCodes.Ldloc, other);
+        il.Emit(OpCodes.Stloc, alias);
+        var skipAlias = Instruction.Create(OpCodes.Ldloc, alias);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Brfalse, skipAlias);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Stloc, alias);
+        il.Append(skipAlias);
+        il.Emit(OpCodes.Call, rewrite);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
     public void ShouldSuppressFinding_OwningProcessPassedToHelper_ReturnsFalse()
     {
         var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
@@ -2520,6 +2574,56 @@ public class ProcessStartRuleTests
         il.Emit(OpCodes.Callvirt, setStartInfo);
         il.Emit(OpCodes.Ldloc, process);
         il.Emit(OpCodes.Call, rewrite);
+        il.Emit(OpCodes.Ldloc, process);
+        var launch = Instruction.Create(OpCodes.Callvirt, processStart);
+        il.Append(launch);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_HelperCalledOnOwningProcess_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var customProcessType = new TypeReference("Test", "CustomProcess", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var process = new VariableDefinition(customProcessType);
+        var startInfo = new VariableDefinition(startInfoType);
+        method.Body.Variables.Add(process);
+        method.Body.Variables.Add(startInfo);
+        var processConstructor = new MethodReference(".ctor", method.ReturnType, customProcessType) { HasThis = true };
+        var startInfoConstructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var setStartInfo = new MethodReference("set_StartInfo", method.ReturnType, processType) { HasThis = true };
+        setStartInfo.Parameters.Add(new ParameterDefinition(startInfoType));
+        var rewrite = new MethodReference("RewriteTarget", method.ReturnType, customProcessType) { HasThis = true };
+        var processStart = new MethodReference("Start", new TypeReference("System", "Boolean", null, null),
+            processType) { HasThis = true };
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Newobj, processConstructor);
+        il.Emit(OpCodes.Stloc, process);
+        il.Emit(OpCodes.Newobj, startInfoConstructor);
+        il.Emit(OpCodes.Stloc, startInfo);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Emit(OpCodes.Ldloc, process);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Callvirt, setStartInfo);
+        il.Emit(OpCodes.Ldloc, process);
+        il.Emit(OpCodes.Callvirt, rewrite);
         il.Emit(OpCodes.Ldloc, process);
         var launch = Instruction.Create(OpCodes.Callvirt, processStart);
         il.Append(launch);

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -1847,6 +1847,57 @@ public class ProcessStartRuleTests
         result.Should().BeFalse();
     }
 
+    [Theory]
+    [InlineData(@"C:\temp\payload.wsf")]
+    [InlineData(@"C:\temp\payload.jse")]
+    [InlineData(@"C:\temp\payload.vbe")]
+    public void ShouldSuppressFinding_ExplorerWithWindowsScriptArgument_ReturnsFalse(string argument)
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processStart = CreateProcessStart(stringType, stringType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Ldstr, "explorer.exe");
+        il.Emit(OpCodes.Ldstr, argument);
+        il.Emit(OpCodes.Call, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_EquivalentExplorerLiteralsAcrossBranch_ReturnsTrue()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        method.Parameters.Add(new ParameterDefinition(new TypeReference("System", "Boolean", null, null)));
+        var stringType = new TypeReference("System", "String", null, null);
+        var target = new VariableDefinition(stringType);
+        method.Body.Variables.Add(target);
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        var falseBranch = Instruction.Create(OpCodes.Ldstr, "explorer.exe");
+        var launchTarget = Instruction.Create(OpCodes.Ldloc, target);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Brfalse, falseBranch);
+        il.Emit(OpCodes.Ldstr, "explorer.exe");
+        il.Emit(OpCodes.Stloc, target);
+        il.Emit(OpCodes.Br, launchTarget);
+        il.Append(falseBranch);
+        il.Emit(OpCodes.Stloc, target);
+        il.Append(launchTarget);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeTrue();
+    }
+
     [Fact]
     public void ShouldSuppressFinding_RestartTargetOverwrittenInFinally_ReturnsFalse()
     {

--- a/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/ProcessStartRuleTests.cs
@@ -1868,6 +1868,26 @@ public class ProcessStartRuleTests
         result.Should().BeFalse();
     }
 
+    [Theory]
+    [InlineData(@"C:\temp\payload.application")]
+    [InlineData(@"C:\temp\payload.appref-ms")]
+    public void ShouldSuppressFinding_ExplorerWithClickOnceArgument_ReturnsFalse(string argument)
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processStart = CreateProcessStart(stringType, stringType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Ldstr, "explorer.exe");
+        il.Emit(OpCodes.Ldstr, argument);
+        il.Emit(OpCodes.Call, processStart);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.Count - 1, new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
     [Fact]
     public void ShouldSuppressFinding_EquivalentExplorerLiteralsAcrossBranch_ReturnsTrue()
     {
@@ -2409,6 +2429,129 @@ public class ProcessStartRuleTests
         il.Emit(OpCodes.Ldloc, startInfo);
         il.Emit(OpCodes.Call, rewrite);
         il.Emit(OpCodes.Ldloc, startInfo);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_ProcessStartInfoPassedAsObjectToHelper_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var objectType = new TypeReference("System", "Object", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var startInfo = new VariableDefinition(startInfoType);
+        method.Body.Variables.Add(startInfo);
+        var constructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var rewrite = new MethodReference("RewriteTarget", method.ReturnType,
+            new TypeReference("Test", "Helpers", null, null));
+        rewrite.Parameters.Add(new ParameterDefinition(objectType));
+        var processStart = CreateProcessStart(startInfoType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Newobj, constructor);
+        il.Emit(OpCodes.Stloc, startInfo);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Call, rewrite);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        var launch = Instruction.Create(OpCodes.Call, processStart);
+        il.Append(launch);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_OwningProcessPassedToHelper_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var startInfoType = new TypeReference("System.Diagnostics", "ProcessStartInfo", null, null);
+        var process = new VariableDefinition(processType);
+        var startInfo = new VariableDefinition(startInfoType);
+        method.Body.Variables.Add(process);
+        method.Body.Variables.Add(startInfo);
+        var processConstructor = new MethodReference(".ctor", method.ReturnType, processType) { HasThis = true };
+        var startInfoConstructor = new MethodReference(".ctor", method.ReturnType, startInfoType) { HasThis = true };
+        var setFileName = new MethodReference("set_FileName", method.ReturnType, startInfoType) { HasThis = true };
+        setFileName.Parameters.Add(new ParameterDefinition(stringType));
+        var setStartInfo = new MethodReference("set_StartInfo", method.ReturnType, processType) { HasThis = true };
+        setStartInfo.Parameters.Add(new ParameterDefinition(startInfoType));
+        var rewrite = new MethodReference("RewriteProcess", method.ReturnType,
+            new TypeReference("Test", "Helpers", null, null));
+        rewrite.Parameters.Add(new ParameterDefinition(processType));
+        var processStart = new MethodReference("Start", new TypeReference("System", "Boolean", null, null),
+            processType) { HasThis = true };
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Newobj, processConstructor);
+        il.Emit(OpCodes.Stloc, process);
+        il.Emit(OpCodes.Newobj, startInfoConstructor);
+        il.Emit(OpCodes.Stloc, startInfo);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt, setFileName);
+        il.Emit(OpCodes.Ldloc, process);
+        il.Emit(OpCodes.Ldloc, startInfo);
+        il.Emit(OpCodes.Callvirt, setStartInfo);
+        il.Emit(OpCodes.Ldloc, process);
+        il.Emit(OpCodes.Call, rewrite);
+        il.Emit(OpCodes.Ldloc, process);
+        var launch = Instruction.Create(OpCodes.Callvirt, processStart);
+        il.Append(launch);
+
+        var result = _rule.ShouldSuppressFinding(processStart, method.Body.Instructions,
+            method.Body.Instructions.IndexOf(launch), new MethodSignals());
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressFinding_StaticFieldAddressEscape_ReturnsFalse()
+    {
+        var method = new MethodDefinition("TestMethod", MethodAttributes.Public | MethodAttributes.Static,
+            new TypeReference("System", "Void", null, null));
+        var stringType = new TypeReference("System", "String", null, null);
+        var processType = new TypeReference("System.Diagnostics", "Process", null, null);
+        var processModuleType = new TypeReference("System.Diagnostics", "ProcessModule", null, null);
+        var field = new FieldReference("RestartPath", stringType,
+            new TypeReference("Test", "State", null, null));
+        var processStart = CreateProcessStart(stringType);
+        var il = method.Body.GetILProcessor();
+        il.Emit(OpCodes.Call, new MethodReference("GetCurrentProcess", processType, processType));
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_MainModule", processModuleType, processType) { HasThis = true });
+        il.Emit(OpCodes.Callvirt,
+            new MethodReference("get_FileName", stringType, processModuleType) { HasThis = true });
+        il.Emit(OpCodes.Stsfld, field);
+        il.Emit(OpCodes.Ldsflda, field);
+        il.Emit(OpCodes.Ldstr, "arbitrary.exe");
+        il.Emit(OpCodes.Stind_Ref);
+        il.Emit(OpCodes.Ldsfld, field);
         var launch = Instruction.Create(OpCodes.Call, processStart);
         il.Append(launch);
 

--- a/MLVScan.Core.Tests/Unit/Services/MethodScannerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/MethodScannerTests.cs
@@ -132,6 +132,73 @@ public class MethodScannerTests
         result.Findings.Should().Contain(finding => finding.RuleId == "ProcessStartRule");
     }
 
+    [Fact]
+    public void ScanMethod_MultiSignalDisabled_PropagatesExceptionHandlersToSuppression()
+    {
+        var config = new ScanConfig { EnableMultiSignalDetection = false };
+        var rule = new CapturingSuppressionRule();
+        var scanner = CreateScanner(config, new IScanRule[] { rule });
+        var method = CreateMethod();
+        var il = method.Body.GetILProcessor();
+        var ret = method.Body.Instructions.Single();
+        var tryStart = Instruction.Create(OpCodes.Nop);
+        var handlerStart = Instruction.Create(OpCodes.Pop);
+        var afterHandler = Instruction.Create(OpCodes.Call,
+            new MethodReference("Target", method.Module.TypeSystem.Void,
+                new TypeReference("Test", "Target", method.Module, method.Module.TypeSystem.CoreLibrary)));
+        il.InsertBefore(ret, tryStart);
+        il.InsertBefore(ret, Instruction.Create(OpCodes.Leave, afterHandler));
+        il.InsertBefore(ret, handlerStart);
+        il.InsertBefore(ret, Instruction.Create(OpCodes.Leave, afterHandler));
+        il.InsertBefore(ret, afterHandler);
+        method.Body.ExceptionHandlers.Add(new ExceptionHandler(ExceptionHandlerType.Catch)
+        {
+            TryStart = tryStart,
+            TryEnd = handlerStart,
+            HandlerStart = handlerStart,
+            HandlerEnd = afterHandler,
+            CatchType = method.Module.ImportReference(typeof(Exception))
+        });
+
+        using var assemblyBytes = new MemoryStream();
+        method.Module.Assembly.Write(assemblyBytes);
+        assemblyBytes.Position = 0;
+        using var reloadedAssembly = AssemblyDefinition.ReadAssembly(assemblyBytes);
+        var reloadedMethod = reloadedAssembly.MainModule.Types
+            .Single(type => type.FullName == "Test.Type").Methods
+            .Single(candidate => candidate.Name == "Run");
+
+        var result = scanner.ScanMethod(reloadedMethod, "Test.Type");
+
+        result.Findings.Should().BeEmpty();
+        rule.ObservedExceptionHandlerCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void ScanMethod_MultiSignalDisabled_DoesNotEnableCompanionCorrelation()
+    {
+        var config = new ScanConfig { EnableMultiSignalDetection = false };
+        var scanner = CreateScanner(config, new IScanRule[]
+        {
+            new NamedCallRule("Primary", "Primary", requiresCompanionFinding: false),
+            new ContextualNamedCallRule("Companion", "Target")
+        });
+        var method = CreateMethod();
+        var il = method.Body.GetILProcessor();
+        var ret = method.Body.Instructions.Single();
+        il.InsertBefore(ret, Instruction.Create(OpCodes.Call,
+            new MethodReference("Primary", method.Module.TypeSystem.Void,
+                new TypeReference("Test", "Target", method.Module, method.Module.TypeSystem.CoreLibrary))));
+        il.InsertBefore(ret, Instruction.Create(OpCodes.Call,
+            new MethodReference("Target", method.Module.TypeSystem.Void,
+                new TypeReference("Test", "Target", method.Module, method.Module.TypeSystem.CoreLibrary))));
+
+        var result = scanner.ScanMethod(method, "Test.Type");
+
+        result.Findings.Should().ContainSingle(finding => finding.RuleId == "Primary");
+        result.Findings.Should().NotContain(finding => finding.RuleId == "Companion");
+    }
+
     private static MethodScanner CreateScanner(ScanConfig config, IEnumerable<IScanRule> rules)
     {
         var signalTracker = new SignalTracker(config);
@@ -229,6 +296,72 @@ public class MethodScannerTests
         {
             AnalyzeInstructionsCallCount++;
             return new[] { new ScanFinding($"{method.DeclaringType?.FullName}.{method.Name}", "counted", Severity.Low) };
+        }
+    }
+
+    private sealed class CapturingSuppressionRule : IScanRule
+    {
+        public int ObservedExceptionHandlerCount { get; private set; }
+
+        public string Description => "Capturing suppression rule";
+        public Severity Severity => Severity.High;
+        public string RuleId => "CapturingSuppressionRule";
+        public bool RequiresCompanionFinding => false;
+        public bool IsSuspicious(MethodReference method) => method.Name == "Target";
+
+        public bool ShouldSuppressFinding(
+            MethodReference method,
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            int instructionIndex,
+            MethodSignals methodSignals,
+            MethodSignals? typeSignals = null)
+        {
+            ObservedExceptionHandlerCount = methodSignals.ExceptionHandlers.Count;
+            return true;
+        }
+    }
+
+    private sealed class NamedCallRule : IScanRule
+    {
+        private readonly string _methodName;
+
+        public NamedCallRule(string ruleId, string methodName, bool requiresCompanionFinding)
+        {
+            RuleId = ruleId;
+            _methodName = methodName;
+            RequiresCompanionFinding = requiresCompanionFinding;
+        }
+
+        public string Description => $"Named call: {_methodName}";
+        public Severity Severity => Severity.High;
+        public string RuleId { get; }
+        public bool RequiresCompanionFinding { get; }
+        public bool IsSuspicious(MethodReference method) => method.Name == _methodName;
+    }
+
+    private sealed class ContextualNamedCallRule : IScanRule
+    {
+        private readonly string _methodName;
+
+        public ContextualNamedCallRule(string ruleId, string methodName)
+        {
+            RuleId = ruleId;
+            _methodName = methodName;
+        }
+
+        public string Description => $"Contextual named call: {_methodName}";
+        public Severity Severity => Severity.High;
+        public string RuleId { get; }
+        public bool RequiresCompanionFinding => true;
+        public bool IsSuspicious(MethodReference method) => false;
+
+        public IEnumerable<ScanFinding> AnalyzeContextualPattern(MethodReference calledMethod,
+            Mono.Collections.Generic.Collection<Instruction> instructions, int instructionIndex,
+            MethodSignals methodSignals)
+        {
+            return calledMethod.Name == _methodName
+                ? new[] { new ScanFinding("Test.Type.Run", Description, Severity) { RuleId = RuleId } }
+                : Enumerable.Empty<ScanFinding>();
         }
     }
 }

--- a/Models/MethodSignals.cs
+++ b/Models/MethodSignals.cs
@@ -6,6 +6,9 @@ namespace MLVScan.Models
     /// </summary>
     public class MethodSignals
     {
+        internal IReadOnlyList<Mono.Cecil.Cil.ExceptionHandler> ExceptionHandlers { get; set; } =
+            Array.Empty<Mono.Cecil.Cil.ExceptionHandler>();
+
         /// <summary>
         /// Gets or sets a value indicating whether encoded or obfuscated strings were observed.
         /// </summary>

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -31,6 +31,33 @@ namespace MLVScan.Models.Rules.Helpers
         private static readonly Regex FormatItemRegex =
             new Regex(@"\{(\d+)(?:[^}]*)\}", RegexOptions.CultureInvariant);
 
+        private static readonly HashSet<string> TrustedFrameworkAssemblyNames = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "mscorlib",
+            "netstandard",
+            "System",
+            "System.Diagnostics.Process",
+            "System.Runtime"
+        };
+
+        internal static bool IsTrustedFrameworkMethod(
+            MethodReference method,
+            string declaringType,
+            string methodName,
+            bool allowDetachedReference = false)
+        {
+            if (method.DeclaringType?.FullName != declaringType || method.Name != methodName)
+                return false;
+
+            var scope = method.DeclaringType.Scope;
+            if (scope is AssemblyNameReference assemblyReference)
+                return TrustedFrameworkAssemblyNames.Contains(assemblyReference.Name);
+
+            // Unit tests construct detached Cecil references without a module or resolution scope.
+            // Production references must identify a known framework assembly explicitly.
+            return allowDetachedReference && scope == null && method.Module == null;
+        }
+
         /// <summary>
         /// Tries to resolve the executable or command target passed to a process-launching call.
         /// </summary>
@@ -967,8 +994,8 @@ namespace MLVScan.Models.Rules.Helpers
         {
             if (fileNameIndex < 0 || fileNameIndex >= instructions.Count ||
                 instructions[fileNameIndex].Operand is not MethodReference fileName ||
-                fileName.DeclaringType?.FullName != "System.Diagnostics.ProcessModule" ||
-                fileName.Name != "get_FileName")
+                !IsTrustedFrameworkMethod(fileName,
+                    "System.Diagnostics.ProcessModule", "get_FileName", allowDetachedReference: true))
             {
                 return false;
             }
@@ -977,13 +1004,13 @@ namespace MLVScan.Models.Rules.Helpers
             return producerMap.TryGetReceiverProducer(fileNameIndex, out int mainModuleIndex) &&
                    mainModuleIndex >= 0 && mainModuleIndex < instructions.Count &&
                    instructions[mainModuleIndex].Operand is MethodReference mainModule &&
-                   mainModule.DeclaringType?.FullName == "System.Diagnostics.Process" &&
-                   mainModule.Name == "get_MainModule" &&
+                   IsTrustedFrameworkMethod(mainModule,
+                       "System.Diagnostics.Process", "get_MainModule", allowDetachedReference: true) &&
                    producerMap.TryGetReceiverProducer(mainModuleIndex, out int currentProcessIndex) &&
                    currentProcessIndex >= 0 && currentProcessIndex < instructions.Count &&
                    instructions[currentProcessIndex].Operand is MethodReference currentProcess &&
-                   currentProcess.DeclaringType?.FullName == "System.Diagnostics.Process" &&
-                   currentProcess.Name == "GetCurrentProcess";
+                   IsTrustedFrameworkMethod(currentProcess,
+                       "System.Diagnostics.Process", "GetCurrentProcess", allowDetachedReference: true);
         }
 
         private sealed class ExceptionalTargetCache
@@ -1362,8 +1389,7 @@ namespace MLVScan.Models.Rules.Helpers
         {
             return index >= 0 && index < instructions.Count &&
                    instructions[index].Operand is MethodReference method &&
-                   method.DeclaringType?.FullName == declaringType &&
-                   method.Name == methodName;
+                   IsTrustedFrameworkMethod(method, declaringType, methodName, allowDetachedReference: true);
         }
 
         private static bool IsArrayElementStore(Instruction instruction)

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -810,6 +810,26 @@ namespace MLVScan.Models.Rules.Helpers
             return reachedUse;
         }
 
+        public static bool TryResolveEquivalentCallArgumentReachingDefinitions(
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers,
+            int useIndex,
+            Func<Instruction, bool> isDefinition,
+            int argumentIndex,
+            out string identity)
+        {
+            return TryResolveEquivalentReachingDefinitions(
+                instructions, exceptionHandlers, useIndex, isDefinition, 0, out identity,
+                definitionIdentityResolver: (int definitionIndex, out string definitionIdentity) =>
+                {
+                    definitionIdentity = string.Empty;
+                    return instructions[definitionIndex].Operand is MethodReference method &&
+                           argumentIndex >= 0 && argumentIndex < method.Parameters.Count &&
+                           TryResolveCallArgumentIdentity(method, instructions, definitionIndex, argumentIndex,
+                               exceptionHandlers, out definitionIdentity);
+                });
+        }
+
         private static bool TryResolveEquivalentReachingDefinitions(
             Mono.Collections.Generic.Collection<Instruction> instructions,
             IReadOnlyList<ExceptionHandler> exceptionHandlers,
@@ -818,7 +838,8 @@ namespace MLVScan.Models.Rules.Helpers
             int depth,
             out string identity,
             string requiredReceiverIdentity = "",
-            Func<Instruction, bool>? invalidatesDefinition = null)
+            Func<Instruction, bool>? invalidatesDefinition = null,
+            TryResolveDefinitionIdentity? definitionIdentityResolver = null)
         {
             identity = string.Empty;
             if (!TryBuildExceptionalTargets(instructions, exceptionHandlers, out var exceptionTargets))
@@ -928,9 +949,15 @@ namespace MLVScan.Models.Rules.Helpers
                     }
                 }
 
-                if (!producerMap.TryGetStoredValueProducer(definitionIndex, out int storedValueProducer) ||
-                    !TryBuildProducerIdentity(instructions, storedValueProducer, exceptionHandlers,
-                        depth + 1, out var definitionIdentity))
+                string definitionIdentity;
+                if (definitionIdentityResolver != null)
+                {
+                    if (!definitionIdentityResolver(definitionIndex, out definitionIdentity))
+                        return false;
+                }
+                else if (!producerMap.TryGetStoredValueProducer(definitionIndex, out int storedValueProducer) ||
+                         !TryBuildProducerIdentity(instructions, storedValueProducer, exceptionHandlers,
+                             depth + 1, out definitionIdentity))
                 {
                     return false;
                 }
@@ -944,6 +971,8 @@ namespace MLVScan.Models.Rules.Helpers
 
             return identity.Length > 0;
         }
+
+        private delegate bool TryResolveDefinitionIdentity(int definitionIndex, out string identity);
 
         private static bool AreEquivalentProducerIdentities(
             Mono.Collections.Generic.Collection<Instruction> instructions,

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -181,6 +181,7 @@ namespace MLVScan.Models.Rules.Helpers
 
         public static bool IsGuaranteedToExecuteBefore(
             Mono.Collections.Generic.Collection<Instruction> instructions,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers,
             int instructionIndex,
             int useIndex)
         {
@@ -188,6 +189,32 @@ namespace MLVScan.Models.Rules.Helpers
                 instructionIndex >= instructions.Count || useIndex >= instructions.Count)
             {
                 return false;
+            }
+
+            const int maxExceptionalEdges = 4096;
+            var exceptionTargets = new Dictionary<int, List<int>>();
+            int exceptionalEdgeCount = 0;
+            foreach (var handler in exceptionHandlers)
+            {
+                int tryStartIndex = instructions.IndexOf(handler.TryStart);
+                int tryEndIndex = handler.TryEnd == null ? instructions.Count : instructions.IndexOf(handler.TryEnd);
+                int handlerStartIndex = instructions.IndexOf(handler.HandlerStart);
+                if (tryStartIndex < 0 || tryEndIndex < tryStartIndex || handlerStartIndex < 0)
+                    return false;
+
+                for (int i = tryStartIndex; i < tryEndIndex; i++)
+                {
+                    if (++exceptionalEdgeCount > maxExceptionalEdges)
+                        return false;
+
+                    if (!exceptionTargets.TryGetValue(i, out var targets))
+                    {
+                        targets = new List<int>();
+                        exceptionTargets[i] = targets;
+                    }
+
+                    targets.Add(handlerStartIndex);
+                }
             }
 
             var pending = new Queue<(int Index, bool Executed)>();
@@ -212,6 +239,16 @@ namespace MLVScan.Models.Rules.Helpers
 
                 bool executed = current.Executed || current.Index == instructionIndex;
                 var instruction = instructions[current.Index];
+
+                if (exceptionTargets.TryGetValue(current.Index, out var handlerTargets))
+                {
+                    foreach (var handlerTarget in handlerTargets)
+                    {
+                        // A protected instruction may transfer to the handler before completing.
+                        pending.Enqueue((handlerTarget, current.Executed));
+                    }
+                }
+
                 if (instruction.Operand is Instruction target)
                 {
                     pending.Enqueue((instructions.IndexOf(target), executed));

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -16,7 +16,13 @@ namespace MLVScan.Models.Rules.Helpers
         private const int MaxTrackedCallArguments = 32;
 
         private static readonly ConditionalWeakTable<
-            Mono.Collections.Generic.Collection<Instruction>, CallArgumentProducerMap> CallArgumentProducerMaps = new();
+            Mono.Collections.Generic.Collection<Instruction>, CallArgumentProducerMapCache> CallArgumentProducerMaps = new();
+
+        private static readonly ConditionalWeakTable<
+            Mono.Collections.Generic.Collection<Instruction>, Dictionary<Instruction, int>> InstructionIndexMaps = new();
+
+        private static readonly ConditionalWeakTable<
+            Mono.Collections.Generic.Collection<Instruction>, ExceptionalTargetCache> ExceptionalTargetCaches = new();
 
         private static readonly Regex ExecutableNameRegex =
             new Regex(@"([A-Za-z0-9._-]+\.(?:exe|bat|cmd|com|ps1|msi))",
@@ -122,6 +128,19 @@ namespace MLVScan.Models.Rules.Helpers
             int argumentIndex,
             out string valueDisplay)
         {
+            return TryResolveCallArgumentDisplay(containingMethod, calledMethod, instructions, callIndex,
+                argumentIndex, Array.Empty<ExceptionHandler>(), out valueDisplay);
+        }
+
+        public static bool TryResolveCallArgumentDisplay(
+            MethodDefinition? containingMethod,
+            MethodReference calledMethod,
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            int callIndex,
+            int argumentIndex,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers,
+            out string valueDisplay)
+        {
             valueDisplay = "<unknown/non-literal>";
             if (argumentIndex < 0 || argumentIndex >= calledMethod.Parameters.Count)
             {
@@ -130,7 +149,7 @@ namespace MLVScan.Models.Rules.Helpers
 
             var context = new ResolverContext(containingMethod?.Module);
             if (TryResolveCallArgumentFromBasicBlock(context, containingMethod, instructions, callIndex,
-                    calledMethod.Parameters.Count, argumentIndex, out valueDisplay))
+                    calledMethod.Parameters.Count, argumentIndex, exceptionHandlers, out valueDisplay))
             {
                 return true;
             }
@@ -164,7 +183,7 @@ namespace MLVScan.Models.Rules.Helpers
             out string identity)
         {
             identity = string.Empty;
-            var producerMap = CallArgumentProducerMaps.GetValue(instructions, BuildCallArgumentProducerMap);
+            var producerMap = GetCallArgumentProducerMap(instructions, exceptionHandlers);
             return producerMap.TryGetReceiverProducer(callIndex, out int producerIndex) &&
                    TryBuildProducerIdentity(instructions, producerIndex, exceptionHandlers, out identity);
         }
@@ -195,7 +214,7 @@ namespace MLVScan.Models.Rules.Helpers
             if (argumentIndex < 0 || argumentIndex >= calledMethod.Parameters.Count)
                 return false;
 
-            var producerMap = CallArgumentProducerMaps.GetValue(instructions, BuildCallArgumentProducerMap);
+            var producerMap = GetCallArgumentProducerMap(instructions, exceptionHandlers);
             return producerMap.TryGetProducer(callIndex, calledMethod.Parameters.Count, argumentIndex,
                        out int producerIndex) &&
                    TryBuildProducerIdentity(instructions, producerIndex, exceptionHandlers, out identity);
@@ -213,8 +232,13 @@ namespace MLVScan.Models.Rules.Helpers
                 return false;
             }
 
+            if (HasRelevantUnsupportedHandler(instructions, exceptionHandlers, instructionIndex, useIndex))
+                return false;
+
             if (!TryBuildExceptionalTargets(instructions, exceptionHandlers, out var exceptionTargets))
                 return false;
+
+            var instructionIndexes = InstructionIndexMaps.GetValue(instructions, BuildInstructionIndexMap);
 
             var pending = new Queue<(int Index, bool Executed)>();
             var visited = new HashSet<(int Index, bool Executed)>();
@@ -250,12 +274,20 @@ namespace MLVScan.Models.Rules.Helpers
 
                 if (instruction.Operand is Instruction target)
                 {
-                    pending.Enqueue((instructions.IndexOf(target), executed));
+                    if (!instructionIndexes.TryGetValue(target, out int targetIndex))
+                        return false;
+
+                    pending.Enqueue((targetIndex, executed));
                 }
                 else if (instruction.Operand is Instruction[] targets)
                 {
                     foreach (var switchTarget in targets)
-                        pending.Enqueue((instructions.IndexOf(switchTarget), executed));
+                    {
+                        if (!instructionIndexes.TryGetValue(switchTarget, out int targetIndex))
+                            return false;
+
+                        pending.Enqueue((targetIndex, executed));
+                    }
                 }
 
                 var flowControl = instruction.OpCode.FlowControl;
@@ -266,38 +298,198 @@ namespace MLVScan.Models.Rules.Helpers
             return reachedUse;
         }
 
+        public static bool CanExecuteBetween(
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers,
+            int startIndex,
+            int candidateIndex,
+            int useIndex)
+        {
+            if (instructions == null || startIndex < 0 || candidateIndex < 0 || useIndex < 0 ||
+                startIndex >= instructions.Count || candidateIndex >= instructions.Count || useIndex >= instructions.Count ||
+                HasRelevantUnsupportedHandler(instructions, exceptionHandlers, startIndex, useIndex) ||
+                !TryBuildExceptionalTargets(instructions, exceptionHandlers, out var exceptionTargets))
+            {
+                return true;
+            }
+
+            var instructionIndexes = InstructionIndexMaps.GetValue(instructions, BuildInstructionIndexMap);
+            var pending = new Queue<(int Index, bool CandidateSeen)>();
+            var visited = new HashSet<(int Index, bool CandidateSeen)>();
+            pending.Enqueue((startIndex, startIndex == candidateIndex));
+
+            while (pending.Count > 0)
+            {
+                var current = pending.Dequeue();
+                if (current.Index < 0 || current.Index >= instructions.Count || !visited.Add(current))
+                    continue;
+
+                if (current.Index == useIndex)
+                {
+                    if (current.CandidateSeen)
+                        return true;
+
+                    continue;
+                }
+
+                var instruction = instructions[current.Index];
+                bool candidateSeen = current.CandidateSeen || current.Index == candidateIndex;
+
+                if (exceptionTargets.TryGetValue(current.Index, out var handlerTargets))
+                {
+                    foreach (var handlerTarget in handlerTargets)
+                        pending.Enqueue((handlerTarget, current.CandidateSeen));
+                }
+
+                if (instruction.Operand is Instruction target)
+                {
+                    if (!instructionIndexes.TryGetValue(target, out int targetIndex))
+                        return true;
+
+                    pending.Enqueue((targetIndex, candidateSeen));
+                }
+                else if (instruction.Operand is Instruction[] targets)
+                {
+                    foreach (var switchTarget in targets)
+                    {
+                        if (!instructionIndexes.TryGetValue(switchTarget, out int targetIndex))
+                            return true;
+
+                        pending.Enqueue((targetIndex, candidateSeen));
+                    }
+                }
+
+                var flowControl = instruction.OpCode.FlowControl;
+                if (flowControl is not FlowControl.Branch and not FlowControl.Return and not FlowControl.Throw)
+                    pending.Enqueue((current.Index + 1, candidateSeen));
+            }
+
+            return false;
+        }
+
         private static bool TryBuildExceptionalTargets(
             Mono.Collections.Generic.Collection<Instruction> instructions,
             IReadOnlyList<ExceptionHandler> exceptionHandlers,
             out Dictionary<int, List<int>> exceptionTargets)
         {
-            const int maxExceptionalEdges = 4096;
-            exceptionTargets = new Dictionary<int, List<int>>();
-            int exceptionalEdgeCount = 0;
-            foreach (var handler in exceptionHandlers)
+            var cache = ExceptionalTargetCaches.GetValue(instructions, static _ => new ExceptionalTargetCache());
+            lock (cache.Gate)
             {
-                int tryStartIndex = instructions.IndexOf(handler.TryStart);
-                int tryEndIndex = handler.TryEnd == null ? instructions.Count : instructions.IndexOf(handler.TryEnd);
-                int handlerStartIndex = instructions.IndexOf(handler.HandlerStart);
-                if (tryStartIndex < 0 || tryEndIndex < tryStartIndex || handlerStartIndex < 0)
-                    return false;
-
-                for (int i = tryStartIndex; i < tryEndIndex; i++)
+                if (cache.Matches(exceptionHandlers))
                 {
-                    if (++exceptionalEdgeCount > maxExceptionalEdges)
-                        return false;
+                    exceptionTargets = cache.Targets;
+                    return cache.IsValid;
+                }
 
-                    if (!exceptionTargets.TryGetValue(i, out var targets))
+                const int maxExceptionalEdges = 4096;
+                var instructionIndexes = InstructionIndexMaps.GetValue(instructions, BuildInstructionIndexMap);
+                var targetsByInstruction = new Dictionary<int, List<int>>();
+                int exceptionalEdgeCount = 0;
+                bool isValid = true;
+                foreach (var handler in exceptionHandlers)
+                {
+                    if (!instructionIndexes.TryGetValue(handler.TryStart, out int tryStartIndex) ||
+                        (handler.TryEnd != null && !instructionIndexes.TryGetValue(handler.TryEnd, out _)) ||
+                        !instructionIndexes.TryGetValue(handler.HandlerStart, out int handlerStartIndex))
                     {
-                        targets = new List<int>();
-                        exceptionTargets[i] = targets;
+                        isValid = false;
+                        break;
                     }
 
-                    targets.Add(handlerStartIndex);
+                    int tryEndIndex = handler.TryEnd == null
+                        ? instructions.Count
+                        : instructionIndexes[handler.TryEnd];
+                    if (tryEndIndex < tryStartIndex)
+                    {
+                        isValid = false;
+                        break;
+                    }
+
+                    // Non-catch handlers require query-specific treatment. They are rejected by
+                    // HasRelevantUnsupportedHandler only when they can run between the value's
+                    // definition and use; otherwise they cannot affect the resolved value.
+                    if (handler.HandlerType != ExceptionHandlerType.Catch)
+                        continue;
+
+                    for (int i = tryStartIndex; i < tryEndIndex; i++)
+                    {
+                        if (++exceptionalEdgeCount > maxExceptionalEdges)
+                        {
+                            isValid = false;
+                            break;
+                        }
+
+                        if (!targetsByInstruction.TryGetValue(i, out var targets))
+                        {
+                            targets = new List<int>();
+                            targetsByInstruction[i] = targets;
+                        }
+
+                        targets.Add(handlerStartIndex);
+                    }
+
+                    if (!isValid)
+                        break;
                 }
+
+                cache.Update(exceptionHandlers, targetsByInstruction, isValid);
+                exceptionTargets = cache.Targets;
+                return cache.IsValid;
+            }
+        }
+
+        private static bool HasRelevantUnsupportedHandler(
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers,
+            int startIndex,
+            int useIndex)
+        {
+            var instructionIndexes = InstructionIndexMaps.GetValue(instructions, BuildInstructionIndexMap);
+            foreach (var handler in exceptionHandlers)
+            {
+                if (handler.HandlerType == ExceptionHandlerType.Catch)
+                    continue;
+
+                int tryEndIndex = instructions.Count;
+                int handlerEndIndex = instructions.Count;
+                if (!instructionIndexes.TryGetValue(handler.TryStart, out int tryStartIndex) ||
+                    !instructionIndexes.TryGetValue(handler.HandlerStart, out int handlerStartIndex) ||
+                    (handler.TryEnd != null && !instructionIndexes.TryGetValue(handler.TryEnd, out tryEndIndex)) ||
+                    (handler.HandlerEnd != null &&
+                     !instructionIndexes.TryGetValue(handler.HandlerEnd, out handlerEndIndex)))
+                {
+                    return true;
+                }
+
+                if (tryEndIndex < tryStartIndex || handlerEndIndex < handlerStartIndex)
+                    return true;
+
+                // A use inside the protected region happens before its finally/fault handler.
+                // A definition and use inside the same handler do not cross that handler. A handler
+                // wholly before the definition or after the use is likewise unrelated.
+                if ((useIndex >= tryStartIndex && useIndex < tryEndIndex) ||
+                    (startIndex >= handlerStartIndex && startIndex < handlerEndIndex &&
+                     useIndex >= handlerStartIndex && useIndex < handlerEndIndex) ||
+                    useIndex < tryStartIndex ||
+                    startIndex >= handlerEndIndex)
+                {
+                    continue;
+                }
+
+                return true;
             }
 
-            return true;
+            return false;
+        }
+
+        private static Dictionary<Instruction, int> BuildInstructionIndexMap(
+            Mono.Collections.Generic.Collection<Instruction> instructions)
+        {
+            var indexes = new Dictionary<Instruction, int>(instructions.Count);
+            for (int i = 0; i < instructions.Count; i++)
+                indexes[instructions[i]] = i;
+
+            return indexes;
         }
 
         public static bool TryResolveCallArgumentProducerIndex(
@@ -307,11 +499,23 @@ namespace MLVScan.Models.Rules.Helpers
             int argumentIndex,
             out int producerIndex)
         {
+            return TryResolveCallArgumentProducerIndex(calledMethod, instructions, callIndex, argumentIndex,
+                Array.Empty<ExceptionHandler>(), out producerIndex);
+        }
+
+        public static bool TryResolveCallArgumentProducerIndex(
+            MethodReference calledMethod,
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            int callIndex,
+            int argumentIndex,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers,
+            out int producerIndex)
+        {
             producerIndex = -1;
             if (argumentIndex < 0 || argumentIndex >= calledMethod.Parameters.Count)
                 return false;
 
-            var producerMap = CallArgumentProducerMaps.GetValue(instructions, BuildCallArgumentProducerMap);
+            var producerMap = GetCallArgumentProducerMap(instructions, exceptionHandlers);
             return producerMap.TryGetProducer(callIndex, calledMethod.Parameters.Count, argumentIndex,
                 out producerIndex);
         }
@@ -339,50 +543,49 @@ namespace MLVScan.Models.Rules.Helpers
             var producer = instructions[producerIndex];
             if (TryGetLoadedLocalIndex(producer, out int localIndex))
             {
-                for (int i = producerIndex - 1; i >= 0; i--)
-                {
-                    if (!TryGetStoredLocalIndex(instructions[i], out int storedLocalIndex) ||
-                        storedLocalIndex != localIndex)
-                    {
-                        continue;
-                    }
-
-                    if (!HasUnambiguousReachingDefinition(instructions, exceptionHandlers, i, producerIndex,
-                            instruction => TryGetStoredLocalIndex(instruction, out int storedIndex) &&
-                                           storedIndex == localIndex))
-                        return false;
-
-                    var producerMap = CallArgumentProducerMaps.GetValue(instructions, BuildCallArgumentProducerMap);
-                    return producerMap.TryGetStoredValueProducer(i, out int storedValueProducer) &&
-                           TryBuildProducerIdentity(instructions, storedValueProducer, exceptionHandlers,
-                               depth + 1, out identity);
-                }
-
-                return false;
+                return TryResolveEquivalentReachingDefinitions(instructions, exceptionHandlers, producerIndex,
+                    instruction => TryGetStoredLocalIndex(instruction, out int storedIndex) &&
+                                   storedIndex == localIndex,
+                    depth, out identity);
             }
 
             if (TryGetLoadedArgumentIndex(producer, out int argumentIndex))
             {
-                for (int i = producerIndex - 1; i >= 0; i--)
+                bool hasArgumentStore = false;
+                for (int i = 0; i < producerIndex; i++)
                 {
-                    if (!TryGetStoredArgumentIndex(instructions[i], out int storedArgumentIndex) ||
-                        storedArgumentIndex != argumentIndex)
+                    if (TryGetStoredArgumentIndex(instructions[i], out int storedArgumentIndex) &&
+                        storedArgumentIndex == argumentIndex)
                     {
-                        continue;
+                        hasArgumentStore = true;
+                        break;
                     }
-
-                    if (!HasUnambiguousReachingDefinition(instructions, exceptionHandlers, i, producerIndex,
-                            instruction => TryGetStoredArgumentIndex(instruction, out int storedIndex) &&
-                                           storedIndex == argumentIndex))
-                    {
-                        return false;
-                    }
-
-                    var producerMap = CallArgumentProducerMaps.GetValue(instructions, BuildCallArgumentProducerMap);
-                    return producerMap.TryGetStoredValueProducer(i, out int storedValueProducer) &&
-                           TryBuildProducerIdentity(instructions, storedValueProducer, exceptionHandlers,
-                               depth + 1, out identity);
                 }
+
+                if (hasArgumentStore)
+                    return TryResolveEquivalentReachingDefinitions(instructions, exceptionHandlers, producerIndex,
+                        instruction => TryGetStoredArgumentIndex(instruction, out int storedIndex) &&
+                                       storedIndex == argumentIndex,
+                        depth, out identity);
+            }
+
+            if (producer.Operand is FieldReference loadedField &&
+                producer.OpCode.Code is Code.Ldfld or Code.Ldsfld)
+            {
+                var producerMap = GetCallArgumentProducerMap(instructions, exceptionHandlers);
+                string receiverIdentity = string.Empty;
+                if (producer.OpCode.Code == Code.Ldfld &&
+                    (!producerMap.TryGetFieldReceiverProducer(producerIndex, out int receiverProducer) ||
+                     !TryBuildProducerIdentity(instructions, receiverProducer, exceptionHandlers,
+                         depth + 1, out receiverIdentity)))
+                {
+                    return false;
+                }
+
+                return TryResolveEquivalentReachingDefinitions(instructions, exceptionHandlers, producerIndex,
+                    instruction => IsMatchingFieldStore(instruction, loadedField,
+                        producer.OpCode.Code == Code.Ldsfld), depth, out identity,
+                    receiverIdentity, IsPotentialFieldMutation);
             }
 
             identity = producer.OpCode.Code switch
@@ -400,6 +603,18 @@ namespace MLVScan.Models.Rules.Helpers
             };
 
             return identity.Length > 0;
+        }
+
+        private static bool IsMatchingFieldStore(Instruction instruction, FieldReference loadedField, bool isStatic)
+        {
+            return instruction.Operand is FieldReference storedField &&
+                   storedField.FullName == loadedField.FullName &&
+                   instruction.OpCode.Code == (isStatic ? Code.Stsfld : Code.Stfld);
+        }
+
+        private static bool IsPotentialFieldMutation(Instruction instruction)
+        {
+            return instruction.OpCode.Code is Code.Call or Code.Callvirt or Code.Calli or Code.Newobj;
         }
 
         private static bool TryGetLoadedLocalIndex(Instruction instruction, out int localIndex)
@@ -430,8 +645,13 @@ namespace MLVScan.Models.Rules.Helpers
 
             var pending = new Queue<(int Index, byte State)>();
             var visited = new HashSet<(int Index, byte State)>();
+            if (HasRelevantUnsupportedHandler(instructions, exceptionHandlers, definitionIndex, useIndex))
+                return false;
+
             if (!TryBuildExceptionalTargets(instructions, exceptionHandlers, out var exceptionTargets))
                 return false;
+
+            var instructionIndexes = InstructionIndexMaps.GetValue(instructions, BuildInstructionIndexMap);
 
             pending.Enqueue((0, unresolved));
             bool reachedUse = false;
@@ -470,12 +690,20 @@ namespace MLVScan.Models.Rules.Helpers
 
                 if (instruction.Operand is Instruction target)
                 {
-                    pending.Enqueue((instructions.IndexOf(target), nextState));
+                    if (!instructionIndexes.TryGetValue(target, out int targetIndex))
+                        return false;
+
+                    pending.Enqueue((targetIndex, nextState));
                 }
                 else if (instruction.Operand is Instruction[] targets)
                 {
                     foreach (var switchTarget in targets)
-                        pending.Enqueue((instructions.IndexOf(switchTarget), nextState));
+                    {
+                        if (!instructionIndexes.TryGetValue(switchTarget, out int targetIndex))
+                            return false;
+
+                        pending.Enqueue((targetIndex, nextState));
+                    }
                 }
 
                 var flowControl = instruction.OpCode.FlowControl;
@@ -484,6 +712,222 @@ namespace MLVScan.Models.Rules.Helpers
             }
 
             return reachedUse;
+        }
+
+        private static bool TryResolveEquivalentReachingDefinitions(
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers,
+            int useIndex,
+            Func<Instruction, bool> isDefinition,
+            int depth,
+            out string identity,
+            string requiredReceiverIdentity = "",
+            Func<Instruction, bool>? invalidatesDefinition = null)
+        {
+            identity = string.Empty;
+            if (!TryBuildExceptionalTargets(instructions, exceptionHandlers, out var exceptionTargets))
+                return false;
+
+            const int maxReachingDefinitions = 64;
+            const int maxWorkUnits = 65_536;
+            var instructionIndexes = InstructionIndexMaps.GetValue(instructions, BuildInstructionIndexMap);
+            var pending = new Queue<(int Index, int DefinitionIndex)>();
+            var visited = new HashSet<(int Index, int DefinitionIndex)>();
+            var reachingDefinitions = new HashSet<int>();
+            pending.Enqueue((0, -1));
+            foreach (var handler in exceptionHandlers)
+            {
+                int handlerEndIndex = instructions.Count;
+                if (handler.HandlerType == ExceptionHandlerType.Catch ||
+                    !instructionIndexes.TryGetValue(handler.HandlerStart, out int handlerStartIndex) ||
+                    (handler.HandlerEnd != null &&
+                     !instructionIndexes.TryGetValue(handler.HandlerEnd, out handlerEndIndex)))
+                {
+                    continue;
+                }
+
+                if (useIndex >= handlerStartIndex && useIndex < handlerEndIndex)
+                    pending.Enqueue((handlerStartIndex, -1));
+            }
+            int workUnits = 0;
+
+            while (pending.Count > 0)
+            {
+                if (++workUnits > maxWorkUnits)
+                    return false;
+
+                var current = pending.Dequeue();
+                if (current.Index < 0 || current.Index >= instructions.Count || !visited.Add(current))
+                    continue;
+
+                if (current.Index == useIndex)
+                {
+                    if (current.DefinitionIndex < 0 ||
+                        reachingDefinitions.Count >= maxReachingDefinitions &&
+                        !reachingDefinitions.Contains(current.DefinitionIndex))
+                    {
+                        return false;
+                    }
+
+                    reachingDefinitions.Add(current.DefinitionIndex);
+                    continue;
+                }
+
+                var instruction = instructions[current.Index];
+                int nextDefinition = isDefinition(instruction)
+                    ? current.Index
+                    : invalidatesDefinition?.Invoke(instruction) == true
+                        ? -2
+                        : current.DefinitionIndex;
+
+                if (exceptionTargets.TryGetValue(current.Index, out var handlerTargets))
+                {
+                    foreach (var handlerTarget in handlerTargets)
+                        pending.Enqueue((handlerTarget, current.DefinitionIndex));
+                }
+
+                if (instruction.Operand is Instruction target)
+                {
+                    if (!instructionIndexes.TryGetValue(target, out int targetIndex))
+                        return false;
+
+                    pending.Enqueue((targetIndex, nextDefinition));
+                }
+                else if (instruction.Operand is Instruction[] targets)
+                {
+                    foreach (var switchTarget in targets)
+                    {
+                        if (!instructionIndexes.TryGetValue(switchTarget, out int targetIndex))
+                            return false;
+
+                        pending.Enqueue((targetIndex, nextDefinition));
+                    }
+                }
+
+                var flowControl = instruction.OpCode.FlowControl;
+                if (flowControl is not FlowControl.Branch and not FlowControl.Return and not FlowControl.Throw)
+                    pending.Enqueue((current.Index + 1, nextDefinition));
+            }
+
+            if (reachingDefinitions.Count == 0)
+                return false;
+
+            var producerMap = GetCallArgumentProducerMap(instructions, exceptionHandlers);
+            foreach (int definitionIndex in reachingDefinitions)
+            {
+                if (HasRelevantUnsupportedHandler(instructions, exceptionHandlers, definitionIndex, useIndex))
+                    return false;
+
+                if (requiredReceiverIdentity.Length > 0)
+                {
+                    if (!producerMap.TryGetFieldReceiverProducer(definitionIndex, out int receiverProducer) ||
+                        !TryBuildProducerIdentity(instructions, receiverProducer, exceptionHandlers,
+                            depth + 1, out var receiverIdentity) ||
+                        !receiverIdentity.Equals(requiredReceiverIdentity, StringComparison.Ordinal))
+                    {
+                        return false;
+                    }
+                }
+
+                if (!producerMap.TryGetStoredValueProducer(definitionIndex, out int storedValueProducer) ||
+                    !TryBuildProducerIdentity(instructions, storedValueProducer, exceptionHandlers,
+                        depth + 1, out var definitionIdentity))
+                {
+                    return false;
+                }
+
+                if (identity.Length == 0)
+                    identity = definitionIdentity;
+                else if (!AreEquivalentProducerIdentities(instructions, exceptionHandlers,
+                             identity, definitionIdentity))
+                    return false;
+            }
+
+            return identity.Length > 0;
+        }
+
+        private static bool AreEquivalentProducerIdentities(
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers,
+            string left,
+            string right)
+        {
+            if (left.Equals(right, StringComparison.Ordinal))
+                return true;
+
+            return TryGetCallIdentityIndex(left, out int leftIndex) &&
+                   TryGetCallIdentityIndex(right, out int rightIndex) &&
+                   IsCurrentProcessFileNameCall(instructions, exceptionHandlers, leftIndex) &&
+                   IsCurrentProcessFileNameCall(instructions, exceptionHandlers, rightIndex);
+        }
+
+        private static bool TryGetCallIdentityIndex(string identity, out int index)
+        {
+            const string prefix = "call:";
+            index = -1;
+            return identity.StartsWith(prefix, StringComparison.Ordinal) &&
+                   int.TryParse(identity.AsSpan(prefix.Length), out index);
+        }
+
+        private static bool IsCurrentProcessFileNameCall(
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers,
+            int fileNameIndex)
+        {
+            if (fileNameIndex < 0 || fileNameIndex >= instructions.Count ||
+                instructions[fileNameIndex].Operand is not MethodReference fileName ||
+                fileName.DeclaringType?.FullName != "System.Diagnostics.ProcessModule" ||
+                fileName.Name != "get_FileName")
+            {
+                return false;
+            }
+
+            var producerMap = GetCallArgumentProducerMap(instructions, exceptionHandlers);
+            return producerMap.TryGetReceiverProducer(fileNameIndex, out int mainModuleIndex) &&
+                   mainModuleIndex >= 0 && mainModuleIndex < instructions.Count &&
+                   instructions[mainModuleIndex].Operand is MethodReference mainModule &&
+                   mainModule.DeclaringType?.FullName == "System.Diagnostics.Process" &&
+                   mainModule.Name == "get_MainModule" &&
+                   producerMap.TryGetReceiverProducer(mainModuleIndex, out int currentProcessIndex) &&
+                   currentProcessIndex >= 0 && currentProcessIndex < instructions.Count &&
+                   instructions[currentProcessIndex].Operand is MethodReference currentProcess &&
+                   currentProcess.DeclaringType?.FullName == "System.Diagnostics.Process" &&
+                   currentProcess.Name == "GetCurrentProcess";
+        }
+
+        private sealed class ExceptionalTargetCache
+        {
+            public object Gate { get; } = new();
+
+            public ExceptionHandler[] Handlers { get; private set; } = Array.Empty<ExceptionHandler>();
+
+            public Dictionary<int, List<int>> Targets { get; private set; } = new();
+
+            public bool IsValid { get; private set; } = true;
+
+            public bool Matches(IReadOnlyList<ExceptionHandler> handlers)
+            {
+                if (Handlers.Length != handlers.Count)
+                    return false;
+
+                for (int i = 0; i < Handlers.Length; i++)
+                {
+                    if (!ReferenceEquals(Handlers[i], handlers[i]))
+                        return false;
+                }
+
+                return true;
+            }
+
+            public void Update(
+                IReadOnlyList<ExceptionHandler> handlers,
+                Dictionary<int, List<int>> targets,
+                bool isValid)
+            {
+                Handlers = handlers.ToArray();
+                Targets = targets;
+                IsValid = isValid;
+            }
         }
 
         private static bool TryGetLoadedArgumentIndex(Instruction instruction, out int argumentIndex)
@@ -536,10 +980,11 @@ namespace MLVScan.Models.Rules.Helpers
             int callIndex,
             int parameterCount,
             int argumentIndex,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers,
             out string valueDisplay)
         {
             valueDisplay = "<unknown/non-literal>";
-            var producerMap = CallArgumentProducerMaps.GetValue(instructions, BuildCallArgumentProducerMap);
+            var producerMap = GetCallArgumentProducerMap(instructions, exceptionHandlers);
             if (!producerMap.TryGetProducer(callIndex, parameterCount, argumentIndex, out int producerIndex))
                 return false;
 
@@ -553,16 +998,51 @@ namespace MLVScan.Models.Rules.Helpers
             return true;
         }
 
+        private static CallArgumentProducerMap GetCallArgumentProducerMap(
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers)
+        {
+            var cache = CallArgumentProducerMaps.GetValue(instructions, static _ => new CallArgumentProducerMapCache());
+            lock (cache.Gate)
+            {
+                if (!cache.Matches(exceptionHandlers))
+                    cache.Update(exceptionHandlers, BuildCallArgumentProducerMap(instructions, exceptionHandlers));
+
+                return cache.Map;
+            }
+        }
+
         private static CallArgumentProducerMap BuildCallArgumentProducerMap(
-            Mono.Collections.Generic.Collection<Instruction> instructions)
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers)
         {
             var instructionIndices = new Dictionary<Instruction, int>(instructions.Count);
             for (int i = 0; i < instructions.Count; i++)
                 instructionIndices[instructions[i]] = i;
 
             var blockStarts = new bool[instructions.Count];
+            var catchHandlerStarts = new bool[instructions.Count];
             if (blockStarts.Length > 0)
                 blockStarts[0] = true;
+
+            foreach (var handler in exceptionHandlers)
+            {
+                if (!instructionIndices.TryGetValue(handler.HandlerStart, out int handlerStartIndex))
+                    return CallArgumentProducerMap.Empty;
+
+                blockStarts[handlerStartIndex] = true;
+                if (handler.HandlerType is ExceptionHandlerType.Catch or ExceptionHandlerType.Filter)
+                    catchHandlerStarts[handlerStartIndex] = true;
+
+                if (handler.FilterStart != null)
+                {
+                    if (!instructionIndices.TryGetValue(handler.FilterStart, out int filterStartIndex))
+                        return CallArgumentProducerMap.Empty;
+
+                    blockStarts[filterStartIndex] = true;
+                    catchHandlerStarts[filterStartIndex] = true;
+                }
+            }
 
             for (int i = 0; i < instructions.Count; i++)
             {
@@ -588,6 +1068,7 @@ namespace MLVScan.Models.Rules.Helpers
 
             var producersByCallIndex = new Dictionary<int, CallProducers>();
             var producersByStoreIndex = new Dictionary<int, int>();
+            var fieldReceiversByInstructionIndex = new Dictionary<int, int>();
             var stack = new List<int>();
             bool validBlock = true;
 
@@ -596,6 +1077,8 @@ namespace MLVScan.Models.Rules.Helpers
                 if (blockStarts[i])
                 {
                     stack.Clear();
+                    if (catchHandlerStarts[i])
+                        stack.Add(-1); // Catch and filter entries receive the implicit exception object.
                     validBlock = true;
                 }
 
@@ -604,10 +1087,16 @@ namespace MLVScan.Models.Rules.Helpers
 
                 var instruction = instructions[i];
                 if ((TryGetStoredLocalIndex(instruction, out _) ||
-                     TryGetStoredArgumentIndex(instruction, out _)) && stack.Count > 0)
+                     TryGetStoredArgumentIndex(instruction, out _) ||
+                     instruction.OpCode.Code is Code.Stfld or Code.Stsfld) && stack.Count > 0)
                 {
                     producersByStoreIndex[i] = stack[^1];
                 }
+
+                if (instruction.OpCode.Code == Code.Ldfld && stack.Count >= 1)
+                    fieldReceiversByInstructionIndex[i] = stack[^1];
+                else if (instruction.OpCode.Code == Code.Stfld && stack.Count >= 2)
+                    fieldReceiversByInstructionIndex[i] = stack[^2];
 
                 if ((instruction.OpCode == OpCodes.Call || instruction.OpCode == OpCodes.Callvirt ||
                      instruction.OpCode == OpCodes.Newobj) &&
@@ -663,7 +1152,8 @@ namespace MLVScan.Models.Rules.Helpers
                     stack.Add(i);
             }
 
-            return new CallArgumentProducerMap(producersByCallIndex, producersByStoreIndex);
+            return new CallArgumentProducerMap(producersByCallIndex, producersByStoreIndex,
+                fieldReceiversByInstructionIndex);
         }
 
         private static bool IsArrayElementStore(Instruction instruction)
@@ -675,15 +1165,22 @@ namespace MLVScan.Models.Rules.Helpers
 
         private sealed class CallArgumentProducerMap
         {
+            public static CallArgumentProducerMap Empty { get; } =
+                new(new Dictionary<int, CallProducers>(), new Dictionary<int, int>(),
+                    new Dictionary<int, int>());
+
             private readonly Dictionary<int, CallProducers> _producersByCallIndex;
             private readonly Dictionary<int, int> _producersByStoreIndex;
+            private readonly Dictionary<int, int> _fieldReceiversByInstructionIndex;
 
             public CallArgumentProducerMap(
                 Dictionary<int, CallProducers> producersByCallIndex,
-                Dictionary<int, int> producersByStoreIndex)
+                Dictionary<int, int> producersByStoreIndex,
+                Dictionary<int, int> fieldReceiversByInstructionIndex)
             {
                 _producersByCallIndex = producersByCallIndex;
                 _producersByStoreIndex = producersByStoreIndex;
+                _fieldReceiversByInstructionIndex = fieldReceiversByInstructionIndex;
             }
 
             public bool TryGetProducer(int callIndex, int parameterCount, int argumentIndex, out int producerIndex)
@@ -710,6 +1207,43 @@ namespace MLVScan.Models.Rules.Helpers
             public bool TryGetStoredValueProducer(int storeIndex, out int producerIndex)
             {
                 return _producersByStoreIndex.TryGetValue(storeIndex, out producerIndex);
+            }
+
+            public bool TryGetFieldReceiverProducer(int instructionIndex, out int producerIndex)
+            {
+                return _fieldReceiversByInstructionIndex.TryGetValue(instructionIndex, out producerIndex);
+            }
+        }
+
+        private sealed class CallArgumentProducerMapCache
+        {
+            public object Gate { get; } = new();
+            public ExceptionHandler[] Handlers { get; private set; } = Array.Empty<ExceptionHandler>();
+            public CallArgumentProducerMap Map { get; private set; } = CallArgumentProducerMap.Empty;
+            private bool IsInitialized { get; set; }
+
+            public bool Matches(IReadOnlyList<ExceptionHandler> handlers)
+            {
+                if (!IsInitialized)
+                    return false;
+
+                if (Handlers.Length != handlers.Count)
+                    return false;
+
+                for (int i = 0; i < Handlers.Length; i++)
+                {
+                    if (!ReferenceEquals(Handlers[i], handlers[i]))
+                        return false;
+                }
+
+                return true;
+            }
+
+            public void Update(IReadOnlyList<ExceptionHandler> handlers, CallArgumentProducerMap map)
+            {
+                Handlers = handlers.ToArray();
+                Map = map;
+                IsInitialized = true;
             }
         }
 

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -637,7 +637,11 @@ namespace MLVScan.Models.Rules.Helpers
 
         private static bool IsPotentialFieldMutation(Instruction instruction)
         {
-            return instruction.OpCode.Code is Code.Call or Code.Callvirt or Code.Calli or Code.Newobj;
+            return instruction.OpCode.Code is
+                Code.Call or Code.Callvirt or Code.Calli or Code.Newobj or
+                Code.Ldflda or Code.Ldsflda or
+                Code.Stind_I or Code.Stind_I1 or Code.Stind_I2 or Code.Stind_I4 or Code.Stind_I8 or
+                Code.Stind_R4 or Code.Stind_R8 or Code.Stind_Ref;
         }
 
         private static bool TryGetLoadedLocalIndex(Instruction instruction, out int localIndex)

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -243,6 +243,23 @@ namespace MLVScan.Models.Rules.Helpers
             var pending = new Queue<(int Index, bool Executed)>();
             var visited = new HashSet<(int Index, bool Executed)>();
             pending.Enqueue((0, false));
+            foreach (var handler in exceptionHandlers)
+            {
+                int handlerEndIndex = instructions.Count;
+                if (handler.HandlerType == ExceptionHandlerType.Catch ||
+                    !instructionIndexes.TryGetValue(handler.HandlerStart, out int handlerStartIndex) ||
+                    (handler.HandlerEnd != null &&
+                     !instructionIndexes.TryGetValue(handler.HandlerEnd, out handlerEndIndex)))
+                {
+                    continue;
+                }
+
+                if (instructionIndex >= handlerStartIndex && instructionIndex < handlerEndIndex &&
+                    useIndex >= handlerStartIndex && useIndex < handlerEndIndex)
+                {
+                    pending.Enqueue((handlerStartIndex, false));
+                }
+            }
             bool reachedUse = false;
 
             while (pending.Count > 0)
@@ -552,7 +569,7 @@ namespace MLVScan.Models.Rules.Helpers
             if (TryGetLoadedArgumentIndex(producer, out int argumentIndex))
             {
                 bool hasArgumentStore = false;
-                for (int i = 0; i < producerIndex; i++)
+                for (int i = 0; i < instructions.Count; i++)
                 {
                     if (TryGetStoredArgumentIndex(instructions[i], out int storedArgumentIndex) &&
                         storedArgumentIndex == argumentIndex)

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -228,6 +228,7 @@ namespace MLVScan.Models.Rules.Helpers
                 Code.Ldarg or Code.Ldarg_S when producer.Operand is ParameterDefinition parameter =>
                     $"argument:{parameter.Index + (parameter.Method?.HasThis == true ? 1 : 0)}",
                 Code.Newobj => $"new:{producerIndex}",
+                Code.Call or Code.Callvirt => $"call:{producerIndex}",
                 _ => string.Empty
             };
 

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -535,6 +535,18 @@ namespace MLVScan.Models.Rules.Helpers
                 out producerIndex);
         }
 
+        public static bool TryResolveStoredValueIdentity(
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            int storeIndex,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers,
+            out string identity)
+        {
+            identity = string.Empty;
+            var producerMap = GetCallArgumentProducerMap(instructions, exceptionHandlers);
+            return producerMap.TryGetStoredValueProducer(storeIndex, out int producerIndex) &&
+                   TryBuildProducerIdentity(instructions, producerIndex, exceptionHandlers, out identity);
+        }
+
         private static bool TryBuildProducerIdentity(
             Mono.Collections.Generic.Collection<Instruction> instructions,
             int producerIndex,
@@ -608,7 +620,7 @@ namespace MLVScan.Models.Rules.Helpers
                 return TryResolveEquivalentReachingDefinitions(instructions, exceptionHandlers, producerIndex,
                     instruction => IsMatchingFieldStore(instruction, loadedField,
                         producer.OpCode.Code == Code.Ldsfld), depth, out identity,
-                    receiverIdentity, IsPotentialFieldMutation);
+                    receiverIdentity, instruction => IsPotentialFieldMutation(instruction, loadedField.FieldType));
             }
 
             identity = producer.OpCode.Code switch
@@ -635,8 +647,19 @@ namespace MLVScan.Models.Rules.Helpers
                    instruction.OpCode.Code == (isStatic ? Code.Stsfld : Code.Stfld);
         }
 
-        private static bool IsPotentialFieldMutation(Instruction instruction)
+        private static bool IsPotentialFieldMutation(Instruction instruction, TypeReference fieldType)
         {
+            if (fieldType.FullName == "System.Diagnostics.ProcessStartInfo" &&
+                instruction.Operand is MethodReference method &&
+                ((method.DeclaringType?.FullName, method.Name) is
+                    ("System.Diagnostics.Process", "GetCurrentProcess") or
+                    ("System.Diagnostics.Process", "get_MainModule") or
+                    ("System.Diagnostics.ProcessModule", "get_FileName") ||
+                 method.DeclaringType?.FullName == "System.Diagnostics.ProcessStartInfo"))
+            {
+                return false;
+            }
+
             return instruction.OpCode.Code is
                 Code.Call or Code.Callvirt or Code.Calli or Code.Newobj or
                 Code.Ldflda or Code.Ldsflda or
@@ -1163,7 +1186,8 @@ namespace MLVScan.Models.Rules.Helpers
                 var instruction = instructions[i];
                 if ((TryGetStoredLocalIndex(instruction, out _) ||
                      TryGetStoredArgumentIndex(instruction, out _) ||
-                     instruction.OpCode.Code is Code.Stfld or Code.Stsfld) && stack.Count > 0)
+                     instruction.OpCode.Code is Code.Stfld or Code.Stsfld ||
+                     IsArrayElementStore(instruction)) && stack.Count > 0)
                 {
                     int producer = stack[^1];
                     producersByStoreIndex[i] = producersByStoreIndex.TryGetValue(i, out int existingProducer)

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -620,7 +620,6 @@ namespace MLVScan.Models.Rules.Helpers
                         storedArgumentIndex == argumentIndex)
                     {
                         hasArgumentStore = true;
-                        break;
                     }
                 }
 
@@ -628,7 +627,9 @@ namespace MLVScan.Models.Rules.Helpers
                     return TryResolveEquivalentReachingDefinitions(instructions, exceptionHandlers, producerIndex,
                         instruction => TryGetStoredArgumentIndex(instruction, out int storedIndex) &&
                                        storedIndex == argumentIndex,
-                        depth, out identity);
+                        depth, out identity, invalidatesDefinition: instruction =>
+                            TryGetLoadedArgumentAddressIndex(instruction, out int escapedIndex) &&
+                            escapedIndex == argumentIndex);
             }
 
             if (producer.Operand is FieldReference loadedField &&

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -875,6 +875,18 @@ namespace MLVScan.Models.Rules.Helpers
             if (left.Equals(right, StringComparison.Ordinal))
                 return true;
 
+            if (TryGetLiteralIdentityIndex(left, out int leftLiteralIndex) &&
+                TryGetLiteralIdentityIndex(right, out int rightLiteralIndex) &&
+                leftLiteralIndex >= 0 && leftLiteralIndex < instructions.Count &&
+                rightLiteralIndex >= 0 && rightLiteralIndex < instructions.Count &&
+                instructions[leftLiteralIndex].OpCode.Code == Code.Ldstr &&
+                instructions[rightLiteralIndex].OpCode.Code == Code.Ldstr &&
+                instructions[leftLiteralIndex].Operand is string leftLiteral &&
+                instructions[rightLiteralIndex].Operand is string rightLiteral)
+            {
+                return leftLiteral.Equals(rightLiteral, StringComparison.Ordinal);
+            }
+
             return TryGetCallIdentityIndex(left, out int leftIndex) &&
                    TryGetCallIdentityIndex(right, out int rightIndex) &&
                    IsCurrentProcessFileNameCall(instructions, exceptionHandlers, leftIndex) &&
@@ -884,6 +896,14 @@ namespace MLVScan.Models.Rules.Helpers
         private static bool TryGetCallIdentityIndex(string identity, out int index)
         {
             const string prefix = "call:";
+            index = -1;
+            return identity.StartsWith(prefix, StringComparison.Ordinal) &&
+                   int.TryParse(identity.AsSpan(prefix.Length), out index);
+        }
+
+        private static bool TryGetLiteralIdentityIndex(string identity, out int index)
+        {
+            const string prefix = "literal:";
             index = -1;
             return identity.StartsWith(prefix, StringComparison.Ordinal) &&
                    int.TryParse(identity.AsSpan(prefix.Length), out index);

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -1058,83 +1058,105 @@ namespace MLVScan.Models.Rules.Helpers
             for (int i = 0; i < instructions.Count; i++)
                 instructionIndices[instructions[i]] = i;
 
-            var blockStarts = new bool[instructions.Count];
-            var catchHandlerStarts = new bool[instructions.Count];
-            if (blockStarts.Length > 0)
-                blockStarts[0] = true;
+            var producersByCallIndex = new Dictionary<int, CallProducers>();
+            var producersByStoreIndex = new Dictionary<int, int>();
+            var fieldReceiversByInstructionIndex = new Dictionary<int, int>();
+            var incomingStacks = new Dictionary<int, int[]>();
+            var pending = new Queue<int>();
+
+            void EnqueueState(int index, IReadOnlyList<int> state)
+            {
+                if (index < 0 || index >= instructions.Count)
+                    return;
+
+                var candidate = state.ToArray();
+                if (!incomingStacks.TryGetValue(index, out var existing))
+                {
+                    incomingStacks[index] = candidate;
+                    pending.Enqueue(index);
+                    return;
+                }
+
+                int[] merged;
+                if (existing.Length != candidate.Length)
+                {
+                    merged = Array.Empty<int>();
+                }
+                else
+                {
+                    merged = new int[existing.Length];
+                    for (int slot = 0; slot < existing.Length; slot++)
+                    {
+                        merged[slot] = MergeStackProducerIndexes(instructions, producersByCallIndex,
+                            existing[slot], candidate[slot]);
+                    }
+                }
+
+                if (!existing.SequenceEqual(merged))
+                {
+                    incomingStacks[index] = merged;
+                    pending.Enqueue(index);
+                }
+            }
+
+            if (instructions.Count > 0)
+                EnqueueState(0, Array.Empty<int>());
 
             foreach (var handler in exceptionHandlers)
             {
                 if (!instructionIndices.TryGetValue(handler.HandlerStart, out int handlerStartIndex))
                     return CallArgumentProducerMap.Empty;
 
-                blockStarts[handlerStartIndex] = true;
-                if (handler.HandlerType is ExceptionHandlerType.Catch or ExceptionHandlerType.Filter)
-                    catchHandlerStarts[handlerStartIndex] = true;
+                EnqueueState(handlerStartIndex,
+                    handler.HandlerType is ExceptionHandlerType.Catch or ExceptionHandlerType.Filter
+                        ? new[] { -1 }
+                        : Array.Empty<int>());
 
                 if (handler.FilterStart != null)
                 {
                     if (!instructionIndices.TryGetValue(handler.FilterStart, out int filterStartIndex))
                         return CallArgumentProducerMap.Empty;
 
-                    blockStarts[filterStartIndex] = true;
-                    catchHandlerStarts[filterStartIndex] = true;
+                    EnqueueState(filterStartIndex, new[] { -1 });
                 }
             }
 
-            for (int i = 0; i < instructions.Count; i++)
+            const int maxWorkUnits = 65_536;
+            int workUnits = 0;
+            while (pending.Count > 0)
             {
-                var flowControl = instructions[i].OpCode.FlowControl;
-                if ((flowControl is FlowControl.Branch or FlowControl.Cond_Branch or
-                     FlowControl.Return or FlowControl.Throw) && i + 1 < instructions.Count)
-                    blockStarts[i + 1] = true;
+                if (++workUnits > maxWorkUnits)
+                    return CallArgumentProducerMap.Empty;
 
-                if (instructions[i].Operand is Instruction target)
-                {
-                    if (instructionIndices.TryGetValue(target, out int targetIndex))
-                        blockStarts[targetIndex] = true;
-                }
-                else if (instructions[i].Operand is Instruction[] targets)
-                {
-                    foreach (var switchTarget in targets)
-                    {
-                        if (instructionIndices.TryGetValue(switchTarget, out int targetIndex))
-                            blockStarts[targetIndex] = true;
-                    }
-                }
-            }
-
-            var producersByCallIndex = new Dictionary<int, CallProducers>();
-            var producersByStoreIndex = new Dictionary<int, int>();
-            var fieldReceiversByInstructionIndex = new Dictionary<int, int>();
-            var stack = new List<int>();
-            bool validBlock = true;
-
-            for (int i = 0; i < instructions.Count; i++)
-            {
-                if (blockStarts[i])
-                {
-                    stack.Clear();
-                    if (catchHandlerStarts[i])
-                        stack.Add(-1); // Catch and filter entries receive the implicit exception object.
-                    validBlock = true;
-                }
-
-                if (!validBlock)
-                    continue;
-
+                int i = pending.Dequeue();
+                var stack = new List<int>(incomingStacks[i]);
                 var instruction = instructions[i];
                 if ((TryGetStoredLocalIndex(instruction, out _) ||
                      TryGetStoredArgumentIndex(instruction, out _) ||
                      instruction.OpCode.Code is Code.Stfld or Code.Stsfld) && stack.Count > 0)
                 {
-                    producersByStoreIndex[i] = stack[^1];
+                    int producer = stack[^1];
+                    producersByStoreIndex[i] = producersByStoreIndex.TryGetValue(i, out int existingProducer)
+                        ? MergeStackProducerIndexes(instructions, producersByCallIndex, existingProducer, producer)
+                        : producer;
                 }
 
                 if (instruction.OpCode.Code == Code.Ldfld && stack.Count >= 1)
-                    fieldReceiversByInstructionIndex[i] = stack[^1];
+                {
+                    int receiver = stack[^1];
+                    fieldReceiversByInstructionIndex[i] =
+                        fieldReceiversByInstructionIndex.TryGetValue(i, out int existingReceiver)
+                            ? MergeStackProducerIndexes(instructions, producersByCallIndex, existingReceiver, receiver)
+                            : receiver;
+                }
                 else if (instruction.OpCode.Code == Code.Stfld && stack.Count >= 2)
-                    fieldReceiversByInstructionIndex[i] = stack[^2];
+                {
+                    int receiver = stack[^2];
+                    fieldReceiversByInstructionIndex[i] =
+                        fieldReceiversByInstructionIndex.TryGetValue(i, out int existingReceiver)
+                            ? MergeStackProducerIndexes(instructions, producersByCallIndex, existingReceiver, receiver)
+                            : receiver;
+                }
 
                 if ((instruction.OpCode == OpCodes.Call || instruction.OpCode == OpCodes.Callvirt ||
                      instruction.OpCode == OpCodes.Newobj) &&
@@ -1153,6 +1175,19 @@ namespace MLVScan.Models.Rules.Helpers
                         for (int argumentIndex = 0; argumentIndex < parameterCount; argumentIndex++)
                             argumentProducers[argumentIndex] = stack[firstArgumentIndex + argumentIndex];
 
+                        if (producersByCallIndex.TryGetValue(i, out var existingCallProducers))
+                        {
+                            for (int argumentIndex = 0; argumentIndex < argumentProducers.Length; argumentIndex++)
+                            {
+                                argumentProducers[argumentIndex] = MergeStackProducerIndexes(
+                                    instructions, producersByCallIndex,
+                                    existingCallProducers.Arguments[argumentIndex], argumentProducers[argumentIndex]);
+                            }
+
+                            receiverProducer = MergeStackProducerIndexes(instructions, producersByCallIndex,
+                                existingCallProducers.Receiver, receiverProducer);
+                        }
+
                         producersByCallIndex[i] = new CallProducers(argumentProducers, receiverProducer);
                     }
                 }
@@ -1160,38 +1195,121 @@ namespace MLVScan.Models.Rules.Helpers
                 if (instruction.OpCode == OpCodes.Dup)
                 {
                     if (stack.Count == 0)
-                    {
-                        validBlock = false;
                         continue;
-                    }
 
                     stack.Add(stack[^1]);
-                    continue;
                 }
-
-                if (instruction.OpCode == OpCodes.Calli)
+                else
                 {
-                    validBlock = false;
-                    continue;
+                    if (instruction.OpCode == OpCodes.Calli)
+                        continue;
+
+                    int popCount = IsArrayElementStore(instruction) ? 3 : instruction.GetPopCount();
+                    if (popCount > stack.Count)
+                        continue;
+
+                    if (popCount > 0)
+                        stack.RemoveRange(stack.Count - popCount, popCount);
+
+                    int pushCount = instruction.GetPushCount();
+                    for (int push = 0; push < pushCount; push++)
+                        stack.Add(i);
                 }
 
-                int popCount = IsArrayElementStore(instruction) ? 3 : instruction.GetPopCount();
-                if (popCount > stack.Count)
+                IReadOnlyList<int> successorStack =
+                    instruction.OpCode.Code is Code.Leave or Code.Leave_S
+                        ? Array.Empty<int>()
+                        : stack;
+
+                if (instruction.Operand is Instruction target)
                 {
-                    validBlock = false;
-                    continue;
+                    if (!instructionIndices.TryGetValue(target, out int targetIndex))
+                        return CallArgumentProducerMap.Empty;
+
+                    EnqueueState(targetIndex, successorStack);
+                }
+                else if (instruction.Operand is Instruction[] targets)
+                {
+                    foreach (var switchTarget in targets)
+                    {
+                        if (!instructionIndices.TryGetValue(switchTarget, out int targetIndex))
+                            return CallArgumentProducerMap.Empty;
+
+                        EnqueueState(targetIndex, successorStack);
+                    }
                 }
 
-                if (popCount > 0)
-                    stack.RemoveRange(stack.Count - popCount, popCount);
-
-                int pushCount = instruction.GetPushCount();
-                for (int push = 0; push < pushCount; push++)
-                    stack.Add(i);
+                var flowControl = instruction.OpCode.FlowControl;
+                if (flowControl is not FlowControl.Branch and not FlowControl.Return and not FlowControl.Throw &&
+                    i + 1 < instructions.Count)
+                {
+                    EnqueueState(i + 1, successorStack);
+                }
             }
 
             return new CallArgumentProducerMap(producersByCallIndex, producersByStoreIndex,
                 fieldReceiversByInstructionIndex);
+        }
+
+        private static int MergeStackProducerIndexes(
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            IReadOnlyDictionary<int, CallProducers> producersByCallIndex,
+            int left,
+            int right)
+        {
+            if (left == right)
+                return left;
+
+            if (left < 0 || right < 0 || left >= instructions.Count || right >= instructions.Count)
+                return -1;
+
+            if (instructions[left].OpCode.Code == Code.Ldstr &&
+                instructions[right].OpCode.Code == Code.Ldstr &&
+                instructions[left].Operand is string leftLiteral &&
+                instructions[right].Operand is string rightLiteral &&
+                leftLiteral.Equals(rightLiteral, StringComparison.Ordinal))
+            {
+                return left;
+            }
+
+            return AreEquivalentCurrentProcessFileNameProducers(
+                instructions, producersByCallIndex, left, right)
+                ? left
+                : -1;
+        }
+
+        private static bool AreEquivalentCurrentProcessFileNameProducers(
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            IReadOnlyDictionary<int, CallProducers> producersByCallIndex,
+            int left,
+            int right)
+        {
+            return IsMethodCall(instructions, left, "System.Diagnostics.ProcessModule", "get_FileName") &&
+                   IsMethodCall(instructions, right, "System.Diagnostics.ProcessModule", "get_FileName") &&
+                   producersByCallIndex.TryGetValue(left, out var leftFileName) &&
+                   producersByCallIndex.TryGetValue(right, out var rightFileName) &&
+                   IsMethodCall(instructions, leftFileName.Receiver,
+                       "System.Diagnostics.Process", "get_MainModule") &&
+                   IsMethodCall(instructions, rightFileName.Receiver,
+                       "System.Diagnostics.Process", "get_MainModule") &&
+                   producersByCallIndex.TryGetValue(leftFileName.Receiver, out var leftMainModule) &&
+                   producersByCallIndex.TryGetValue(rightFileName.Receiver, out var rightMainModule) &&
+                   IsMethodCall(instructions, leftMainModule.Receiver,
+                       "System.Diagnostics.Process", "GetCurrentProcess") &&
+                   IsMethodCall(instructions, rightMainModule.Receiver,
+                       "System.Diagnostics.Process", "GetCurrentProcess");
+        }
+
+        private static bool IsMethodCall(
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            int index,
+            string declaringType,
+            string methodName)
+        {
+            return index >= 0 && index < instructions.Count &&
+                   instructions[index].Operand is MethodReference method &&
+                   method.DeclaringType?.FullName == declaringType &&
+                   method.Name == methodName;
         }
 
         private static bool IsArrayElementStore(Instruction instruction)

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -179,6 +179,57 @@ namespace MLVScan.Models.Rules.Helpers
                    TryBuildProducerIdentity(instructions, producerIndex, out identity);
         }
 
+        public static bool IsGuaranteedToExecuteBefore(
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            int instructionIndex,
+            int useIndex)
+        {
+            if (instructions == null || instructionIndex < 0 || useIndex < 0 ||
+                instructionIndex >= instructions.Count || useIndex >= instructions.Count)
+            {
+                return false;
+            }
+
+            var pending = new Queue<(int Index, bool Executed)>();
+            var visited = new HashSet<(int Index, bool Executed)>();
+            pending.Enqueue((0, false));
+            bool reachedUse = false;
+
+            while (pending.Count > 0)
+            {
+                var current = pending.Dequeue();
+                if (current.Index < 0 || current.Index >= instructions.Count || !visited.Add(current))
+                    continue;
+
+                if (current.Index == useIndex)
+                {
+                    reachedUse = true;
+                    if (!current.Executed)
+                        return false;
+
+                    continue;
+                }
+
+                bool executed = current.Executed || current.Index == instructionIndex;
+                var instruction = instructions[current.Index];
+                if (instruction.Operand is Instruction target)
+                {
+                    pending.Enqueue((instructions.IndexOf(target), executed));
+                }
+                else if (instruction.Operand is Instruction[] targets)
+                {
+                    foreach (var switchTarget in targets)
+                        pending.Enqueue((instructions.IndexOf(switchTarget), executed));
+                }
+
+                var flowControl = instruction.OpCode.FlowControl;
+                if (flowControl is not FlowControl.Branch and not FlowControl.Return and not FlowControl.Throw)
+                    pending.Enqueue((current.Index + 1, executed));
+            }
+
+            return reachedUse;
+        }
+
         public static bool TryResolveCallArgumentProducerIndex(
             MethodReference calledMethod,
             Mono.Collections.Generic.Collection<Instruction> instructions,

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -799,8 +799,11 @@ namespace MLVScan.Models.Rules.Helpers
 
                 if (exceptionTargets.TryGetValue(current.Index, out var handlerTargets))
                 {
+                    int exceptionalDefinition = invalidatesDefinition?.Invoke(instruction) == true
+                        ? -2
+                        : current.DefinitionIndex;
                     foreach (var handlerTarget in handlerTargets)
-                        pending.Enqueue((handlerTarget, current.DefinitionIndex));
+                        pending.Enqueue((handlerTarget, exceptionalDefinition));
                 }
 
                 if (instruction.Operand is Instruction target)

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -561,7 +561,9 @@ namespace MLVScan.Models.Rules.Helpers
                 return TryResolveEquivalentReachingDefinitions(instructions, exceptionHandlers, producerIndex,
                     instruction => TryGetStoredLocalIndex(instruction, out int storedIndex) &&
                                    storedIndex == localIndex,
-                    depth, out identity);
+                    depth, out identity, invalidatesDefinition: instruction =>
+                        TryGetLoadedLocalAddressIndex(instruction, out int escapedLocalIndex) &&
+                        escapedLocalIndex == localIndex);
             }
 
             if (TryGetLoadedArgumentIndex(producer, out int argumentIndex))
@@ -569,6 +571,12 @@ namespace MLVScan.Models.Rules.Helpers
                 bool hasArgumentStore = false;
                 for (int i = 0; i < instructions.Count; i++)
                 {
+                    if (TryGetLoadedArgumentAddressIndex(instructions[i], out int escapedArgumentIndex) &&
+                        escapedArgumentIndex == argumentIndex)
+                    {
+                        return false;
+                    }
+
                     if (TryGetStoredArgumentIndex(instructions[i], out int storedArgumentIndex) &&
                         storedArgumentIndex == argumentIndex)
                     {
@@ -645,6 +653,24 @@ namespace MLVScan.Models.Rules.Helpers
             };
 
             return localIndex >= 0;
+        }
+
+        private static bool TryGetLoadedLocalAddressIndex(Instruction instruction, out int localIndex)
+        {
+            localIndex = (instruction.OpCode.Code is Code.Ldloca or Code.Ldloca_S) &&
+                         instruction.Operand is VariableDefinition variable
+                ? variable.Index
+                : -1;
+            return localIndex >= 0;
+        }
+
+        private static bool TryGetLoadedArgumentAddressIndex(Instruction instruction, out int argumentIndex)
+        {
+            argumentIndex = (instruction.OpCode.Code is Code.Ldarga or Code.Ldarga_S) &&
+                            instruction.Operand is ParameterDefinition parameter
+                ? parameter.Index + (parameter.Method?.HasThis == true ? 1 : 0)
+                : -1;
+            return argumentIndex >= 0;
         }
 
         private static bool HasUnambiguousReachingDefinition(

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -224,7 +224,7 @@ namespace MLVScan.Models.Rules.Helpers
                         continue;
                     }
 
-                    if (!HasUnambiguousLinearReach(instructions, i, producerIndex))
+                    if (!HasUnambiguousReachingDefinition(instructions, i, producerIndex, localIndex))
                         return false;
 
                     var producerMap = CallArgumentProducerMaps.GetValue(instructions, BuildCallArgumentProducerMap);
@@ -266,41 +266,64 @@ namespace MLVScan.Models.Rules.Helpers
             return localIndex >= 0;
         }
 
-        private static bool HasUnambiguousLinearReach(
+        private static bool HasUnambiguousReachingDefinition(
             Mono.Collections.Generic.Collection<Instruction> instructions,
             int definitionIndex,
-            int useIndex)
+            int useIndex,
+            int localIndex)
         {
-            for (int i = definitionIndex + 1; i < useIndex; i++)
-            {
-                var flowControl = instructions[i].OpCode.FlowControl;
-                if (flowControl is FlowControl.Branch or FlowControl.Cond_Branch or
-                    FlowControl.Return or FlowControl.Throw)
-                {
-                    return false;
-                }
-            }
+            const byte unresolved = 0;
+            const byte expectedDefinition = 1;
+            const byte overwritten = 2;
 
-            for (int i = 0; i < instructions.Count; i++)
+            var pending = new Queue<(int Index, byte State)>();
+            var visited = new HashSet<(int Index, byte State)>();
+            pending.Enqueue((0, unresolved));
+            bool reachedUse = false;
+
+            while (pending.Count > 0)
             {
-                if (instructions[i].Operand is Instruction target)
+                var current = pending.Dequeue();
+                if (current.Index < 0 || current.Index >= instructions.Count || !visited.Add(current))
+                    continue;
+
+                if (current.Index == useIndex)
                 {
-                    int targetIndex = instructions.IndexOf(target);
-                    if (targetIndex > definitionIndex && targetIndex <= useIndex)
+                    reachedUse = true;
+                    if (current.State != expectedDefinition)
                         return false;
+
+                    continue;
                 }
-                else if (instructions[i].Operand is Instruction[] targets)
+
+                var instruction = instructions[current.Index];
+                byte nextState = current.State;
+                if (current.Index == definitionIndex)
+                {
+                    nextState = expectedDefinition;
+                }
+                else if (TryGetStoredLocalIndex(instruction, out int storedLocalIndex) &&
+                         storedLocalIndex == localIndex)
+                {
+                    nextState = overwritten;
+                }
+
+                if (instruction.Operand is Instruction target)
+                {
+                    pending.Enqueue((instructions.IndexOf(target), nextState));
+                }
+                else if (instruction.Operand is Instruction[] targets)
                 {
                     foreach (var switchTarget in targets)
-                    {
-                        int targetIndex = instructions.IndexOf(switchTarget);
-                        if (targetIndex > definitionIndex && targetIndex <= useIndex)
-                            return false;
-                    }
+                        pending.Enqueue((instructions.IndexOf(switchTarget), nextState));
                 }
+
+                var flowControl = instruction.OpCode.FlowControl;
+                if (flowControl is not FlowControl.Branch and not FlowControl.Return and not FlowControl.Throw)
+                    pending.Enqueue((current.Index + 1, nextState));
             }
 
-            return true;
+            return reachedUse;
         }
 
         private static bool TryGetStoredLocalIndex(Instruction instruction, out int localIndex)

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -153,10 +153,20 @@ namespace MLVScan.Models.Rules.Helpers
             int callIndex,
             out string identity)
         {
+            return TryResolveCallReceiverIdentity(
+                instructions, callIndex, Array.Empty<ExceptionHandler>(), out identity);
+        }
+
+        public static bool TryResolveCallReceiverIdentity(
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            int callIndex,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers,
+            out string identity)
+        {
             identity = string.Empty;
             var producerMap = CallArgumentProducerMaps.GetValue(instructions, BuildCallArgumentProducerMap);
             return producerMap.TryGetReceiverProducer(callIndex, out int producerIndex) &&
-                   TryBuildProducerIdentity(instructions, producerIndex, out identity);
+                   TryBuildProducerIdentity(instructions, producerIndex, exceptionHandlers, out identity);
         }
 
         /// <summary>
@@ -169,6 +179,18 @@ namespace MLVScan.Models.Rules.Helpers
             int argumentIndex,
             out string identity)
         {
+            return TryResolveCallArgumentIdentity(calledMethod, instructions, callIndex, argumentIndex,
+                Array.Empty<ExceptionHandler>(), out identity);
+        }
+
+        public static bool TryResolveCallArgumentIdentity(
+            MethodReference calledMethod,
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            int callIndex,
+            int argumentIndex,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers,
+            out string identity)
+        {
             identity = string.Empty;
             if (argumentIndex < 0 || argumentIndex >= calledMethod.Parameters.Count)
                 return false;
@@ -176,7 +198,7 @@ namespace MLVScan.Models.Rules.Helpers
             var producerMap = CallArgumentProducerMaps.GetValue(instructions, BuildCallArgumentProducerMap);
             return producerMap.TryGetProducer(callIndex, calledMethod.Parameters.Count, argumentIndex,
                        out int producerIndex) &&
-                   TryBuildProducerIdentity(instructions, producerIndex, out identity);
+                   TryBuildProducerIdentity(instructions, producerIndex, exceptionHandlers, out identity);
         }
 
         public static bool IsGuaranteedToExecuteBefore(
@@ -191,31 +213,8 @@ namespace MLVScan.Models.Rules.Helpers
                 return false;
             }
 
-            const int maxExceptionalEdges = 4096;
-            var exceptionTargets = new Dictionary<int, List<int>>();
-            int exceptionalEdgeCount = 0;
-            foreach (var handler in exceptionHandlers)
-            {
-                int tryStartIndex = instructions.IndexOf(handler.TryStart);
-                int tryEndIndex = handler.TryEnd == null ? instructions.Count : instructions.IndexOf(handler.TryEnd);
-                int handlerStartIndex = instructions.IndexOf(handler.HandlerStart);
-                if (tryStartIndex < 0 || tryEndIndex < tryStartIndex || handlerStartIndex < 0)
-                    return false;
-
-                for (int i = tryStartIndex; i < tryEndIndex; i++)
-                {
-                    if (++exceptionalEdgeCount > maxExceptionalEdges)
-                        return false;
-
-                    if (!exceptionTargets.TryGetValue(i, out var targets))
-                    {
-                        targets = new List<int>();
-                        exceptionTargets[i] = targets;
-                    }
-
-                    targets.Add(handlerStartIndex);
-                }
-            }
+            if (!TryBuildExceptionalTargets(instructions, exceptionHandlers, out var exceptionTargets))
+                return false;
 
             var pending = new Queue<(int Index, bool Executed)>();
             var visited = new HashSet<(int Index, bool Executed)>();
@@ -267,6 +266,40 @@ namespace MLVScan.Models.Rules.Helpers
             return reachedUse;
         }
 
+        private static bool TryBuildExceptionalTargets(
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers,
+            out Dictionary<int, List<int>> exceptionTargets)
+        {
+            const int maxExceptionalEdges = 4096;
+            exceptionTargets = new Dictionary<int, List<int>>();
+            int exceptionalEdgeCount = 0;
+            foreach (var handler in exceptionHandlers)
+            {
+                int tryStartIndex = instructions.IndexOf(handler.TryStart);
+                int tryEndIndex = handler.TryEnd == null ? instructions.Count : instructions.IndexOf(handler.TryEnd);
+                int handlerStartIndex = instructions.IndexOf(handler.HandlerStart);
+                if (tryStartIndex < 0 || tryEndIndex < tryStartIndex || handlerStartIndex < 0)
+                    return false;
+
+                for (int i = tryStartIndex; i < tryEndIndex; i++)
+                {
+                    if (++exceptionalEdgeCount > maxExceptionalEdges)
+                        return false;
+
+                    if (!exceptionTargets.TryGetValue(i, out var targets))
+                    {
+                        targets = new List<int>();
+                        exceptionTargets[i] = targets;
+                    }
+
+                    targets.Add(handlerStartIndex);
+                }
+            }
+
+            return true;
+        }
+
         public static bool TryResolveCallArgumentProducerIndex(
             MethodReference calledMethod,
             Mono.Collections.Generic.Collection<Instruction> instructions,
@@ -286,14 +319,16 @@ namespace MLVScan.Models.Rules.Helpers
         private static bool TryBuildProducerIdentity(
             Mono.Collections.Generic.Collection<Instruction> instructions,
             int producerIndex,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers,
             out string identity)
         {
-            return TryBuildProducerIdentity(instructions, producerIndex, 0, out identity);
+            return TryBuildProducerIdentity(instructions, producerIndex, exceptionHandlers, 0, out identity);
         }
 
         private static bool TryBuildProducerIdentity(
             Mono.Collections.Generic.Collection<Instruction> instructions,
             int producerIndex,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers,
             int depth,
             out string identity)
         {
@@ -312,15 +347,42 @@ namespace MLVScan.Models.Rules.Helpers
                         continue;
                     }
 
-                    if (!HasUnambiguousReachingDefinition(instructions, i, producerIndex, localIndex))
+                    if (!HasUnambiguousReachingDefinition(instructions, exceptionHandlers, i, producerIndex,
+                            instruction => TryGetStoredLocalIndex(instruction, out int storedIndex) &&
+                                           storedIndex == localIndex))
                         return false;
 
                     var producerMap = CallArgumentProducerMaps.GetValue(instructions, BuildCallArgumentProducerMap);
                     return producerMap.TryGetStoredValueProducer(i, out int storedValueProducer) &&
-                           TryBuildProducerIdentity(instructions, storedValueProducer, depth + 1, out identity);
+                           TryBuildProducerIdentity(instructions, storedValueProducer, exceptionHandlers,
+                               depth + 1, out identity);
                 }
 
                 return false;
+            }
+
+            if (TryGetLoadedArgumentIndex(producer, out int argumentIndex))
+            {
+                for (int i = producerIndex - 1; i >= 0; i--)
+                {
+                    if (!TryGetStoredArgumentIndex(instructions[i], out int storedArgumentIndex) ||
+                        storedArgumentIndex != argumentIndex)
+                    {
+                        continue;
+                    }
+
+                    if (!HasUnambiguousReachingDefinition(instructions, exceptionHandlers, i, producerIndex,
+                            instruction => TryGetStoredArgumentIndex(instruction, out int storedIndex) &&
+                                           storedIndex == argumentIndex))
+                    {
+                        return false;
+                    }
+
+                    var producerMap = CallArgumentProducerMaps.GetValue(instructions, BuildCallArgumentProducerMap);
+                    return producerMap.TryGetStoredValueProducer(i, out int storedValueProducer) &&
+                           TryBuildProducerIdentity(instructions, storedValueProducer, exceptionHandlers,
+                               depth + 1, out identity);
+                }
             }
 
             identity = producer.OpCode.Code switch
@@ -356,9 +418,10 @@ namespace MLVScan.Models.Rules.Helpers
 
         private static bool HasUnambiguousReachingDefinition(
             Mono.Collections.Generic.Collection<Instruction> instructions,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers,
             int definitionIndex,
             int useIndex,
-            int localIndex)
+            Func<Instruction, bool> isCompetingStore)
         {
             const byte unresolved = 0;
             const byte expectedDefinition = 1;
@@ -366,6 +429,9 @@ namespace MLVScan.Models.Rules.Helpers
 
             var pending = new Queue<(int Index, byte State)>();
             var visited = new HashSet<(int Index, byte State)>();
+            if (!TryBuildExceptionalTargets(instructions, exceptionHandlers, out var exceptionTargets))
+                return false;
+
             pending.Enqueue((0, unresolved));
             bool reachedUse = false;
 
@@ -390,10 +456,15 @@ namespace MLVScan.Models.Rules.Helpers
                 {
                     nextState = expectedDefinition;
                 }
-                else if (TryGetStoredLocalIndex(instruction, out int storedLocalIndex) &&
-                         storedLocalIndex == localIndex)
+                else if (isCompetingStore(instruction))
                 {
                     nextState = overwritten;
+                }
+
+                if (exceptionTargets.TryGetValue(current.Index, out var handlerTargets))
+                {
+                    foreach (var handlerTarget in handlerTargets)
+                        pending.Enqueue((handlerTarget, current.State));
                 }
 
                 if (instruction.Operand is Instruction target)
@@ -412,6 +483,34 @@ namespace MLVScan.Models.Rules.Helpers
             }
 
             return reachedUse;
+        }
+
+        private static bool TryGetLoadedArgumentIndex(Instruction instruction, out int argumentIndex)
+        {
+            argumentIndex = instruction.OpCode.Code switch
+            {
+                Code.Ldarg_0 => 0,
+                Code.Ldarg_1 => 1,
+                Code.Ldarg_2 => 2,
+                Code.Ldarg_3 => 3,
+                Code.Ldarg or Code.Ldarg_S when instruction.Operand is ParameterDefinition parameter =>
+                    parameter.Index + (parameter.Method?.HasThis == true ? 1 : 0),
+                _ => -1
+            };
+
+            return argumentIndex >= 0;
+        }
+
+        private static bool TryGetStoredArgumentIndex(Instruction instruction, out int argumentIndex)
+        {
+            argumentIndex = instruction.OpCode.Code switch
+            {
+                Code.Starg or Code.Starg_S when instruction.Operand is ParameterDefinition parameter =>
+                    parameter.Index + (parameter.Method?.HasThis == true ? 1 : 0),
+                _ => -1
+            };
+
+            return argumentIndex >= 0;
         }
 
         private static bool TryGetStoredLocalIndex(Instruction instruction, out int localIndex)
@@ -503,7 +602,8 @@ namespace MLVScan.Models.Rules.Helpers
                     continue;
 
                 var instruction = instructions[i];
-                if (TryGetStoredLocalIndex(instruction, out _) && stack.Count > 0)
+                if ((TryGetStoredLocalIndex(instruction, out _) ||
+                     TryGetStoredArgumentIndex(instruction, out _)) && stack.Count > 0)
                 {
                     producersByStoreIndex[i] = stack[^1];
                 }

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -345,8 +345,6 @@ namespace MLVScan.Models.Rules.Helpers
                 {
                     if (current.CandidateSeen)
                         return true;
-
-                    continue;
                 }
 
                 var instruction = instructions[current.Index];

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -179,6 +179,22 @@ namespace MLVScan.Models.Rules.Helpers
                    TryBuildProducerIdentity(instructions, producerIndex, out identity);
         }
 
+        public static bool TryResolveCallArgumentProducerIndex(
+            MethodReference calledMethod,
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            int callIndex,
+            int argumentIndex,
+            out int producerIndex)
+        {
+            producerIndex = -1;
+            if (argumentIndex < 0 || argumentIndex >= calledMethod.Parameters.Count)
+                return false;
+
+            var producerMap = CallArgumentProducerMaps.GetValue(instructions, BuildCallArgumentProducerMap);
+            return producerMap.TryGetProducer(callIndex, calledMethod.Parameters.Count, argumentIndex,
+                out producerIndex);
+        }
+
         private static bool TryBuildProducerIdentity(
             Mono.Collections.Generic.Collection<Instruction> instructions,
             int producerIndex,
@@ -381,12 +397,13 @@ namespace MLVScan.Models.Rules.Helpers
                     producersByStoreIndex[i] = stack[^1];
                 }
 
-                if ((instruction.OpCode == OpCodes.Call || instruction.OpCode == OpCodes.Callvirt) &&
+                if ((instruction.OpCode == OpCodes.Call || instruction.OpCode == OpCodes.Callvirt ||
+                     instruction.OpCode == OpCodes.Newobj) &&
                     instruction.Operand is MethodReference calledMethod &&
                     calledMethod.Parameters.Count <= MaxTrackedCallArguments)
                 {
                     int parameterCount = calledMethod.Parameters.Count;
-                    int receiverCount = calledMethod.HasThis ? 1 : 0;
+                    int receiverCount = instruction.OpCode == OpCodes.Newobj ? 0 : calledMethod.HasThis ? 1 : 0;
                     int consumedCount = parameterCount + receiverCount;
                     if (stack.Count >= consumedCount)
                     {

--- a/Models/Rules/Helpers/InstructionValueResolver.cs
+++ b/Models/Rules/Helpers/InstructionValueResolver.cs
@@ -393,6 +393,7 @@ namespace MLVScan.Models.Rules.Helpers
                 Code.Ldarg_3 => "argument:3",
                 Code.Ldarg or Code.Ldarg_S when producer.Operand is ParameterDefinition parameter =>
                     $"argument:{parameter.Index + (parameter.Method?.HasThis == true ? 1 : 0)}",
+                Code.Ldstr => $"literal:{producerIndex}",
                 Code.Newobj => $"new:{producerIndex}",
                 Code.Call or Code.Callvirt => $"call:{producerIndex}",
                 _ => string.Empty

--- a/Models/Rules/ProcessStartRule.cs
+++ b/Models/Rules/ProcessStartRule.cs
@@ -1089,7 +1089,7 @@ namespace MLVScan.Models.Rules
                 processStartMethod.Parameters[0].ParameterType.FullName != "System.Diagnostics.ProcessStartInfo")
             {
                 return InstructionValueResolver.TryResolveCallArgumentIdentity(processStartMethod, instructions,
-                    processStartIndex, 0, out targetIdentity);
+                    processStartIndex, 0, exceptionHandlers, out targetIdentity);
             }
 
             string startInfoIdentity;
@@ -1097,7 +1097,7 @@ namespace MLVScan.Models.Rules
             if (processStartMethod.Parameters.Count > 0)
             {
                 if (!InstructionValueResolver.TryResolveCallArgumentIdentity(processStartMethod, instructions,
-                        processStartIndex, 0, out startInfoIdentity))
+                        processStartIndex, 0, exceptionHandlers, out startInfoIdentity))
                 {
                     return false;
                 }
@@ -1106,7 +1106,7 @@ namespace MLVScan.Models.Rules
             {
                 if (!processStartMethod.HasThis ||
                     !InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, processStartIndex,
-                        out launchedProcessIdentity))
+                        exceptionHandlers, out launchedProcessIdentity))
                 {
                     return false;
                 }
@@ -1118,14 +1118,19 @@ namespace MLVScan.Models.Rules
                         setter.DeclaringType?.FullName != "System.Diagnostics.Process" ||
                         setter.Name != "set_StartInfo" ||
                         !InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, i,
-                            out var receiverIdentity) ||
+                            exceptionHandlers, out var receiverIdentity) ||
                         !receiverIdentity.Equals(launchedProcessIdentity, StringComparison.Ordinal) ||
                         !InstructionValueResolver.TryResolveCallArgumentIdentity(setter, instructions, i, 0,
-                            out startInfoIdentity))
+                            exceptionHandlers, out var candidateStartInfoIdentity) ||
+                        !InstructionValueResolver.IsGuaranteedToExecuteBefore(
+                            instructions, exceptionHandlers, i, processStartIndex) ||
+                        HasLaterStartInfoWrite(
+                            launchedProcessIdentity, instructions, exceptionHandlers, i, processStartIndex))
                     {
                         continue;
                     }
 
+                    startInfoIdentity = candidateStartInfoIdentity;
                     break;
                 }
 
@@ -1137,17 +1142,19 @@ namespace MLVScan.Models.Rules
                     setter.DeclaringType?.FullName != "System.Diagnostics.ProcessStartInfo" ||
                     setter.Name != "set_FileName" ||
                     !InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, i,
-                        out var receiverIdentity) ||
+                        exceptionHandlers, out var receiverIdentity) ||
                     !IsMatchingStartInfoReceiver(receiverIdentity, startInfoIdentity, launchedProcessIdentity,
-                        instructions, i, processStartIndex) ||
+                        instructions, exceptionHandlers, i, processStartIndex) ||
                     !InstructionValueResolver.IsGuaranteedToExecuteBefore(
-                        instructions, exceptionHandlers, i, processStartIndex))
+                        instructions, exceptionHandlers, i, processStartIndex) ||
+                    HasLaterFileNameWrite(startInfoIdentity, launchedProcessIdentity, instructions,
+                        exceptionHandlers, i, processStartIndex))
                 {
                     continue;
                 }
 
                 return InstructionValueResolver.TryResolveCallArgumentIdentity(setter, instructions, i, 0,
-                    out targetIdentity);
+                    exceptionHandlers, out targetIdentity);
             }
 
             if (TryGetProducerIndex(startInfoIdentity, "new:", out int constructorIndex) &&
@@ -1158,7 +1165,59 @@ namespace MLVScan.Models.Rules
                 constructor.Parameters[0].ParameterType.FullName == "System.String")
             {
                 return InstructionValueResolver.TryResolveCallArgumentIdentity(constructor, instructions,
-                    constructorIndex, 0, out targetIdentity);
+                    constructorIndex, 0, exceptionHandlers, out targetIdentity);
+            }
+
+            return false;
+        }
+
+        private static bool HasLaterStartInfoWrite(
+            string launchedProcessIdentity,
+            Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers,
+            int assignmentIndex,
+            int processStartIndex)
+        {
+            for (int i = assignmentIndex + 1; i < processStartIndex; i++)
+            {
+                if (instructions[i].Operand is MethodReference setter &&
+                    setter.DeclaringType?.FullName == "System.Diagnostics.Process" &&
+                    setter.Name == "set_StartInfo" &&
+                    InstructionValueResolver.TryResolveCallReceiverIdentity(
+                        instructions, i, exceptionHandlers, out var receiverIdentity) &&
+                    receiverIdentity.Equals(launchedProcessIdentity, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool HasLaterFileNameWrite(
+            string assignedStartInfoIdentity,
+            string launchedProcessIdentity,
+            Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers,
+            int assignmentIndex,
+            int processStartIndex)
+        {
+            for (int i = assignmentIndex + 1; i < processStartIndex; i++)
+            {
+                if (instructions[i].Operand is not MethodReference setter ||
+                    setter.DeclaringType?.FullName != "System.Diagnostics.ProcessStartInfo" ||
+                    setter.Name != "set_FileName" ||
+                    !InstructionValueResolver.TryResolveCallReceiverIdentity(
+                        instructions, i, exceptionHandlers, out var receiverIdentity))
+                {
+                    continue;
+                }
+
+                if (IsMatchingStartInfoReceiver(receiverIdentity, assignedStartInfoIdentity,
+                        launchedProcessIdentity, instructions, exceptionHandlers, i, processStartIndex))
+                {
+                    return true;
+                }
             }
 
             return false;
@@ -1169,6 +1228,7 @@ namespace MLVScan.Models.Rules
             string assignedStartInfoIdentity,
             string launchedProcessIdentity,
             Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers,
             int fileNameSetterIndex,
             int processStartIndex)
         {
@@ -1185,7 +1245,7 @@ namespace MLVScan.Models.Rules
                 getter.DeclaringType?.FullName != "System.Diagnostics.Process" ||
                 getter.Name != "get_StartInfo" ||
                 !InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, getterIndex,
-                    out var getterReceiverIdentity) ||
+                    exceptionHandlers, out var getterReceiverIdentity) ||
                 !getterReceiverIdentity.Equals(launchedProcessIdentity, StringComparison.Ordinal))
             {
                 return false;
@@ -1197,7 +1257,7 @@ namespace MLVScan.Models.Rules
                     setter.DeclaringType?.FullName == "System.Diagnostics.Process" &&
                     setter.Name == "set_StartInfo" &&
                     InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, i,
-                        out var setterReceiverIdentity) &&
+                        exceptionHandlers, out var setterReceiverIdentity) &&
                     setterReceiverIdentity.Equals(launchedProcessIdentity, StringComparison.Ordinal))
                 {
                     return false;

--- a/Models/Rules/ProcessStartRule.cs
+++ b/Models/Rules/ProcessStartRule.cs
@@ -29,6 +29,10 @@ namespace MLVScan.Models.Rules
             Mono.Collections.Generic.Collection<Instruction>, RestartAnalysisComplexity>
             RestartAnalysisComplexities = new();
 
+        private static readonly ConditionalWeakTable<
+            Mono.Collections.Generic.Collection<Instruction>, RestartAnalysisComplexity>
+            ExplorerAnalysisComplexities = new();
+
         private Severity _severity = Severity.Critical;
 
         public string Description => "Detected Process.Start call which could execute arbitrary programs.";
@@ -684,6 +688,7 @@ namespace MLVScan.Models.Rules
             IReadOnlyList<ExceptionHandler> exceptionHandlers)
         {
             if (processStartMethod == null ||
+                !IsExplorerAnalysisWithinBudget(instructions) ||
                 processStartMethod.Parameters.Count is < 1 or > 2 ||
                 !InstructionValueResolver.TryResolveCallArgumentDisplay(null, processStartMethod, instructions,
                     processStartIndex, 0, exceptionHandlers, out var target) ||
@@ -753,6 +758,29 @@ namespace MLVScan.Models.Rules
             }
 
             return false;
+        }
+
+        internal static bool IsExplorerAnalysisWithinBudget(
+            Mono.Collections.Generic.Collection<Instruction> instructions)
+        {
+            var complexity = ExplorerAnalysisComplexities.GetValue(instructions, static body =>
+            {
+                int processStartCount = 0;
+                foreach (var instruction in body)
+                {
+                    if (instruction.Operand is MethodReference method &&
+                        method.DeclaringType?.FullName == "System.Diagnostics.Process" &&
+                        method.Name == "Start")
+                    {
+                        processStartCount++;
+                    }
+                }
+
+                long estimatedWork = (long)Math.Max(1, processStartCount) * Math.Max(1, body.Count);
+                return new RestartAnalysisComplexity(estimatedWork <= MaxRestartReachabilityWork);
+            });
+
+            return complexity.IsWithinBudget;
         }
 
         private static bool IsSafeShellFolderLaunch(

--- a/Models/Rules/ProcessStartRule.cs
+++ b/Models/Rules/ProcessStartRule.cs
@@ -116,7 +116,7 @@ namespace MLVScan.Models.Rules
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex ScriptDropExtensionPattern = new Regex(
-            @"(?i)\.(bat|cmd|ps1|vbs|js|hta)(\b|\s|\""|'|$)",
+            @"(?i)\.(bat|cmd|ps1|psm1|psd1|vbs|vbe|js|jse|wsf|wsh|hta|sct)(\b|\s|\""|'|$)",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex ExecutableShellTargetPattern = new Regex(

--- a/Models/Rules/ProcessStartRule.cs
+++ b/Models/Rules/ProcessStartRule.cs
@@ -124,7 +124,7 @@ namespace MLVScan.Models.Rules
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex ExecutableShellTargetPattern = new Regex(
-            @"(?i)\.(exe|com|msi|msp|mst|scr|cpl|lnk|url|scf|application|appref-ms|gadget|diagcab|chm|jar|reg|inf|settingcontent-ms)(\b|\s|\""|'|$)",
+            @"(?i)\.(exe|com|pif|msi|msp|mst|scr|cpl|lnk|url|scf|application|appref-ms|gadget|diagcab|chm|jar|reg|inf|settingcontent-ms)(\b|\s|\""|'|$)",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex StagedLoaderPivotPattern = new Regex(
@@ -1513,12 +1513,6 @@ namespace MLVScan.Models.Rules
                     continue;
                 }
 
-                if (calledMethod.DeclaringType?.FullName == "System.Diagnostics.Process" &&
-                    calledMethod.Name == "set_StartInfo")
-                {
-                    continue;
-                }
-
                 if (calledMethod.DeclaringType?.FullName == "System.Diagnostics.ProcessStartInfo" &&
                     calledMethod.Name != "set_FileName")
                 {
@@ -1528,6 +1522,20 @@ namespace MLVScan.Models.Rules
                         return true;
                     }
 
+                    continue;
+                }
+
+                if (calledMethod.DeclaringType?.FullName == "System.Diagnostics.Process" &&
+                    calledMethod.Name == "set_StartInfo" &&
+                    launchedProcessIdentity.Length > 0 &&
+                    InstructionValueResolver.TryResolveCallReceiverIdentity(
+                        instructions, i, exceptionHandlers, out var bindingReceiverIdentity) &&
+                    bindingReceiverIdentity.Equals(launchedProcessIdentity, StringComparison.Ordinal) &&
+                    InstructionValueResolver.TryResolveCallArgumentIdentity(
+                        calledMethod, instructions, i, 0, exceptionHandlers, out var boundStartInfoIdentity) &&
+                    IsMatchingStartInfoReceiver(boundStartInfoIdentity, assignedStartInfoIdentity,
+                        launchedProcessIdentity, instructions, exceptionHandlers, i, processStartIndex))
+                {
                     continue;
                 }
 
@@ -1635,6 +1643,12 @@ namespace MLVScan.Models.Rules
                 return true;
             }
 
+            if (AreEquivalentStartInfoGetterIdentities(receiverIdentity, assignedStartInfoIdentity,
+                    instructions, exceptionHandlers))
+            {
+                return true;
+            }
+
             if (launchedProcessIdentity.Length == 0 ||
                 !TryGetCallProducerIndex(receiverIdentity, out int getterIndex) ||
                 getterIndex >= fileNameSetterIndex ||
@@ -1666,6 +1680,29 @@ namespace MLVScan.Models.Rules
             }
 
             return true;
+        }
+
+        private static bool AreEquivalentStartInfoGetterIdentities(
+            string leftIdentity,
+            string rightIdentity,
+            Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers)
+        {
+            return TryGetCallProducerIndex(leftIdentity, out int leftGetterIndex) &&
+                   TryGetCallProducerIndex(rightIdentity, out int rightGetterIndex) &&
+                   leftGetterIndex >= 0 && leftGetterIndex < instructions.Count &&
+                   rightGetterIndex >= 0 && rightGetterIndex < instructions.Count &&
+                   instructions[leftGetterIndex].Operand is MethodReference leftGetter &&
+                   instructions[rightGetterIndex].Operand is MethodReference rightGetter &&
+                   InstructionValueResolver.IsTrustedFrameworkMethod(leftGetter,
+                       "System.Diagnostics.Process", "get_StartInfo", allowDetachedReference: true) &&
+                   InstructionValueResolver.IsTrustedFrameworkMethod(rightGetter,
+                       "System.Diagnostics.Process", "get_StartInfo", allowDetachedReference: true) &&
+                   InstructionValueResolver.TryResolveCallReceiverIdentity(
+                       instructions, leftGetterIndex, exceptionHandlers, out var leftReceiverIdentity) &&
+                   InstructionValueResolver.TryResolveCallReceiverIdentity(
+                       instructions, rightGetterIndex, exceptionHandlers, out var rightReceiverIdentity) &&
+                   leftReceiverIdentity.Equals(rightReceiverIdentity, StringComparison.Ordinal);
         }
 
         private static bool TryGetCallProducerIndex(string identity, out int producerIndex)

--- a/Models/Rules/ProcessStartRule.cs
+++ b/Models/Rules/ProcessStartRule.cs
@@ -1224,6 +1224,9 @@ namespace MLVScan.Models.Rules
             int processStartIndex,
             IReadOnlyList<ExceptionHandler> exceptionHandlers)
         {
+            bool allowDetachedFrameworkReferences = processStartMethod?.DeclaringType?.Scope == null &&
+                                                    processStartMethod?.Module == null;
+
             if (processStartMethod == null ||
                 !IsRestartAnalysisWithinBudget(instructions) ||
                 !TryResolveLaunchedTargetIdentity(processStartMethod, instructions, processStartIndex,
@@ -1238,20 +1241,20 @@ namespace MLVScan.Models.Rules
             {
                 if (!launchedTargetIdentity.Equals($"call:{getFileNameIndex}", StringComparison.Ordinal) ||
                     instructions[getFileNameIndex].Operand is not MethodReference getFileName ||
-                    getFileName.DeclaringType?.FullName != "System.Diagnostics.ProcessModule" ||
-                    getFileName.Name != "get_FileName" ||
+                    !InstructionValueResolver.IsTrustedFrameworkMethod(getFileName,
+                        "System.Diagnostics.ProcessModule", "get_FileName", allowDetachedFrameworkReferences) ||
                     !InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, getFileNameIndex,
                         exceptionHandlers, out var mainModuleIdentity) ||
                     !TryGetCallProducerIndex(mainModuleIdentity, out int getMainModuleIndex) ||
                     instructions[getMainModuleIndex].Operand is not MethodReference getMainModule ||
-                    getMainModule.DeclaringType?.FullName != "System.Diagnostics.Process" ||
-                    getMainModule.Name != "get_MainModule" ||
+                    !InstructionValueResolver.IsTrustedFrameworkMethod(getMainModule,
+                        "System.Diagnostics.Process", "get_MainModule", allowDetachedFrameworkReferences) ||
                     !InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, getMainModuleIndex,
                         exceptionHandlers, out var currentProcessIdentity) ||
                     !TryGetCallProducerIndex(currentProcessIdentity, out int getCurrentProcessIndex) ||
                     instructions[getCurrentProcessIndex].Operand is not MethodReference getCurrentProcess ||
-                    getCurrentProcess.DeclaringType?.FullName != "System.Diagnostics.Process" ||
-                    getCurrentProcess.Name != "GetCurrentProcess")
+                    !InstructionValueResolver.IsTrustedFrameworkMethod(getCurrentProcess,
+                        "System.Diagnostics.Process", "GetCurrentProcess", allowDetachedFrameworkReferences))
                 {
                     continue;
                 }

--- a/Models/Rules/ProcessStartRule.cs
+++ b/Models/Rules/ProcessStartRule.cs
@@ -672,12 +672,14 @@ namespace MLVScan.Models.Rules
                 processStartMethod.Parameters.Count == 0 ||
                 !InstructionValueResolver.TryResolveCallArgumentDisplay(null, processStartMethod, instructions,
                     processStartIndex, 0, out var target) ||
+                !InstructionValueResolver.TryResolveCallArgumentProducerIndex(processStartMethod, instructions,
+                    processStartIndex, 0, out var targetProducerIndex) ||
                 !target.Equals("explorer.exe", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
 
-            return !HasPathManipulation(instructions, Math.Max(0, processStartIndex - 10), processStartIndex);
+            return !HasPathManipulation(instructions, targetProducerIndex, processStartIndex);
         }
 
         private static bool IsSafeShellFolderLaunch(
@@ -1020,81 +1022,52 @@ namespace MLVScan.Models.Rules
                 return false;
             }
 
-            bool foundGetCurrentProcess = false;
-            bool foundGetMainModule = false;
-            bool foundGetFileName = false;
-
-            int getCurrentProcessIndex = -1;
-            int getMainModuleIndex = -1;
-            int getFileNameIndex = -1;
-
             int searchStart = Math.Max(0, processStartIndex - 40);
-
-            for (int i = searchStart; i < processStartIndex; i++)
+            for (int getFileNameIndex = searchStart; getFileNameIndex < processStartIndex; getFileNameIndex++)
             {
-                var instruction = instructions[i];
-
-                if (instruction.OpCode != Mono.Cecil.Cil.OpCodes.Call &&
-                    instruction.OpCode != Mono.Cecil.Cil.OpCodes.Callvirt)
+                if (!launchedTargetIdentity.Equals($"call:{getFileNameIndex}", StringComparison.Ordinal) ||
+                    instructions[getFileNameIndex].Operand is not MethodReference getFileName ||
+                    getFileName.DeclaringType?.FullName != "System.Diagnostics.ProcessModule" ||
+                    getFileName.Name != "get_FileName" ||
+                    !InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, getFileNameIndex,
+                        out var mainModuleIdentity) ||
+                    !TryGetCallProducerIndex(mainModuleIdentity, out int getMainModuleIndex) ||
+                    instructions[getMainModuleIndex].Operand is not MethodReference getMainModule ||
+                    getMainModule.DeclaringType?.FullName != "System.Diagnostics.Process" ||
+                    getMainModule.Name != "get_MainModule" ||
+                    !InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, getMainModuleIndex,
+                        out var currentProcessIdentity) ||
+                    !TryGetCallProducerIndex(currentProcessIdentity, out int getCurrentProcessIndex) ||
+                    instructions[getCurrentProcessIndex].Operand is not MethodReference getCurrentProcess ||
+                    getCurrentProcess.DeclaringType?.FullName != "System.Diagnostics.Process" ||
+                    getCurrentProcess.Name != "GetCurrentProcess")
+                {
                     continue;
-
-                if (instruction.Operand is not MethodReference methodRef)
-                    continue;
-
-                var typeName = methodRef.DeclaringType?.FullName ?? "";
-                var methodName = methodRef.Name ?? "";
-
-                if (typeName == "System.Diagnostics.Process" && methodName == "GetCurrentProcess")
-                {
-                    foundGetCurrentProcess = true;
-                    getCurrentProcessIndex = i;
                 }
-                else if (typeName == "System.Diagnostics.Process" && methodName == "get_MainModule")
-                {
-                    if (foundGetCurrentProcess && i > getCurrentProcessIndex)
-                    {
-                        foundGetMainModule = true;
-                        getMainModuleIndex = i;
-                    }
-                }
-                else if (typeName == "System.Diagnostics.ProcessModule" && methodName == "get_FileName")
-                {
-                    if (foundGetMainModule && i > getMainModuleIndex)
-                    {
-                        foundGetFileName = true;
-                        getFileNameIndex = i;
-                    }
-                }
-            }
 
-            if (foundGetCurrentProcess && foundGetMainModule && foundGetFileName)
-            {
-                if (getFileNameIndex > 0)
+                for (int i = getFileNameIndex + 1; i < processStartIndex; i++)
                 {
-                    for (int i = getFileNameIndex + 1; i < processStartIndex; i++)
-                    {
-                        var inst = instructions[i];
-                        if (inst.OpCode != Mono.Cecil.Cil.OpCodes.Call &&
-                            inst.OpCode != Mono.Cecil.Cil.OpCodes.Callvirt)
-                            continue;
+                    var inst = instructions[i];
+                    if (inst.OpCode != Mono.Cecil.Cil.OpCodes.Call &&
+                        inst.OpCode != Mono.Cecil.Cil.OpCodes.Callvirt)
+                        continue;
 
-                        if (inst.Operand is MethodReference methodRef)
+                    if (inst.Operand is MethodReference methodRef)
+                    {
+                        var typeName = methodRef.DeclaringType?.FullName ?? "";
+                        var methodName = methodRef.Name ?? "";
+
+                        if ((typeName == "System.String" &&
+                             (methodName == "Concat" || methodName == "Format" || methodName == "Replace")) ||
+                            (typeName == "System.IO.Path" &&
+                             (methodName == "Combine" || methodName == "Join")))
                         {
-                            var typeName = methodRef.DeclaringType?.FullName ?? "";
-                            var methodName = methodRef.Name ?? "";
-
-                            if ((typeName == "System.String" &&
-                                 (methodName == "Concat" || methodName == "Format" || methodName == "Replace")) ||
-                                (typeName == "System.IO.Path" &&
-                                 (methodName == "Combine" || methodName == "Join")))
-                            {
-                                return false;
-                            }
+                            return false;
                         }
                     }
                 }
 
-                return launchedTargetIdentity.Equals($"call:{getFileNameIndex}", StringComparison.Ordinal);
+                return true;
             }
 
             return false;
@@ -1171,7 +1144,30 @@ namespace MLVScan.Models.Rules
                     out targetIdentity);
             }
 
+            if (TryGetProducerIndex(startInfoIdentity, "new:", out int constructorIndex) &&
+                instructions[constructorIndex].OpCode == OpCodes.Newobj &&
+                instructions[constructorIndex].Operand is MethodReference constructor &&
+                constructor.DeclaringType?.FullName == "System.Diagnostics.ProcessStartInfo" &&
+                constructor.Parameters.Count > 0 &&
+                constructor.Parameters[0].ParameterType.FullName == "System.String")
+            {
+                return InstructionValueResolver.TryResolveCallArgumentIdentity(constructor, instructions,
+                    constructorIndex, 0, out targetIdentity);
+            }
+
             return false;
+        }
+
+        private static bool TryGetCallProducerIndex(string identity, out int producerIndex)
+        {
+            return TryGetProducerIndex(identity, "call:", out producerIndex);
+        }
+
+        private static bool TryGetProducerIndex(string identity, string prefix, out int producerIndex)
+        {
+            producerIndex = -1;
+            return identity.StartsWith(prefix, StringComparison.Ordinal) &&
+                   int.TryParse(identity.AsSpan(prefix.Length), out producerIndex);
         }
 
         private static string ExtractProcessTarget(

--- a/Models/Rules/ProcessStartRule.cs
+++ b/Models/Rules/ProcessStartRule.cs
@@ -1465,12 +1465,36 @@ namespace MLVScan.Models.Rules
         {
             for (int i = 0; i < instructions.Count; i++)
             {
-                if (i == assignmentIndex ||
-                    instructions[i].Operand is not MethodReference setter ||
-                    setter.DeclaringType?.FullName != "System.Diagnostics.ProcessStartInfo" ||
-                    setter.Name != "set_FileName" ||
+                if (i == assignmentIndex || i == processStartIndex ||
+                    instructions[i].Operand is not MethodReference calledMethod ||
                     !InstructionValueResolver.CanExecuteBetween(
                         instructions, exceptionHandlers, assignmentIndex, i, processStartIndex))
+                {
+                    continue;
+                }
+
+                if (calledMethod.DeclaringType?.FullName == "System.Diagnostics.Process" &&
+                    calledMethod.Name == "set_StartInfo")
+                {
+                    continue;
+                }
+
+                for (int argumentIndex = 0; argumentIndex < calledMethod.Parameters.Count; argumentIndex++)
+                {
+                    if (!IsProcessStartInfoParameter(calledMethod.Parameters[argumentIndex].ParameterType))
+                        continue;
+
+                    if (!InstructionValueResolver.TryResolveCallArgumentIdentity(calledMethod, instructions, i,
+                            argumentIndex, exceptionHandlers, out var argumentIdentity) ||
+                        IsMatchingStartInfoReceiver(argumentIdentity, assignedStartInfoIdentity,
+                            launchedProcessIdentity, instructions, exceptionHandlers, i, processStartIndex))
+                    {
+                        return true;
+                    }
+                }
+
+                if (calledMethod.DeclaringType?.FullName != "System.Diagnostics.ProcessStartInfo" ||
+                    calledMethod.Name != "set_FileName")
                 {
                     continue;
                 }
@@ -1487,6 +1511,13 @@ namespace MLVScan.Models.Rules
             }
 
             return false;
+        }
+
+        private static bool IsProcessStartInfoParameter(TypeReference parameterType)
+        {
+            return parameterType.FullName == "System.Diagnostics.ProcessStartInfo" ||
+                   parameterType is ByReferenceType byReferenceType &&
+                   byReferenceType.ElementType.FullName == "System.Diagnostics.ProcessStartInfo";
         }
 
         private static bool IsMatchingStartInfoReceiver(

--- a/Models/Rules/ProcessStartRule.cs
+++ b/Models/Rules/ProcessStartRule.cs
@@ -645,7 +645,9 @@ namespace MLVScan.Models.Rules
                 return false;
             }
 
-            if (IsSafeBareExplorerLaunch(method, instructions, instructionIndex))
+            var exceptionHandlers = methodSignals?.ExceptionHandlers ?? Array.Empty<ExceptionHandler>();
+
+            if (IsSafeBareExplorerLaunch(method, instructions, instructionIndex, exceptionHandlers))
             {
                 return true;
             }
@@ -656,7 +658,7 @@ namespace MLVScan.Models.Rules
             }
 
             if (IsCurrentProcessRestart(method, instructions, instructionIndex,
-                    methodSignals?.ExceptionHandlers ?? Array.Empty<ExceptionHandler>()))
+                    exceptionHandlers))
             {
                 return true;
             }
@@ -667,7 +669,8 @@ namespace MLVScan.Models.Rules
         private static bool IsSafeBareExplorerLaunch(
             MethodReference processStartMethod,
             Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
-            int processStartIndex)
+            int processStartIndex,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers)
         {
             if (processStartMethod == null ||
                 processStartMethod.Parameters.Count == 0 ||
@@ -675,6 +678,8 @@ namespace MLVScan.Models.Rules
                     processStartIndex, 0, out var target) ||
                 !InstructionValueResolver.TryResolveCallArgumentProducerIndex(processStartMethod, instructions,
                     processStartIndex, 0, out var targetProducerIndex) ||
+                !InstructionValueResolver.TryResolveCallArgumentIdentity(processStartMethod, instructions,
+                    processStartIndex, 0, exceptionHandlers, out _) ||
                 !target.Equals("explorer.exe", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
@@ -1033,13 +1038,13 @@ namespace MLVScan.Models.Rules
                     getFileName.DeclaringType?.FullName != "System.Diagnostics.ProcessModule" ||
                     getFileName.Name != "get_FileName" ||
                     !InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, getFileNameIndex,
-                        out var mainModuleIdentity) ||
+                        exceptionHandlers, out var mainModuleIdentity) ||
                     !TryGetCallProducerIndex(mainModuleIdentity, out int getMainModuleIndex) ||
                     instructions[getMainModuleIndex].Operand is not MethodReference getMainModule ||
                     getMainModule.DeclaringType?.FullName != "System.Diagnostics.Process" ||
                     getMainModule.Name != "get_MainModule" ||
                     !InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, getMainModuleIndex,
-                        out var currentProcessIdentity) ||
+                        exceptionHandlers, out var currentProcessIdentity) ||
                     !TryGetCallProducerIndex(currentProcessIdentity, out int getCurrentProcessIndex) ||
                     instructions[getCurrentProcessIndex].Operand is not MethodReference getCurrentProcess ||
                     getCurrentProcess.DeclaringType?.FullName != "System.Diagnostics.Process" ||
@@ -1162,7 +1167,9 @@ namespace MLVScan.Models.Rules
                 instructions[constructorIndex].Operand is MethodReference constructor &&
                 constructor.DeclaringType?.FullName == "System.Diagnostics.ProcessStartInfo" &&
                 constructor.Parameters.Count > 0 &&
-                constructor.Parameters[0].ParameterType.FullName == "System.String")
+                constructor.Parameters[0].ParameterType.FullName == "System.String" &&
+                !HasLaterFileNameWrite(startInfoIdentity, launchedProcessIdentity, instructions,
+                    exceptionHandlers, constructorIndex, processStartIndex))
             {
                 return InstructionValueResolver.TryResolveCallArgumentIdentity(constructor, instructions,
                     constructorIndex, 0, exceptionHandlers, out targetIdentity);

--- a/Models/Rules/ProcessStartRule.cs
+++ b/Models/Rules/ProcessStartRule.cs
@@ -1089,6 +1089,7 @@ namespace MLVScan.Models.Rules
             }
 
             string startInfoIdentity;
+            string launchedProcessIdentity = string.Empty;
             if (processStartMethod.Parameters.Count > 0)
             {
                 if (!InstructionValueResolver.TryResolveCallArgumentIdentity(processStartMethod, instructions,
@@ -1101,7 +1102,7 @@ namespace MLVScan.Models.Rules
             {
                 if (!processStartMethod.HasThis ||
                     !InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, processStartIndex,
-                        out var launchedProcessIdentity))
+                        out launchedProcessIdentity))
                 {
                     return false;
                 }
@@ -1124,27 +1125,6 @@ namespace MLVScan.Models.Rules
                     break;
                 }
 
-                if (startInfoIdentity.Length == 0)
-                {
-                    for (int i = processStartIndex - 1; i >= Math.Max(0, processStartIndex - 80); i--)
-                    {
-                        if (instructions[i].Operand is not MethodReference getter ||
-                            getter.DeclaringType?.FullName != "System.Diagnostics.Process" ||
-                            getter.Name != "get_StartInfo" ||
-                            !InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, i,
-                                out var receiverIdentity) ||
-                            !receiverIdentity.Equals(launchedProcessIdentity, StringComparison.Ordinal))
-                        {
-                            continue;
-                        }
-
-                        startInfoIdentity = $"call:{i}";
-                        break;
-                    }
-                }
-
-                if (startInfoIdentity.Length == 0)
-                    return false;
             }
 
             for (int i = processStartIndex - 1; i >= Math.Max(0, processStartIndex - 80); i--)
@@ -1154,7 +1134,8 @@ namespace MLVScan.Models.Rules
                     setter.Name != "set_FileName" ||
                     !InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, i,
                         out var receiverIdentity) ||
-                    !receiverIdentity.Equals(startInfoIdentity, StringComparison.Ordinal))
+                    !IsMatchingStartInfoReceiver(receiverIdentity, startInfoIdentity, launchedProcessIdentity,
+                        instructions, i, processStartIndex))
                 {
                     continue;
                 }
@@ -1175,6 +1156,49 @@ namespace MLVScan.Models.Rules
             }
 
             return false;
+        }
+
+        private static bool IsMatchingStartInfoReceiver(
+            string receiverIdentity,
+            string assignedStartInfoIdentity,
+            string launchedProcessIdentity,
+            Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
+            int fileNameSetterIndex,
+            int processStartIndex)
+        {
+            if (assignedStartInfoIdentity.Length > 0 &&
+                receiverIdentity.Equals(assignedStartInfoIdentity, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            if (launchedProcessIdentity.Length == 0 ||
+                !TryGetCallProducerIndex(receiverIdentity, out int getterIndex) ||
+                getterIndex >= fileNameSetterIndex ||
+                instructions[getterIndex].Operand is not MethodReference getter ||
+                getter.DeclaringType?.FullName != "System.Diagnostics.Process" ||
+                getter.Name != "get_StartInfo" ||
+                !InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, getterIndex,
+                    out var getterReceiverIdentity) ||
+                !getterReceiverIdentity.Equals(launchedProcessIdentity, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            for (int i = getterIndex + 1; i < processStartIndex; i++)
+            {
+                if (instructions[i].Operand is MethodReference setter &&
+                    setter.DeclaringType?.FullName == "System.Diagnostics.Process" &&
+                    setter.Name == "set_StartInfo" &&
+                    InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, i,
+                        out var setterReceiverIdentity) &&
+                    setterReceiverIdentity.Equals(launchedProcessIdentity, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private static bool TryGetCallProducerIndex(string identity, out int producerIndex)

--- a/Models/Rules/ProcessStartRule.cs
+++ b/Models/Rules/ProcessStartRule.cs
@@ -1290,29 +1290,24 @@ namespace MLVScan.Models.Rules
             var complexity = RestartAnalysisComplexities.GetValue(instructions, static body =>
             {
                 int processStartCount = 0;
-                int competingWriteCount = 0;
+                int candidateCallCount = 0;
                 foreach (var instruction in body)
                 {
                     if (instruction.Operand is not MethodReference method)
                         continue;
+
+                    candidateCallCount++;
 
                     if (method.DeclaringType?.FullName == "System.Diagnostics.Process" &&
                         method.Name == "Start")
                     {
                         processStartCount++;
                     }
-                    else if ((method.DeclaringType?.FullName == "System.Diagnostics.Process" &&
-                              method.Name == "set_StartInfo") ||
-                             (method.DeclaringType?.FullName == "System.Diagnostics.ProcessStartInfo" &&
-                              method.Name == "set_FileName"))
-                    {
-                        competingWriteCount++;
-                    }
                 }
 
                 long estimatedWork = (long)Math.Max(1, processStartCount) *
-                                     Math.Max(1, competingWriteCount) *
-                                     Math.Max(1, competingWriteCount) *
+                                     Math.Max(1, candidateCallCount) *
+                                     Math.Max(1, candidateCallCount) *
                                      Math.Max(1, body.Count);
                 return new RestartAnalysisComplexity(estimatedWork <= MaxRestartReachabilityWork);
             });
@@ -1466,12 +1461,27 @@ namespace MLVScan.Models.Rules
             for (int i = 0; i < instructions.Count; i++)
             {
                 if (i == assignmentIndex || i == processStartIndex ||
-                    instructions[i].Operand is not MethodReference calledMethod ||
                     !InstructionValueResolver.CanExecuteBetween(
                         instructions, exceptionHandlers, assignmentIndex, i, processStartIndex))
                 {
                     continue;
                 }
+
+                if (instructions[i].OpCode.Code is Code.Stfld or Code.Stsfld or Code.Stelem_Ref)
+                {
+                    if (!InstructionValueResolver.TryResolveStoredValueIdentity(
+                            instructions, i, exceptionHandlers, out var escapedIdentity) ||
+                        IsMatchingStartInfoReceiver(escapedIdentity, assignedStartInfoIdentity,
+                            launchedProcessIdentity, instructions, exceptionHandlers, i, processStartIndex))
+                    {
+                        return true;
+                    }
+
+                    continue;
+                }
+
+                if (instructions[i].Operand is not MethodReference calledMethod)
+                    continue;
 
                 if (calledMethod.DeclaringType?.FullName == "System.Diagnostics.Process" &&
                     calledMethod.Name == "set_StartInfo")

--- a/Models/Rules/ProcessStartRule.cs
+++ b/Models/Rules/ProcessStartRule.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using System.Runtime.CompilerServices;
 using MLVScan.Abstractions;
 using MLVScan.Models;
 using MLVScan.Models.Rules.Helpers;
@@ -22,6 +23,12 @@ namespace MLVScan.Models.Rules
     /// </summary>
     public class ProcessStartRule : IScanRule
     {
+        private const long MaxRestartReachabilityWork = 4_000_000;
+
+        private static readonly ConditionalWeakTable<
+            Mono.Collections.Generic.Collection<Instruction>, RestartAnalysisComplexity>
+            RestartAnalysisComplexities = new();
+
         private Severity _severity = Severity.Critical;
 
         public string Description => "Detected Process.Start call which could execute arbitrary programs.";
@@ -110,6 +117,10 @@ namespace MLVScan.Models.Rules
 
         private static readonly Regex ScriptDropExtensionPattern = new Regex(
             @"(?i)\.(bat|cmd|ps1|vbs|js|hta)(\b|\s|\""|'|$)",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex ExecutableShellTargetPattern = new Regex(
+            @"(?i)\.(exe|com|msi|msp|scr|cpl|lnk|url|scf)(\b|\s|\""|'|$)",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex StagedLoaderPivotPattern = new Regex(
@@ -652,7 +663,7 @@ namespace MLVScan.Models.Rules
                 return true;
             }
 
-            if (IsSafeShellFolderLaunch(method, instructions, instructionIndex))
+            if (IsSafeShellFolderLaunch(method, instructions, instructionIndex, exceptionHandlers))
             {
                 return true;
             }
@@ -673,11 +684,11 @@ namespace MLVScan.Models.Rules
             IReadOnlyList<ExceptionHandler> exceptionHandlers)
         {
             if (processStartMethod == null ||
-                processStartMethod.Parameters.Count == 0 ||
+                processStartMethod.Parameters.Count is < 1 or > 2 ||
                 !InstructionValueResolver.TryResolveCallArgumentDisplay(null, processStartMethod, instructions,
-                    processStartIndex, 0, out var target) ||
+                    processStartIndex, 0, exceptionHandlers, out var target) ||
                 !InstructionValueResolver.TryResolveCallArgumentProducerIndex(processStartMethod, instructions,
-                    processStartIndex, 0, out var targetProducerIndex) ||
+                    processStartIndex, 0, exceptionHandlers, out var targetProducerIndex) ||
                 !InstructionValueResolver.TryResolveCallArgumentIdentity(processStartMethod, instructions,
                     processStartIndex, 0, exceptionHandlers, out _) ||
                 !target.Equals("explorer.exe", StringComparison.OrdinalIgnoreCase))
@@ -685,19 +696,76 @@ namespace MLVScan.Models.Rules
                 return false;
             }
 
-            return !HasPathManipulation(instructions, targetProducerIndex, processStartIndex);
+            if (HasPathManipulation(instructions, targetProducerIndex, processStartIndex))
+                return false;
+
+            if (processStartMethod.Parameters.Count == 1)
+                return true;
+
+            if (!InstructionValueResolver.TryResolveCallArgumentIdentity(processStartMethod, instructions,
+                    processStartIndex, 1, exceptionHandlers, out var launchArgumentIdentity))
+            {
+                return false;
+            }
+
+            bool hasDisplay = InstructionValueResolver.TryResolveCallArgumentDisplay(null, processStartMethod,
+                instructions, processStartIndex, 1, exceptionHandlers, out var launchArgument);
+            if (hasDisplay &&
+                (ScriptDropExtensionPattern.IsMatch(launchArgument) ||
+                 ExecutableShellTargetPattern.IsMatch(launchArgument)))
+            {
+                return false;
+            }
+
+            return (hasDisplay && !IsUnsafeShellTarget(launchArgument)) ||
+                   IsValidatedExplorerFolderArgument(launchArgumentIdentity, instructions,
+                       processStartIndex, exceptionHandlers);
+        }
+
+        private static bool IsValidatedExplorerFolderArgument(
+            string launchArgumentIdentity,
+            Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
+            int processStartIndex,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers)
+        {
+            int searchStart = Math.Max(0, processStartIndex - 80);
+            for (int i = searchStart; i < processStartIndex; i++)
+            {
+                if (instructions[i].Operand is not MethodReference directoryMethod ||
+                    directoryMethod.DeclaringType?.FullName != "System.IO.Directory" ||
+                    directoryMethod.Name is not ("Exists" or "CreateDirectory") ||
+                    !InstructionValueResolver.TryResolveCallArgumentIdentity(directoryMethod, instructions, i, 0,
+                        exceptionHandlers, out var directoryIdentity) ||
+                    !directoryIdentity.Equals(launchArgumentIdentity, StringComparison.Ordinal) ||
+                    !InstructionValueResolver.IsGuaranteedToExecuteBefore(
+                        instructions, exceptionHandlers, i, processStartIndex))
+                {
+                    continue;
+                }
+
+                if (directoryMethod.Name == "CreateDirectory" ||
+                    IsTrueDirectoryExistsGuard(instructions, i, processStartIndex) ||
+                    IsEnsureDirectoryGuard(instructions, i, processStartIndex, launchArgumentIdentity,
+                        exceptionHandlers))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static bool IsSafeShellFolderLaunch(
             MethodReference processStartMethod,
             Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
-            int processStartIndex)
+            int processStartIndex,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers)
         {
             if (processStartMethod == null ||
                 processStartMethod.Parameters.Count != 1 ||
                 processStartMethod.Parameters[0].ParameterType.FullName != "System.Diagnostics.ProcessStartInfo" ||
                 !InstructionValueResolver.TryResolveCallArgumentIdentity(processStartMethod, instructions,
-                    processStartIndex, 0, out var launchedStartInfoIdentity))
+                    processStartIndex, 0, exceptionHandlers, out var launchedStartInfoIdentity))
             {
                 return false;
             }
@@ -726,7 +794,9 @@ namespace MLVScan.Models.Rules
                             ? HasStraightLineDominance(instructions, i, processStartIndex)
                             : IsTrueDirectoryExistsGuard(instructions, i, processStartIndex) ||
                               IsEnsureDirectoryGuard(instructions, i, processStartIndex, directoryTarget);
-                        if (validatesDirectory)
+                        if (validatesDirectory &&
+                            InstructionValueResolver.IsGuaranteedToExecuteBefore(
+                                instructions, exceptionHandlers, i, processStartIndex))
                         {
                             checkedDirectoryTargets[directoryTarget] = i;
                         }
@@ -738,8 +808,10 @@ namespace MLVScan.Models.Rules
                 if (methodRef.DeclaringType?.FullName == "System.Diagnostics.ProcessStartInfo" &&
                     methodRef.Name == "set_FileName")
                 {
-                    if (HasMatchingReceiverIdentity(instructions, i, launchedStartInfoIdentity) &&
+                    if (HasMatchingReceiverIdentity(instructions, i, launchedStartInfoIdentity, exceptionHandlers) &&
                         HasStraightLineDominance(instructions, i, processStartIndex) &&
+                        InstructionValueResolver.IsGuaranteedToExecuteBefore(
+                            instructions, exceptionHandlers, i, processStartIndex) &&
                         InstructionValueResolver.TryResolveStackValueDisplay(null, instructions, i - 1,
                             out var resolvedFileName))
                     {
@@ -752,8 +824,10 @@ namespace MLVScan.Models.Rules
                 if (methodRef.DeclaringType?.FullName == "System.Diagnostics.ProcessStartInfo" &&
                     methodRef.Name == "set_UseShellExecute")
                 {
-                    if (HasMatchingReceiverIdentity(instructions, i, launchedStartInfoIdentity) &&
+                    if (HasMatchingReceiverIdentity(instructions, i, launchedStartInfoIdentity, exceptionHandlers) &&
                         HasStraightLineDominance(instructions, i, processStartIndex) &&
+                        InstructionValueResolver.IsGuaranteedToExecuteBefore(
+                            instructions, exceptionHandlers, i, processStartIndex) &&
                         InstructionValueResolver.TryResolveStackValueDisplay(null, instructions, i - 1,
                             out var resolvedUseShell))
                     {
@@ -766,7 +840,7 @@ namespace MLVScan.Models.Rules
                 if (methodRef.DeclaringType?.FullName == "System.Diagnostics.ProcessStartInfo" &&
                     methodRef.Name == "set_Arguments")
                 {
-                    if (HasMatchingReceiverIdentity(instructions, i, launchedStartInfoIdentity))
+                    if (HasMatchingReceiverIdentity(instructions, i, launchedStartInfoIdentity, exceptionHandlers))
                     {
                         setsArguments = true;
                     }
@@ -784,10 +858,11 @@ namespace MLVScan.Models.Rules
         private static bool HasMatchingReceiverIdentity(
             Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
             int callIndex,
-            string expectedIdentity)
+            string expectedIdentity,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers)
         {
             return InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, callIndex,
-                       out var receiverIdentity) &&
+                       exceptionHandlers, out var receiverIdentity) &&
                    receiverIdentity == expectedIdentity;
         }
 
@@ -920,17 +995,9 @@ namespace MLVScan.Models.Rules
             int processStartIndex,
             string existsTarget)
         {
-            int branchIndex = existsCallIndex + 1;
-            if (branchIndex >= instructions.Count ||
-                (instructions[branchIndex].OpCode != OpCodes.Brtrue &&
-                 instructions[branchIndex].OpCode != OpCodes.Brtrue_S) ||
-                instructions[branchIndex].Operand is not Instruction joinTarget)
-            {
-                return false;
-            }
-
-            int joinIndex = instructions.IndexOf(joinTarget);
-            if (joinIndex <= branchIndex || joinIndex >= processStartIndex ||
+            if (!TryGetEnsureDirectoryJoin(instructions, existsCallIndex, out int branchIndex,
+                    out int joinIndex) ||
+                joinIndex >= processStartIndex ||
                 !HasStraightLineDominance(instructions, joinIndex, processStartIndex))
             {
                 return false;
@@ -960,6 +1027,113 @@ namespace MLVScan.Models.Rules
             }
 
             return createsMatchingDirectory;
+        }
+
+        private static bool IsEnsureDirectoryGuard(
+            Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
+            int existsCallIndex,
+            int processStartIndex,
+            string existsIdentity,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers)
+        {
+            if (!TryGetEnsureDirectoryJoin(instructions, existsCallIndex, out int branchIndex,
+                    out int joinIndex) ||
+                joinIndex >= processStartIndex ||
+                !HasStraightLineDominance(instructions, joinIndex, processStartIndex))
+            {
+                return false;
+            }
+
+            for (int i = branchIndex + 1; i < joinIndex; i++)
+            {
+                var flowControl = instructions[i].OpCode.FlowControl;
+                if (flowControl is FlowControl.Branch or FlowControl.Cond_Branch or
+                    FlowControl.Return or FlowControl.Throw)
+                {
+                    return false;
+                }
+
+                if ((instructions[i].OpCode == OpCodes.Call || instructions[i].OpCode == OpCodes.Callvirt) &&
+                    instructions[i].Operand is MethodReference methodRef &&
+                    methodRef.DeclaringType?.FullName == "System.IO.Directory" &&
+                    methodRef.Name == "CreateDirectory" &&
+                    InstructionValueResolver.TryResolveCallArgumentIdentity(methodRef, instructions, i, 0,
+                        exceptionHandlers, out var createIdentity) &&
+                    createIdentity.Equals(existsIdentity, StringComparison.Ordinal) &&
+                    HasStraightLineDominance(instructions, branchIndex, i))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool TryGetEnsureDirectoryJoin(
+            Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
+            int existsCallIndex,
+            out int branchIndex,
+            out int joinIndex)
+        {
+            branchIndex = existsCallIndex + 1;
+            joinIndex = -1;
+            if (branchIndex < instructions.Count &&
+                (instructions[branchIndex].OpCode == OpCodes.Brtrue ||
+                 instructions[branchIndex].OpCode == OpCodes.Brtrue_S) &&
+                instructions[branchIndex].Operand is Instruction directJoin)
+            {
+                joinIndex = instructions.IndexOf(directJoin);
+                return joinIndex > branchIndex;
+            }
+
+            if (existsCallIndex + 5 >= instructions.Count ||
+                instructions[existsCallIndex + 1].OpCode != OpCodes.Ldc_I4_0 ||
+                instructions[existsCallIndex + 2].OpCode != OpCodes.Ceq ||
+                !TryGetStoredLocalIndex(instructions[existsCallIndex + 3], out int storedLocalIndex) ||
+                !TryGetLoadedLocalIndex(instructions[existsCallIndex + 4], out int loadedLocalIndex) ||
+                storedLocalIndex != loadedLocalIndex)
+            {
+                return false;
+            }
+
+            branchIndex = existsCallIndex + 5;
+            if ((instructions[branchIndex].OpCode != OpCodes.Brfalse &&
+                 instructions[branchIndex].OpCode != OpCodes.Brfalse_S) ||
+                instructions[branchIndex].Operand is not Instruction normalizedJoin)
+            {
+                return false;
+            }
+
+            joinIndex = instructions.IndexOf(normalizedJoin);
+            return joinIndex > branchIndex;
+        }
+
+        private static bool TryGetLoadedLocalIndex(Instruction instruction, out int localIndex)
+        {
+            localIndex = instruction.OpCode.Code switch
+            {
+                Code.Ldloc_0 => 0,
+                Code.Ldloc_1 => 1,
+                Code.Ldloc_2 => 2,
+                Code.Ldloc_3 => 3,
+                Code.Ldloc or Code.Ldloc_S when instruction.Operand is VariableDefinition variable => variable.Index,
+                _ => -1
+            };
+            return localIndex >= 0;
+        }
+
+        private static bool TryGetStoredLocalIndex(Instruction instruction, out int localIndex)
+        {
+            localIndex = instruction.OpCode.Code switch
+            {
+                Code.Stloc_0 => 0,
+                Code.Stloc_1 => 1,
+                Code.Stloc_2 => 2,
+                Code.Stloc_3 => 3,
+                Code.Stloc or Code.Stloc_S when instruction.Operand is VariableDefinition variable => variable.Index,
+                _ => -1
+            };
+            return localIndex >= 0;
         }
 
         private static bool IsUnsafeShellTarget(string target)
@@ -1023,6 +1197,7 @@ namespace MLVScan.Models.Rules
             IReadOnlyList<ExceptionHandler> exceptionHandlers)
         {
             if (processStartMethod == null ||
+                !IsRestartAnalysisWithinBudget(instructions) ||
                 !TryResolveLaunchedTargetIdentity(processStartMethod, instructions, processStartIndex,
                     exceptionHandlers,
                     out var launchedTargetIdentity))
@@ -1079,6 +1254,52 @@ namespace MLVScan.Models.Rules
             }
 
             return false;
+        }
+
+        internal static bool IsRestartAnalysisWithinBudget(
+            Mono.Collections.Generic.Collection<Instruction> instructions)
+        {
+            var complexity = RestartAnalysisComplexities.GetValue(instructions, static body =>
+            {
+                int processStartCount = 0;
+                int competingWriteCount = 0;
+                foreach (var instruction in body)
+                {
+                    if (instruction.Operand is not MethodReference method)
+                        continue;
+
+                    if (method.DeclaringType?.FullName == "System.Diagnostics.Process" &&
+                        method.Name == "Start")
+                    {
+                        processStartCount++;
+                    }
+                    else if ((method.DeclaringType?.FullName == "System.Diagnostics.Process" &&
+                              method.Name == "set_StartInfo") ||
+                             (method.DeclaringType?.FullName == "System.Diagnostics.ProcessStartInfo" &&
+                              method.Name == "set_FileName"))
+                    {
+                        competingWriteCount++;
+                    }
+                }
+
+                long estimatedWork = (long)Math.Max(1, processStartCount) *
+                                     Math.Max(1, competingWriteCount) *
+                                     Math.Max(1, competingWriteCount) *
+                                     Math.Max(1, body.Count);
+                return new RestartAnalysisComplexity(estimatedWork <= MaxRestartReachabilityWork);
+            });
+
+            return complexity.IsWithinBudget;
+        }
+
+        private sealed class RestartAnalysisComplexity
+        {
+            public RestartAnalysisComplexity(bool isWithinBudget)
+            {
+                IsWithinBudget = isWithinBudget;
+            }
+
+            public bool IsWithinBudget { get; }
         }
 
         private static bool TryResolveLaunchedTargetIdentity(
@@ -1185,17 +1406,22 @@ namespace MLVScan.Models.Rules
             int assignmentIndex,
             int processStartIndex)
         {
-            for (int i = assignmentIndex + 1; i < processStartIndex; i++)
+            for (int i = 0; i < instructions.Count; i++)
             {
-                if (instructions[i].Operand is MethodReference setter &&
-                    setter.DeclaringType?.FullName == "System.Diagnostics.Process" &&
-                    setter.Name == "set_StartInfo" &&
-                    InstructionValueResolver.TryResolveCallReceiverIdentity(
-                        instructions, i, exceptionHandlers, out var receiverIdentity) &&
-                    receiverIdentity.Equals(launchedProcessIdentity, StringComparison.Ordinal))
+                if (i == assignmentIndex ||
+                    instructions[i].Operand is not MethodReference setter ||
+                    setter.DeclaringType?.FullName != "System.Diagnostics.Process" ||
+                    setter.Name != "set_StartInfo" ||
+                    !InstructionValueResolver.CanExecuteBetween(
+                        instructions, exceptionHandlers, assignmentIndex, i, processStartIndex))
                 {
-                    return true;
+                    continue;
                 }
+
+                if (!InstructionValueResolver.TryResolveCallReceiverIdentity(
+                        instructions, i, exceptionHandlers, out var receiverIdentity) ||
+                    receiverIdentity.Equals(launchedProcessIdentity, StringComparison.Ordinal))
+                    return true;
             }
 
             return false;
@@ -1209,16 +1435,21 @@ namespace MLVScan.Models.Rules
             int assignmentIndex,
             int processStartIndex)
         {
-            for (int i = assignmentIndex + 1; i < processStartIndex; i++)
+            for (int i = 0; i < instructions.Count; i++)
             {
-                if (instructions[i].Operand is not MethodReference setter ||
+                if (i == assignmentIndex ||
+                    instructions[i].Operand is not MethodReference setter ||
                     setter.DeclaringType?.FullName != "System.Diagnostics.ProcessStartInfo" ||
                     setter.Name != "set_FileName" ||
-                    !InstructionValueResolver.TryResolveCallReceiverIdentity(
-                        instructions, i, exceptionHandlers, out var receiverIdentity))
+                    !InstructionValueResolver.CanExecuteBetween(
+                        instructions, exceptionHandlers, assignmentIndex, i, processStartIndex))
                 {
                     continue;
                 }
+
+                if (!InstructionValueResolver.TryResolveCallReceiverIdentity(
+                        instructions, i, exceptionHandlers, out var receiverIdentity))
+                    return true;
 
                 if (IsMatchingStartInfoReceiver(receiverIdentity, assignedStartInfoIdentity,
                         launchedProcessIdentity, instructions, exceptionHandlers, i, processStartIndex))
@@ -1258,17 +1489,21 @@ namespace MLVScan.Models.Rules
                 return false;
             }
 
-            for (int i = getterIndex + 1; i < processStartIndex; i++)
+            for (int i = 0; i < instructions.Count; i++)
             {
-                if (instructions[i].Operand is MethodReference setter &&
-                    setter.DeclaringType?.FullName == "System.Diagnostics.Process" &&
-                    setter.Name == "set_StartInfo" &&
-                    InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, i,
-                        exceptionHandlers, out var setterReceiverIdentity) &&
-                    setterReceiverIdentity.Equals(launchedProcessIdentity, StringComparison.Ordinal))
+                if (instructions[i].Operand is not MethodReference setter ||
+                    setter.DeclaringType?.FullName != "System.Diagnostics.Process" ||
+                    setter.Name != "set_StartInfo" ||
+                    !InstructionValueResolver.CanExecuteBetween(
+                        instructions, exceptionHandlers, getterIndex, i, processStartIndex))
                 {
-                    return false;
+                    continue;
                 }
+
+                if (!InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, i,
+                        exceptionHandlers, out var setterReceiverIdentity) ||
+                    setterReceiverIdentity.Equals(launchedProcessIdentity, StringComparison.Ordinal))
+                    return false;
             }
 
             return true;

--- a/Models/Rules/ProcessStartRule.cs
+++ b/Models/Rules/ProcessStartRule.cs
@@ -645,7 +645,7 @@ namespace MLVScan.Models.Rules
                 return false;
             }
 
-            if (IsSafeBareExplorerLaunch(instructions, instructionIndex))
+            if (IsSafeBareExplorerLaunch(method, instructions, instructionIndex))
             {
                 return true;
             }
@@ -655,7 +655,7 @@ namespace MLVScan.Models.Rules
                 return true;
             }
 
-            if (IsCurrentProcessRestart(instructions, instructionIndex))
+            if (IsCurrentProcessRestart(method, instructions, instructionIndex))
             {
                 return true;
             }
@@ -664,33 +664,20 @@ namespace MLVScan.Models.Rules
         }
 
         private static bool IsSafeBareExplorerLaunch(
+            MethodReference processStartMethod,
             Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
             int processStartIndex)
         {
-            for (int i = Math.Max(0, processStartIndex - 10); i < processStartIndex; i++)
+            if (processStartMethod == null ||
+                processStartMethod.Parameters.Count == 0 ||
+                !InstructionValueResolver.TryResolveCallArgumentDisplay(null, processStartMethod, instructions,
+                    processStartIndex, 0, out var target) ||
+                !target.Equals("explorer.exe", StringComparison.OrdinalIgnoreCase))
             {
-                var instruction = instructions[i];
-                if (instruction.OpCode == Mono.Cecil.Cil.OpCodes.Ldstr &&
-                    instruction.Operand is string str)
-                {
-                    if (!str.Equals("explorer.exe", StringComparison.OrdinalIgnoreCase))
-                        continue;
-
-                    if (str.Contains("\\") || str.Contains("/") || str.Contains(":"))
-                    {
-                        return false;
-                    }
-
-                    if (HasPathManipulation(instructions, i, processStartIndex))
-                    {
-                        return false;
-                    }
-
-                    return true;
-                }
+                return false;
             }
 
-            return false;
+            return !HasPathManipulation(instructions, Math.Max(0, processStartIndex - 10), processStartIndex);
         }
 
         private static bool IsSafeShellFolderLaunch(
@@ -1022,9 +1009,17 @@ namespace MLVScan.Models.Rules
         }
 
         private static bool IsCurrentProcessRestart(
+            MethodReference processStartMethod,
             Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
             int processStartIndex)
         {
+            if (processStartMethod == null ||
+                !TryResolveLaunchedTargetIdentity(processStartMethod, instructions, processStartIndex,
+                    out var launchedTargetIdentity))
+            {
+                return false;
+            }
+
             bool foundGetCurrentProcess = false;
             bool foundGetMainModule = false;
             bool foundGetFileName = false;
@@ -1099,7 +1094,81 @@ namespace MLVScan.Models.Rules
                     }
                 }
 
-                return true;
+                return launchedTargetIdentity.Equals($"call:{getFileNameIndex}", StringComparison.Ordinal);
+            }
+
+            return false;
+        }
+
+        private static bool TryResolveLaunchedTargetIdentity(
+            MethodReference processStartMethod,
+            Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
+            int processStartIndex,
+            out string targetIdentity)
+        {
+            targetIdentity = string.Empty;
+
+            if (processStartMethod.Parameters.Count > 0 &&
+                processStartMethod.Parameters[0].ParameterType.FullName != "System.Diagnostics.ProcessStartInfo")
+            {
+                return InstructionValueResolver.TryResolveCallArgumentIdentity(processStartMethod, instructions,
+                    processStartIndex, 0, out targetIdentity);
+            }
+
+            string startInfoIdentity;
+            if (processStartMethod.Parameters.Count > 0)
+            {
+                if (!InstructionValueResolver.TryResolveCallArgumentIdentity(processStartMethod, instructions,
+                        processStartIndex, 0, out startInfoIdentity))
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                if (!processStartMethod.HasThis ||
+                    !InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, processStartIndex,
+                        out var launchedProcessIdentity))
+                {
+                    return false;
+                }
+
+                startInfoIdentity = string.Empty;
+                for (int i = processStartIndex - 1; i >= Math.Max(0, processStartIndex - 80); i--)
+                {
+                    if (instructions[i].Operand is not MethodReference setter ||
+                        setter.DeclaringType?.FullName != "System.Diagnostics.Process" ||
+                        setter.Name != "set_StartInfo" ||
+                        !InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, i,
+                            out var receiverIdentity) ||
+                        !receiverIdentity.Equals(launchedProcessIdentity, StringComparison.Ordinal) ||
+                        !InstructionValueResolver.TryResolveCallArgumentIdentity(setter, instructions, i, 0,
+                            out startInfoIdentity))
+                    {
+                        continue;
+                    }
+
+                    break;
+                }
+
+                if (startInfoIdentity.Length == 0)
+                    return false;
+            }
+
+            for (int i = processStartIndex - 1; i >= Math.Max(0, processStartIndex - 80); i--)
+            {
+                if (instructions[i].Operand is not MethodReference setter ||
+                    setter.DeclaringType?.FullName != "System.Diagnostics.ProcessStartInfo" ||
+                    setter.Name != "set_FileName" ||
+                    !InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, i,
+                        out var receiverIdentity) ||
+                    !receiverIdentity.Equals(startInfoIdentity, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                return InstructionValueResolver.TryResolveCallArgumentIdentity(setter, instructions, i, 0,
+                    out targetIdentity);
             }
 
             return false;

--- a/Models/Rules/ProcessStartRule.cs
+++ b/Models/Rules/ProcessStartRule.cs
@@ -1461,30 +1461,57 @@ namespace MLVScan.Models.Rules
             int assignmentIndex,
             int processStartIndex)
         {
+            bool processStateEscapedBeforeAssignment = false;
             for (int i = 0; i < instructions.Count; i++)
             {
-                if (i == assignmentIndex || i == processStartIndex ||
-                    !InstructionValueResolver.CanExecuteBetween(
-                        instructions, exceptionHandlers, assignmentIndex, i, processStartIndex))
-                {
+                if (i == assignmentIndex || i == processStartIndex)
                     continue;
-                }
 
-                if (instructions[i].OpCode.Code is Code.Stfld or Code.Stsfld or Code.Stelem_Ref)
+                bool isEscapeStore = instructions[i].OpCode.Code is Code.Stfld or Code.Stsfld or Code.Stelem_Ref;
+                bool isMethodCall = instructions[i].Operand is MethodReference;
+                if (!isEscapeStore && !isMethodCall)
+                    continue;
+
+                if (isEscapeStore)
                 {
+                    bool precedesSafeAssignment = i < assignmentIndex;
+                    int reachabilityStart = precedesSafeAssignment ? i : assignmentIndex;
+                    if (!InstructionValueResolver.CanExecuteBetween(
+                            instructions, exceptionHandlers, reachabilityStart, i, processStartIndex))
+                    {
+                        continue;
+                    }
+
                     if (!InstructionValueResolver.TryResolveStoredValueIdentity(
-                            instructions, i, exceptionHandlers, out var escapedIdentity) ||
-                        IsMatchingStartInfoReceiver(escapedIdentity, assignedStartInfoIdentity,
+                            instructions, i, exceptionHandlers, out var escapedIdentity))
+                    {
+                        if (!precedesSafeAssignment)
+                            return true;
+
+                        continue;
+                    }
+
+                    if (IsMatchingStartInfoReceiver(escapedIdentity, assignedStartInfoIdentity,
                             launchedProcessIdentity, instructions, exceptionHandlers, i, processStartIndex))
                     {
+                        if (precedesSafeAssignment)
+                        {
+                            processStateEscapedBeforeAssignment = true;
+                            continue;
+                        }
+
                         return true;
                     }
 
                     continue;
                 }
 
-                if (instructions[i].Operand is not MethodReference calledMethod)
+                if (!InstructionValueResolver.CanExecuteBetween(
+                        instructions, exceptionHandlers, assignmentIndex, i, processStartIndex) ||
+                    instructions[i].Operand is not MethodReference calledMethod)
+                {
                     continue;
+                }
 
                 if (calledMethod.DeclaringType?.FullName == "System.Diagnostics.Process" &&
                     calledMethod.Name == "set_StartInfo")
@@ -1495,7 +1522,19 @@ namespace MLVScan.Models.Rules
                 if (calledMethod.DeclaringType?.FullName == "System.Diagnostics.ProcessStartInfo" &&
                     calledMethod.Name != "set_FileName")
                 {
+                    if (processStateEscapedBeforeAssignment &&
+                        !IsKnownProcessConfigurationMethod(calledMethod))
+                    {
+                        return true;
+                    }
+
                     continue;
+                }
+
+                if (processStateEscapedBeforeAssignment &&
+                    !IsKnownProcessConfigurationMethod(calledMethod))
+                {
+                    return true;
                 }
 
                 for (int argumentIndex = 0; argumentIndex < calledMethod.Parameters.Count; argumentIndex++)
@@ -1544,6 +1583,26 @@ namespace MLVScan.Models.Rules
             }
 
             return false;
+        }
+
+        private static bool IsKnownProcessConfigurationMethod(MethodReference method)
+        {
+            if (method.DeclaringType?.FullName == "System.Diagnostics.ProcessStartInfo")
+            {
+                return InstructionValueResolver.IsTrustedFrameworkMethod(method,
+                    "System.Diagnostics.ProcessStartInfo", method.Name, allowDetachedReference: true);
+            }
+
+            return InstructionValueResolver.IsTrustedFrameworkMethod(method,
+                       "System.Diagnostics.Process", "GetCurrentProcess", allowDetachedReference: true) ||
+                   InstructionValueResolver.IsTrustedFrameworkMethod(method,
+                       "System.Diagnostics.Process", "get_MainModule", allowDetachedReference: true) ||
+                   InstructionValueResolver.IsTrustedFrameworkMethod(method,
+                       "System.Diagnostics.ProcessModule", "get_FileName", allowDetachedReference: true) ||
+                   InstructionValueResolver.IsTrustedFrameworkMethod(method,
+                       "System.Diagnostics.Process", "get_StartInfo", allowDetachedReference: true) ||
+                   InstructionValueResolver.IsTrustedFrameworkMethod(method,
+                       "System.Diagnostics.Process", "set_StartInfo", allowDetachedReference: true);
         }
 
         private static bool CanPotentiallyAliasProcessState(TypeReference parameterType)

--- a/Models/Rules/ProcessStartRule.cs
+++ b/Models/Rules/ProcessStartRule.cs
@@ -1125,6 +1125,25 @@ namespace MLVScan.Models.Rules
                 }
 
                 if (startInfoIdentity.Length == 0)
+                {
+                    for (int i = processStartIndex - 1; i >= Math.Max(0, processStartIndex - 80); i--)
+                    {
+                        if (instructions[i].Operand is not MethodReference getter ||
+                            getter.DeclaringType?.FullName != "System.Diagnostics.Process" ||
+                            getter.Name != "get_StartInfo" ||
+                            !InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, i,
+                                out var receiverIdentity) ||
+                            !receiverIdentity.Equals(launchedProcessIdentity, StringComparison.Ordinal))
+                        {
+                            continue;
+                        }
+
+                        startInfoIdentity = $"call:{i}";
+                        break;
+                    }
+                }
+
+                if (startInfoIdentity.Length == 0)
                     return false;
             }
 

--- a/Models/Rules/ProcessStartRule.cs
+++ b/Models/Rules/ProcessStartRule.cs
@@ -1479,15 +1479,38 @@ namespace MLVScan.Models.Rules
                     continue;
                 }
 
+                if (calledMethod.DeclaringType?.FullName == "System.Diagnostics.ProcessStartInfo" &&
+                    calledMethod.Name != "set_FileName")
+                {
+                    continue;
+                }
+
                 for (int argumentIndex = 0; argumentIndex < calledMethod.Parameters.Count; argumentIndex++)
                 {
                     if (InstructionValueResolver.TryResolveCallArgumentIdentity(calledMethod, instructions, i,
-                            argumentIndex, exceptionHandlers, out var argumentIdentity) &&
-                        IsMatchingStartInfoReceiver(argumentIdentity, assignedStartInfoIdentity,
-                            launchedProcessIdentity, instructions, exceptionHandlers, i, processStartIndex))
+                            argumentIndex, exceptionHandlers, out var argumentIdentity))
+                    {
+                        if (IsMatchingStartInfoReceiver(argumentIdentity, assignedStartInfoIdentity,
+                                launchedProcessIdentity, instructions, exceptionHandlers, i, processStartIndex))
+                        {
+                            return true;
+                        }
+                    }
+                    else if (CanPotentiallyAliasProcessState(calledMethod.Parameters[argumentIndex].ParameterType))
                     {
                         return true;
                     }
+                }
+
+                if (calledMethod.HasThis &&
+                    calledMethod.DeclaringType?.FullName is not
+                        ("System.Diagnostics.Process" or "System.Diagnostics.ProcessStartInfo") &&
+                    InstructionValueResolver.TryResolveCallReceiverIdentity(
+                        instructions, i, exceptionHandlers, out var callReceiverIdentity) &&
+                    IsMatchingStartInfoReceiver(callReceiverIdentity, assignedStartInfoIdentity,
+                        launchedProcessIdentity, instructions, exceptionHandlers, i, processStartIndex))
+                {
+                    return true;
                 }
 
                 if (calledMethod.DeclaringType?.FullName != "System.Diagnostics.ProcessStartInfo" ||
@@ -1508,6 +1531,15 @@ namespace MLVScan.Models.Rules
             }
 
             return false;
+        }
+
+        private static bool CanPotentiallyAliasProcessState(TypeReference parameterType)
+        {
+            while (parameterType is ByReferenceType byReferenceType)
+                parameterType = byReferenceType.ElementType;
+
+            return !parameterType.IsValueType &&
+                   parameterType.FullName != "System.String";
         }
 
         private static bool IsMatchingStartInfoReceiver(

--- a/Models/Rules/ProcessStartRule.cs
+++ b/Models/Rules/ProcessStartRule.cs
@@ -124,7 +124,7 @@ namespace MLVScan.Models.Rules
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex ExecutableShellTargetPattern = new Regex(
-            @"(?i)\.(exe|com|msi|msp|scr|cpl|lnk|url|scf)(\b|\s|\""|'|$)",
+            @"(?i)\.(exe|com|msi|msp|mst|scr|cpl|lnk|url|scf|application|appref-ms|gadget|diagcab|chm|jar|reg|inf|settingcontent-ms)(\b|\s|\""|'|$)",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex StagedLoaderPivotPattern = new Regex(
@@ -1481,11 +1481,8 @@ namespace MLVScan.Models.Rules
 
                 for (int argumentIndex = 0; argumentIndex < calledMethod.Parameters.Count; argumentIndex++)
                 {
-                    if (!IsProcessStartInfoParameter(calledMethod.Parameters[argumentIndex].ParameterType))
-                        continue;
-
-                    if (!InstructionValueResolver.TryResolveCallArgumentIdentity(calledMethod, instructions, i,
-                            argumentIndex, exceptionHandlers, out var argumentIdentity) ||
+                    if (InstructionValueResolver.TryResolveCallArgumentIdentity(calledMethod, instructions, i,
+                            argumentIndex, exceptionHandlers, out var argumentIdentity) &&
                         IsMatchingStartInfoReceiver(argumentIdentity, assignedStartInfoIdentity,
                             launchedProcessIdentity, instructions, exceptionHandlers, i, processStartIndex))
                     {
@@ -1513,13 +1510,6 @@ namespace MLVScan.Models.Rules
             return false;
         }
 
-        private static bool IsProcessStartInfoParameter(TypeReference parameterType)
-        {
-            return parameterType.FullName == "System.Diagnostics.ProcessStartInfo" ||
-                   parameterType is ByReferenceType byReferenceType &&
-                   byReferenceType.ElementType.FullName == "System.Diagnostics.ProcessStartInfo";
-        }
-
         private static bool IsMatchingStartInfoReceiver(
             string receiverIdentity,
             string assignedStartInfoIdentity,
@@ -1531,6 +1521,12 @@ namespace MLVScan.Models.Rules
         {
             if (assignedStartInfoIdentity.Length > 0 &&
                 receiverIdentity.Equals(assignedStartInfoIdentity, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            if (launchedProcessIdentity.Length > 0 &&
+                receiverIdentity.Equals(launchedProcessIdentity, StringComparison.Ordinal))
             {
                 return true;
             }

--- a/Models/Rules/ProcessStartRule.cs
+++ b/Models/Rules/ProcessStartRule.cs
@@ -1388,6 +1388,7 @@ namespace MLVScan.Models.Rules
 
             }
 
+            var matchingFileNameSetters = new HashSet<Instruction>();
             for (int i = processStartIndex - 1; i >= Math.Max(0, processStartIndex - 80); i--)
             {
                 if (instructions[i].Operand is not MethodReference setter ||
@@ -1396,8 +1397,13 @@ namespace MLVScan.Models.Rules
                     !InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, i,
                         exceptionHandlers, out var receiverIdentity) ||
                     !IsMatchingStartInfoReceiver(receiverIdentity, startInfoIdentity, launchedProcessIdentity,
-                        instructions, exceptionHandlers, i, processStartIndex) ||
-                    !InstructionValueResolver.IsGuaranteedToExecuteBefore(
+                        instructions, exceptionHandlers, i, processStartIndex))
+                {
+                    continue;
+                }
+
+                matchingFileNameSetters.Add(instructions[i]);
+                if (!InstructionValueResolver.IsGuaranteedToExecuteBefore(
                         instructions, exceptionHandlers, i, processStartIndex) ||
                     HasLaterFileNameWrite(startInfoIdentity, launchedProcessIdentity, instructions,
                         exceptionHandlers, i, processStartIndex))
@@ -1407,6 +1413,20 @@ namespace MLVScan.Models.Rules
 
                 return InstructionValueResolver.TryResolveCallArgumentIdentity(setter, instructions, i, 0,
                     exceptionHandlers, out targetIdentity);
+            }
+
+            if (matchingFileNameSetters.Count > 1 &&
+                InstructionValueResolver.TryResolveEquivalentCallArgumentReachingDefinitions(
+                    instructions, exceptionHandlers, processStartIndex,
+                    matchingFileNameSetters.Contains, 0, out var equivalentTargetIdentity))
+            {
+                int earliestSetterIndex = matchingFileNameSetters.Min(instructions.IndexOf);
+                if (!HasLaterFileNameWrite(startInfoIdentity, launchedProcessIdentity, instructions,
+                        exceptionHandlers, earliestSetterIndex, processStartIndex))
+                {
+                    targetIdentity = equivalentTargetIdentity;
+                    return true;
+                }
             }
 
             if (TryGetProducerIndex(startInfoIdentity, "new:", out int constructorIndex) &&
@@ -1461,7 +1481,9 @@ namespace MLVScan.Models.Rules
             int assignmentIndex,
             int processStartIndex)
         {
-            bool processStateEscapedBeforeAssignment = false;
+            bool processStateEscapedBeforeAssignment =
+                assignedStartInfoIdentity.StartsWith("argument:", StringComparison.Ordinal) ||
+                launchedProcessIdentity.StartsWith("argument:", StringComparison.Ordinal);
             for (int i = 0; i < instructions.Count; i++)
             {
                 if (i == assignmentIndex || i == processStartIndex)

--- a/Models/Rules/ProcessStartRule.cs
+++ b/Models/Rules/ProcessStartRule.cs
@@ -1135,7 +1135,8 @@ namespace MLVScan.Models.Rules
                     !InstructionValueResolver.TryResolveCallReceiverIdentity(instructions, i,
                         out var receiverIdentity) ||
                     !IsMatchingStartInfoReceiver(receiverIdentity, startInfoIdentity, launchedProcessIdentity,
-                        instructions, i, processStartIndex))
+                        instructions, i, processStartIndex) ||
+                    !InstructionValueResolver.IsGuaranteedToExecuteBefore(instructions, i, processStartIndex))
                 {
                     continue;
                 }

--- a/Models/Rules/ProcessStartRule.cs
+++ b/Models/Rules/ProcessStartRule.cs
@@ -655,7 +655,8 @@ namespace MLVScan.Models.Rules
                 return true;
             }
 
-            if (IsCurrentProcessRestart(method, instructions, instructionIndex))
+            if (IsCurrentProcessRestart(method, instructions, instructionIndex,
+                    methodSignals?.ExceptionHandlers ?? Array.Empty<ExceptionHandler>()))
             {
                 return true;
             }
@@ -1013,10 +1014,12 @@ namespace MLVScan.Models.Rules
         private static bool IsCurrentProcessRestart(
             MethodReference processStartMethod,
             Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
-            int processStartIndex)
+            int processStartIndex,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers)
         {
             if (processStartMethod == null ||
                 !TryResolveLaunchedTargetIdentity(processStartMethod, instructions, processStartIndex,
+                    exceptionHandlers,
                     out var launchedTargetIdentity))
             {
                 return false;
@@ -1077,6 +1080,7 @@ namespace MLVScan.Models.Rules
             MethodReference processStartMethod,
             Mono.Collections.Generic.Collection<Mono.Cecil.Cil.Instruction> instructions,
             int processStartIndex,
+            IReadOnlyList<ExceptionHandler> exceptionHandlers,
             out string targetIdentity)
         {
             targetIdentity = string.Empty;
@@ -1136,7 +1140,8 @@ namespace MLVScan.Models.Rules
                         out var receiverIdentity) ||
                     !IsMatchingStartInfoReceiver(receiverIdentity, startInfoIdentity, launchedProcessIdentity,
                         instructions, i, processStartIndex) ||
-                    !InstructionValueResolver.IsGuaranteedToExecuteBefore(instructions, i, processStartIndex))
+                    !InstructionValueResolver.IsGuaranteedToExecuteBefore(
+                        instructions, exceptionHandlers, i, processStartIndex))
                 {
                     continue;
                 }

--- a/Services/InstructionAnalyzer.cs
+++ b/Services/InstructionAnalyzer.cs
@@ -118,13 +118,17 @@ namespace MLVScan.Services
         /// <param name="instructions">The method instructions.</param>
         /// <param name="methodSignals">Optional signal state collected for the current method.</param>
         /// <param name="typeFullName">The declaring type's full name for type-level signal correlation.</param>
+        /// <param name="exceptionHandlers">Optional exception-handler context used by suppression analysis.</param>
         /// <returns>The findings and deferred reflection work collected for the method.</returns>
         public InstructionAnalysisResult AnalyzeInstructions(MethodDefinition method,
             Mono.Collections.Generic.Collection<Instruction> instructions,
-            MethodSignals? methodSignals, string typeFullName)
+            MethodSignals? methodSignals, string typeFullName,
+            IReadOnlyList<ExceptionHandler>? exceptionHandlers = null)
         {
             var result = new InstructionAnalysisResult();
             var effectiveMethodSignals = methodSignals ?? _signalTracker.CreateMethodSignals() ?? new MethodSignals();
+            if (exceptionHandlers != null)
+                effectiveMethodSignals.ExceptionHandlers = exceptionHandlers;
             var analysisStart = _telemetry.StartTimestamp();
             _telemetry.IncrementCounter("InstructionAnalyzer.MethodsAnalyzed");
             _telemetry.IncrementCounter("InstructionAnalyzer.InstructionsVisited", instructions.Count);

--- a/Services/MethodScanner.cs
+++ b/Services/MethodScanner.cs
@@ -257,7 +257,8 @@ namespace MLVScan.Services
                 // Analyze instructions for method calls and suspicious patterns
                 var instructionAnalyzerStart = _telemetry.StartTimestamp();
                 var instructionResult =
-                    _instructionAnalyzer.AnalyzeInstructions(method, instructions, methodSignals, typeFullName);
+                    _instructionAnalyzer.AnalyzeInstructions(method, instructions, methodSignals, typeFullName,
+                        effectiveMethodSignals.ExceptionHandlers);
                 _telemetry.AddPhaseElapsed("MethodScanner.InstructionAnalyzer", instructionAnalyzerStart);
                 result.Findings.AddRange(instructionResult.Findings);
                 result.PendingReflectionFindings.AddRange(instructionResult.PendingReflectionFindings);

--- a/Services/MethodScanner.cs
+++ b/Services/MethodScanner.cs
@@ -126,6 +126,7 @@ namespace MLVScan.Services
                 // Initialize signal tracking for this method
                 var methodSignals = _signalTracker.CreateMethodSignals();
                 var effectiveMethodSignals = methodSignals ?? new MethodSignals();
+                effectiveMethodSignals.ExceptionHandlers = method.Body.ExceptionHandlers.ToArray();
 
                 // Analyze local variables if present
                 if (method.Body.HasVariables)


### PR DESCRIPTION
## Summary
- bind benign Process.Start suppression decisions to the value actually consumed by the launch call
- preserve legitimate bare Explorer and current-process restart behavior, including bound ProcessStartInfo flows
- add regressions for misleading nearby values and disconnected restart computations

## Validation
- ProcessStartRule focused suite: 78 passed
- false-positive suite: 53 passed, 7 optional skipped; disposition baseline remains Clean with no threat-family matches
- quarantine suite: 180 passed, 1 optional skipped; available samples remain KnownThreat
- full suite: 1,578 passed, 19 optional skipped

Security details are intentionally kept in the private Codex Security finding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Bind benign `Process.Start` suppressions to the value consumed by the launch call.
- Preserve safe Explorer launches and current-process restart detection.
- Support `ProcessStartInfo` aliases, constructors, getter-backed targets, and restart chains.
- Add conservative exception-control-flow, alias, overwrite, and identity analysis.
- Add regressions for misleading nearby values, disconnected computations, and exceptional paths.
- Validation: 1,618 tests passed; 19 optional tests skipped.

| Author | Lines added | Lines removed |
|---|---:|---:|
| Author attribution was not provided | 2,080 | 134 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->