### PR TITLE
Bound recursive resource expansion

### DIFF
--- a/MLVScan.Core.Tests/Unit/Rules/AssemblyDynamicLoadRuleBranchTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/AssemblyDynamicLoadRuleBranchTests.cs
@@ -1,6 +1,8 @@
 using FluentAssertions;
+using System.IO.Compression;
 using MLVScan.Models;
 using MLVScan.Models.Rules;
+using MLVScan.Services;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Xunit;
@@ -77,6 +79,38 @@ public class AssemblyDynamicLoadRuleBranchTests
             finding.Description.Contains("powershell.exe", StringComparison.OrdinalIgnoreCase) &&
             finding.Description.Contains("dl.bat", StringComparison.OrdinalIgnoreCase) &&
             finding.BypassCompanionCheck);
+    }
+
+    [Fact]
+    public void PostAnalysisRefine_WhenRecursiveScanningDisabled_SkipsEmbeddedAssembly()
+    {
+        const string resourceName = "payload.dll";
+        var outerAssembly = CreateAssembly("DisabledRecursiveScan");
+        outerAssembly.MainModule.Resources.Add(new EmbeddedResource(resourceName,
+            Mono.Cecil.ManifestResourceAttributes.Private, BuildInnerAssemblyBytesWithProcessStart()));
+        QueueEmbeddedResourceLoad(_rule, outerAssembly.MainModule, resourceName);
+        _ = new AssemblyScanner([_rule], new ScanConfig { EnableRecursiveResourceScanning = false });
+
+        var refined = _rule.PostAnalysisRefine(outerAssembly.MainModule,
+            Enumerable.Empty<ScanFinding>()).ToList();
+
+        refined.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void PostAnalysisRefine_WhenGzipExpansionExceedsConfiguredLimit_StopsWithoutScanning()
+    {
+        const string resourceName = "compressed-payload.dll";
+        var outerAssembly = CreateAssembly("BoundedRecursiveScan");
+        outerAssembly.MainModule.Resources.Add(new EmbeddedResource(resourceName,
+            Mono.Cecil.ManifestResourceAttributes.Private, BuildOversizedGzipPayload(2 * 1024 * 1024)));
+        QueueEmbeddedResourceLoad(_rule, outerAssembly.MainModule, resourceName);
+        _ = new AssemblyScanner([_rule], new ScanConfig { MaxRecursiveResourceSizeMB = 1 });
+
+        var refined = _rule.PostAnalysisRefine(outerAssembly.MainModule,
+            Enumerable.Empty<ScanFinding>()).ToList();
+
+        refined.Should().BeEmpty();
     }
 
     [Fact]
@@ -231,6 +265,44 @@ public class AssemblyDynamicLoadRuleBranchTests
         using var ms = new MemoryStream();
         assembly.Write(ms);
         return ms.ToArray();
+    }
+
+    private static void QueueEmbeddedResourceLoad(
+        AssemblyDynamicLoadRule rule,
+        ModuleDefinition module,
+        string resourceName)
+    {
+        var loadBytes = CreateMethodReference("System.Reflection", "Assembly", "Load", module, "System.Byte[]");
+        var getResource = CreateMethodReference("System.Reflection", "Assembly", "GetManifestResourceStream",
+            module, "System.String");
+        var instructions = new Mono.Collections.Generic.Collection<Instruction>
+        {
+            Instruction.Create(OpCodes.Ldstr, resourceName),
+            Instruction.Create(OpCodes.Call, getResource),
+            Instruction.Create(OpCodes.Call, loadBytes)
+        };
+
+        rule.AnalyzeContextualPattern(loadBytes, instructions, 2, new MethodSignals()).ToList();
+    }
+
+    private static byte[] BuildOversizedGzipPayload(int expandedSize)
+    {
+        using var output = new MemoryStream();
+        using (var gzip = new GZipStream(output, CompressionLevel.SmallestSize, leaveOpen: true))
+        {
+            gzip.WriteByte((byte)'M');
+            gzip.WriteByte((byte)'Z');
+            var zeros = new byte[81920];
+            int remaining = expandedSize - 2;
+            while (remaining > 0)
+            {
+                int count = Math.Min(remaining, zeros.Length);
+                gzip.Write(zeros, 0, count);
+                remaining -= count;
+            }
+        }
+
+        return output.ToArray();
     }
 
     private static MethodReference CreateProcessStartInfoStart(ModuleDefinition module, TypeReference processStartInfoType)

--- a/MLVScan.Core.Tests/Unit/Rules/AssemblyDynamicLoadRuleBranchTests.cs
+++ b/MLVScan.Core.Tests/Unit/Rules/AssemblyDynamicLoadRuleBranchTests.cs
@@ -102,8 +102,12 @@ public class AssemblyDynamicLoadRuleBranchTests
     {
         const string resourceName = "compressed-payload.dll";
         var outerAssembly = CreateAssembly("BoundedRecursiveScan");
+        var compressedPayload = BuildOversizedGzipPayload(
+            BuildInnerAssemblyBytesWithProcessStart(),
+            2 * 1024 * 1024);
+        compressedPayload.Length.Should().BeLessThan(1024 * 1024);
         outerAssembly.MainModule.Resources.Add(new EmbeddedResource(resourceName,
-            Mono.Cecil.ManifestResourceAttributes.Private, BuildOversizedGzipPayload(2 * 1024 * 1024)));
+            Mono.Cecil.ManifestResourceAttributes.Private, compressedPayload));
         QueueEmbeddedResourceLoad(_rule, outerAssembly.MainModule, resourceName);
         _ = new AssemblyScanner([_rule], new ScanConfig { MaxRecursiveResourceSizeMB = 1 });
 
@@ -285,15 +289,15 @@ public class AssemblyDynamicLoadRuleBranchTests
         rule.AnalyzeContextualPattern(loadBytes, instructions, 2, new MethodSignals()).ToList();
     }
 
-    private static byte[] BuildOversizedGzipPayload(int expandedSize)
+    private static byte[] BuildOversizedGzipPayload(byte[] payload, int expandedSize)
     {
+        expandedSize.Should().BeGreaterThan(payload.Length);
         using var output = new MemoryStream();
         using (var gzip = new GZipStream(output, CompressionLevel.SmallestSize, leaveOpen: true))
         {
-            gzip.WriteByte((byte)'M');
-            gzip.WriteByte((byte)'Z');
+            gzip.Write(payload, 0, payload.Length);
             var zeros = new byte[81920];
-            int remaining = expandedSize - 2;
+            int remaining = expandedSize - payload.Length;
             while (remaining > 0)
             {
                 int count = Math.Min(remaining, zeros.Length);

--- a/Models/Rules/AssemblyDynamicLoadRule.cs
+++ b/Models/Rules/AssemblyDynamicLoadRule.cs
@@ -1126,12 +1126,9 @@ namespace MLVScan.Models.Rules
                 if (resource == null)
                     return findings;
 
-                var resourceData = resource.GetResourceData();
-                if (resourceData == null || resourceData.Length == 0)
-                    return findings;
-
-                // Apply the configured limit to both stored and expanded resource bytes.
-                if (resourceData.LongLength > maxResourceBytes)
+                using var storedResourceStream = resource.GetResourceStream();
+                if (!TryReadBounded(storedResourceStream, maxResourceBytes, out var resourceData) ||
+                    resourceData.Length == 0)
                     return findings;
 
                 // Check if it looks like a PE/assembly (MZ header)
@@ -1204,6 +1201,29 @@ namespace MLVScan.Models.Rules
             }
 
             return findings;
+        }
+
+        private static bool TryReadBounded(Stream source, long maxBytes, out byte[] data)
+        {
+            data = Array.Empty<byte>();
+            if (maxBytes <= 0 || (source.CanSeek && source.Length > maxBytes))
+                return false;
+
+            using var destination = new MemoryStream();
+            var buffer = new byte[81920];
+            long totalBytes = 0;
+            int bytesRead;
+            while ((bytesRead = source.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                totalBytes += bytesRead;
+                if (totalBytes > maxBytes)
+                    return false;
+
+                destination.Write(buffer, 0, bytesRead);
+            }
+
+            data = destination.ToArray();
+            return true;
         }
 
         private static ScanFinding CreateEmbeddedChildFinding(string resourceName, ScanFinding innerFinding)

--- a/Models/Rules/AssemblyDynamicLoadRule.cs
+++ b/Models/Rules/AssemblyDynamicLoadRule.cs
@@ -36,6 +36,14 @@ namespace MLVScan.Models.Rules
 
         // Pending findings collected during AnalyzeContextualPattern, refined in PostAnalysisRefine
         private readonly List<PendingLoadFinding> _pendingFindings = new();
+        private bool _enableRecursiveResourceScanning = true;
+        private long _maxRecursiveResourceBytes = 10L * 1024 * 1024;
+
+        internal void ConfigureRecursiveResourceScanning(ScanConfig config)
+        {
+            _enableRecursiveResourceScanning = config.EnableRecursiveResourceScanning;
+            _maxRecursiveResourceBytes = Math.Max(0L, (long)config.MaxRecursiveResourceSizeMB * 1024 * 1024);
+        }
 
         #region Well-Known Safe Assembly Names
 
@@ -306,13 +314,19 @@ namespace MLVScan.Models.Rules
         {
             var additionalFindings = new List<ScanFinding>();
 
+            if (!_enableRecursiveResourceScanning || _maxRecursiveResourceBytes == 0)
+            {
+                _pendingFindings.Clear();
+                return additionalFindings;
+            }
+
             foreach (var pending in _pendingFindings)
             {
                 if (string.IsNullOrEmpty(pending.ResourceName))
                     continue;
 
                 // Try to find and scan the embedded resource
-                var innerFindings = ScanEmbeddedResource(module, pending.ResourceName);
+                var innerFindings = ScanEmbeddedResource(module, pending.ResourceName, _maxRecursiveResourceBytes);
                 if (innerFindings.Count > 0)
                 {
                     // Compute boost from inner findings
@@ -1086,7 +1100,10 @@ namespace MLVScan.Models.Rules
 
         #region Recursive Embedded Resource Scanning
 
-        private static List<ScanFinding> ScanEmbeddedResource(ModuleDefinition module, string resourceName)
+        private static List<ScanFinding> ScanEmbeddedResource(
+            ModuleDefinition module,
+            string resourceName,
+            long maxResourceBytes)
         {
             var findings = new List<ScanFinding>();
 
@@ -1113,8 +1130,8 @@ namespace MLVScan.Models.Rules
                 if (resourceData == null || resourceData.Length == 0)
                     return findings;
 
-                // Size limit: skip resources larger than 10MB
-                if (resourceData.Length > 10 * 1024 * 1024)
+                // Apply the configured limit to both stored and expanded resource bytes.
+                if (resourceData.LongLength > maxResourceBytes)
                     return findings;
 
                 // Check if it looks like a PE/assembly (MZ header)
@@ -1129,7 +1146,17 @@ namespace MLVScan.Models.Rules
                             using var gzipStream = new System.IO.Compression.GZipStream(
                                 compressedStream, System.IO.Compression.CompressionMode.Decompress);
                             using var decompressedStream = new System.IO.MemoryStream();
-                            gzipStream.CopyTo(decompressedStream);
+                            var buffer = new byte[81920];
+                            long expandedBytes = 0;
+                            int bytesRead;
+                            while ((bytesRead = gzipStream.Read(buffer, 0, buffer.Length)) > 0)
+                            {
+                                expandedBytes += bytesRead;
+                                if (expandedBytes > maxResourceBytes)
+                                    return findings;
+
+                                decompressedStream.Write(buffer, 0, bytesRead);
+                            }
                             resourceData = decompressedStream.ToArray();
 
                             // Re-check for MZ header after decompression

--- a/Services/AssemblyScanner.cs
+++ b/Services/AssemblyScanner.cs
@@ -48,6 +48,13 @@ namespace MLVScan.Services
             _config = config ?? new ScanConfig();
             _resolverProvider = resolverProvider ?? DefaultAssemblyResolverProvider.Instance;
             _rules = rules as IReadOnlyCollection<IScanRule> ?? rules.ToList();
+            foreach (var rule in _rules)
+            {
+                if (rule is AssemblyDynamicLoadRule dynamicLoadRule)
+                {
+                    dynamicLoadRule.ConfigureRecursiveResourceScanning(_config);
+                }
+            }
             _telemetry = new ScanTelemetryHub();
             _progressReporter = progressReporter;
 


### PR DESCRIPTION
## Summary
- honor the existing recursive-resource enable and size configuration in the assembly scanner
- apply the configured byte limit to both stored resource data and expanded gzip output
- stop expansion before oversized data is materialized and add focused configuration/budget regressions

## Validation
- AssemblyDynamicLoadRule focused suite: 8 passed
- false-positive suite: 53 passed, 7 optional skipped; disposition baseline remains Clean with no threat-family matches
- quarantine suite: 180 passed, 1 optional skipped; available samples remain KnownThreat
- full suite: 1,581 passed, 19 optional skipped

Security details are intentionally kept in the private Codex Security finding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Bound recursive resource expansion by the configured byte limit.
- Applied the limit to stored resource data and expanded GZip output.
- Prevented oversized data from being materialized.
- Honored disabled recursive scanning and zero-size limits.
- Added configuration and regression tests.
- Verified focused, false-positive, quarantine, and full-suite tests. Hosted CI is green.

| Author | Lines added | Lines removed |
|---|---:|---:|
| ifBars | 111 | 5 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->