### PR TITLE
Fail closed when managed analysis is incomplete

### DIFF
--- a/MLVScan.Core.Tests/Integration/AssemblyScannerTests.cs
+++ b/MLVScan.Core.Tests/Integration/AssemblyScannerTests.cs
@@ -1,8 +1,10 @@
 using FluentAssertions;
+using MLVScan.Abstractions;
 using MLVScan.Core.Tests.TestUtilities;
 using MLVScan.Models;
 using MLVScan.Services;
 using Mono.Cecil.Cil;
+using Mono.Cecil;
 using Xunit;
 
 namespace MLVScan.Core.Tests.Integration;
@@ -228,6 +230,45 @@ public class AssemblyScannerTests
     }
 
     [Fact]
+    public void Scan_MalformedAssembly_ReturnsBlockingIncompleteAnalysisFinding()
+    {
+        byte[] malformedAssembly = [0x4D, 0x5A, 0x00, 0x01, 0x02, 0x03];
+        var scanner = new AssemblyScanner(RuleFactory.CreateDefaultRules());
+        using var stream = new MemoryStream(malformedAssembly);
+
+        var findings = scanner.Scan(stream).ToList();
+        var result = ScanResultMapper.ToDto(findings, "malformed.dll", malformedAssembly, false);
+
+        findings.Should().ContainSingle(finding =>
+            finding.RuleId == "AssemblyScanner" && finding.Severity == Severity.Medium);
+        result.AnalysisCompleteness.IsComplete.Should().BeFalse();
+        result.AnalysisCompleteness.ReviewRecommended.Should().BeTrue();
+        result.Disposition.Should().NotBeNull();
+        result.Disposition!.Classification.Should().Be("ManualReviewRequired");
+        result.Disposition.BlockingRecommended.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Scan_MethodRuleFailure_ReturnsBlockingIncompleteAnalysisFinding()
+    {
+        var assembly = TestAssemblyBuilder.Create("MethodRuleFailure")
+            .AddType("TestType")
+                .AddMethod("Run")
+                .EndMethod()
+            .EndType()
+            .Build();
+        using var stream = new MemoryStream();
+        assembly.Write(stream);
+        stream.Position = 0;
+        var scanner = new AssemblyScanner([new ThrowingInstructionPassRule()]);
+
+        var findings = scanner.Scan(stream, "MethodRuleFailure.dll").ToList();
+
+        findings.Should().ContainSingle(finding =>
+            finding.RuleId == "MethodScanWarning" && finding.Severity == Severity.Medium);
+    }
+
+    [Fact]
     public void Scan_EmptyPath_ThrowsArgumentException()
     {
         var rules = RuleFactory.CreateDefaultRules();
@@ -382,4 +423,20 @@ public class AssemblyScannerTests
             _events.Add(value);
         }
     }
+
+    private sealed class ThrowingInstructionPassRule : IScanRule
+    {
+        public string Description => "Test rule";
+        public Severity Severity => Severity.Low;
+        public string RuleId => nameof(ThrowingInstructionPassRule);
+        public bool RequiresCompanionFinding => false;
+        public bool IsSuspicious(MethodReference method) => false;
+
+        public IEnumerable<ScanFinding> AnalyzeInstructions(
+            MethodDefinition method,
+            Mono.Collections.Generic.Collection<Instruction> instructions,
+            MethodSignals methodSignals)
+            => throw new InvalidOperationException("test failure");
+    }
+
 }

--- a/MLVScan.Core.Tests/Integration/SecurityRegressionEdgeCaseTests.cs
+++ b/MLVScan.Core.Tests/Integration/SecurityRegressionEdgeCaseTests.cs
@@ -12,7 +12,7 @@ namespace MLVScan.Core.Tests.Integration;
 public class SecurityRegressionEdgeCaseTests
 {
     [Fact]
-    public void Scan_InvalidManagedAssemblyStream_WithVirtualPath_ReturnsVisibleScannerWarning()
+    public void Scan_InvalidManagedAssemblyStream_WithVirtualPath_ReturnsBlockingScannerWarning()
     {
         var scanner = new AssemblyScanner(RuleFactory.CreateDefaultRules());
         using var stream = new MemoryStream([0x4d, 0x5a, 0x90, 0x00, 0x00]);
@@ -22,7 +22,7 @@ public class SecurityRegressionEdgeCaseTests
         findings.Should().ContainSingle();
         findings[0].RuleId.Should().Be("AssemblyScanner");
         findings[0].Location.Should().Be("uploaded-malware.dll");
-        findings[0].Severity.Should().Be(Severity.Low);
+        findings[0].Severity.Should().Be(Severity.Medium);
         findings[0].Description.Should().Contain("could not be scanned");
     }
 

--- a/Services/AssemblyScanner.cs
+++ b/Services/AssemblyScanner.cs
@@ -160,8 +160,8 @@ namespace MLVScan.Services
             {
                 findings.Add(new ScanFinding(
                     "Assembly scanning",
-                    "Warning: Some parts of the assembly could not be scanned. This doesn't necessarily mean the mod is malicious.",
-                    Severity.Low) { RuleId = "AssemblyScanner" });
+                    "Warning: The assembly could not be scanned completely. Manual review is required before treating this input as clean.",
+                    Severity.Medium) { RuleId = "AssemblyScanner" });
             }
 
             _telemetry.AddPhaseElapsed("AssemblyScanner.Total", totalStart);
@@ -247,8 +247,8 @@ namespace MLVScan.Services
             {
                 findings.Add(new ScanFinding(
                     virtualPath ?? "Assembly scanning",
-                    "Warning: Some parts of the assembly could not be scanned. Please ensure this is a valid managed .NET assembly. This doesn't necessarily mean the assembly is malicious.",
-                    Severity.Low) { RuleId = "AssemblyScanner" });
+                    "Warning: The assembly could not be scanned completely. Please ensure this is a valid managed .NET assembly. Manual review is required before treating this input as clean.",
+                    Severity.Medium) { RuleId = "AssemblyScanner" });
             }
 
             _telemetry.AddPhaseElapsed("AssemblyScanner.Total", totalStart);
@@ -379,14 +379,6 @@ namespace MLVScan.Services
 
         private static IEnumerable<ScanFinding> FilterEmptyFindings(List<ScanFinding> findings)
         {
-            // Filter out single low-severity warning when nothing else was found
-            if (findings.Count == 1 &&
-                findings[0].Location == "Assembly scanning" &&
-                string.IsNullOrEmpty(findings[0].CodeSnippet))
-            {
-                return new List<ScanFinding>();
-            }
-
             return findings;
         }
 

--- a/Services/MethodScanner.cs
+++ b/Services/MethodScanner.cs
@@ -290,7 +290,13 @@ namespace MLVScan.Services
             }
             catch (Exception)
             {
-                // Skip method if it can't be properly analyzed
+                result.Findings.Add(new ScanFinding(
+                    $"{method.DeclaringType?.FullName}.{method.Name}",
+                    "Warning: Could not complete full IL analysis for this method. Manual review is required.",
+                    Severity.Medium)
+                {
+                    RuleId = "MethodScanWarning"
+                });
             }
             finally
             {

--- a/Services/TypeScanner.cs
+++ b/Services/TypeScanner.cs
@@ -150,7 +150,13 @@ namespace MLVScan.Services
             }
             catch (Exception)
             {
-                // Skip type if it can't be properly analyzed
+                findings.Add(new ScanFinding(
+                    type.FullName,
+                    "Warning: Could not complete full IL analysis for this type. Manual review is required.",
+                    Severity.Medium)
+                {
+                    RuleId = "TypeScanWarning"
+                });
             }
             finally
             {


### PR DESCRIPTION
## Summary
- preserve incomplete-scan findings at a blocking review severity
- surface method and type analysis failures as explicit manual-review findings
- ensure result mapping cannot present incomplete managed analysis as a clean disposition

## Validation
- full suite: 1,583 passed, 19 optional skipped
- false-positive corpus: Clean with no threat family
- quarantine corpus: KnownThreat for all available samples

This PR intentionally keeps the public description at the behavior and safety-contract level.