### PR TITLE
Isolate release credentials from build jobs

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -15,75 +15,75 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   check-version:
     runs-on: ubuntu-latest
     outputs:
       version-changed: ${{ steps.check.outputs.changed }}
       new-version: ${{ steps.check.outputs.version }}
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
       with:
-        fetch-depth: 2  # Need at least 2 commits to compare
-        
+        fetch-depth: 2
+        persist-credentials: false
+
     - name: Check if version changed
       id: check
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        INPUT_VERSION: ${{ inputs.version }}
       run: |
-        # If manually triggered with a version, use that
-        if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
-          echo "Manual trigger with version: ${{ inputs.version }}"
-          echo "changed=true" >> $GITHUB_OUTPUT
-          echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+        set -euo pipefail
+
+        validate_version() {
+          local version="$1"
+          if [[ ! "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "Invalid semantic version" >&2
+            exit 1
+          fi
+        }
+
+        CURRENT_VERSION=$(sed -n 's:.*<Version>\([^<]*\)</Version>.*:\1:p' Directory.Build.props | head -n 1)
+        validate_version "$CURRENT_VERSION"
+
+        if [[ "$EVENT_NAME" == "workflow_dispatch" && -n "$INPUT_VERSION" ]]; then
+          validate_version "$INPUT_VERSION"
+          printf 'changed=true\nversion=%s\n' "$INPUT_VERSION" >> "$GITHUB_OUTPUT"
           exit 0
-        fi
-        
-        # Get current version from Directory.Build.props
-        CURRENT_VERSION=$(grep -oP '<Version>\K[^<]+' Directory.Build.props)
-        echo "Current version: $CURRENT_VERSION"
-        
-        # If manually triggered without version, always use current version
-        if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-          echo "Manual trigger, using current version: $CURRENT_VERSION"
-          echo "changed=true" >> $GITHUB_OUTPUT
-          echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-        
-        # Get previous version from git
-        git checkout HEAD~1 -- Directory.Build.props 2>/dev/null || echo "First commit"
-        PREVIOUS_VERSION=$(grep -oP '<Version>\K[^<]+' Directory.Build.props 2>/dev/null || echo "0.0.0")
-        echo "Previous version: $PREVIOUS_VERSION"
-        
-        # Restore current version
-        git checkout HEAD -- Directory.Build.props
-        
-        # Compare versions
-        if [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
-          echo "Version changed from $PREVIOUS_VERSION to $CURRENT_VERSION"
-          echo "changed=true" >> $GITHUB_OUTPUT
-          echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
-        else
-          echo "Version unchanged"
-          echo "changed=false" >> $GITHUB_OUTPUT
-          echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
         fi
 
-  create-release:
+        if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+          printf 'changed=true\nversion=%s\n' "$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        PREVIOUS_VERSION=$(git show HEAD~1:Directory.Build.props 2>/dev/null |
+          sed -n 's:.*<Version>\([^<]*\)</Version>.*:\1:p' | head -n 1 || true)
+        PREVIOUS_VERSION=${PREVIOUS_VERSION:-0.0.0}
+
+        if [[ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]]; then
+          printf 'changed=true\nversion=%s\n' "$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+        else
+          printf 'changed=false\nversion=%s\n' "$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+        fi
+
+  build-package:
     needs: check-version
     if: needs.check-version.outputs.version-changed == 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      actions: write
-    
+      contents: read
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
       with:
-        token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
-        fetch-depth: 0
+        persist-credentials: false
 
     - name: Pin .NET SDK for CI
       run: |
@@ -95,7 +95,7 @@ jobs:
           }
         }
         EOF
-      
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
@@ -106,69 +106,57 @@ jobs:
 
     - name: Verify version drift guard
       run: dotnet test MLVScan.Core.Tests/MLVScan.Core.Tests.csproj --filter "FullyQualifiedName~MLVScanVersionsTests.CoreVersion_MatchesDirectoryBuildPropsVersion"
-        
+
     - name: Build
       run: dotnet build MLVScan.Core.csproj -c Release
-      
+
     - name: Pack
       run: dotnet pack MLVScan.Core.csproj -c Release -o ./nupkg
-        
-    - name: Generate Release Notes
-      id: release_notes
-      run: |
-        VERSION="${{ needs.check-version.outputs.new-version }}"
-        
-        # Get commits since last tag
-        LAST_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo "")
-        
-        if [ -n "$LAST_TAG" ]; then
-          COMMITS=$(git log $LAST_TAG..HEAD --pretty=format:"- %s (%h)" --no-merges)
-        else
-          COMMITS=$(git log --pretty=format:"- %s (%h)" --no-merges -n 10)
-        fi
-        
-        # Create release notes
-        cat > release_notes.md << EOF
-        ## MLVScan.Core v$VERSION
-        
-        ### Changes
-        
-        $COMMITS
-        
-        ### Installation
-        
-        \`\`\`bash
-        dotnet add package MLVScan.Core --version $VERSION
-        \`\`\`
-        
-        ### NuGet Package
-        
-        This release is available on NuGet: https://www.nuget.org/packages/MLVScan.Core/$VERSION
-        
-        ---
-        
-        **Full Changelog**: https://github.com/${{ github.repository }}/compare/$LAST_TAG...v$VERSION
-        EOF
-        
-        echo "Release notes generated"
-        
+
+    - name: Upload release package
+      uses: actions/upload-artifact@v6
+      with:
+        name: release-package
+        path: ./nupkg/*.nupkg
+        if-no-files-found: error
+
+  create-release:
+    needs:
+      - check-version
+      - build-package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - name: Download release package
+      uses: actions/download-artifact@v6
+      with:
+        name: release-package
+        path: ./nupkg
+
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       with:
         tag_name: v${{ needs.check-version.outputs.new-version }}
         name: MLVScan.Core v${{ needs.check-version.outputs.new-version }}
-        body_path: release_notes.md
         draft: false
         prerelease: false
         make_latest: true
-        files: |
-          ./nupkg/*.nupkg
-        
+        generate_release_notes: true
+        files: ./nupkg/*.nupkg
+
     - name: Summary
+      env:
+        VERSION: ${{ needs.check-version.outputs.new-version }}
       run: |
-        echo "### ✅ Release Created Successfully" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "**Version:** v${{ needs.check-version.outputs.new-version }}" >> $GITHUB_STEP_SUMMARY
-        echo "**Tag:** v${{ needs.check-version.outputs.new-version }}" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "The NuGet and npm publish workflows will be triggered automatically." >> $GITHUB_STEP_SUMMARY
+        {
+          echo "### Release created successfully"
+          echo
+          echo "**Version:** v$VERSION"
+          echo "**Tag:** v$VERSION"
+          echo
+          echo "The package publishing workflows will run after this workflow completes."
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,6 +1,5 @@
 # Publishes @mlvscan/wasm-core.
-# Requires NPM_TOKEN secret in repo Settings → Secrets.
-#   Create token at npmjs.com → Access Tokens → "Automation" or "Publish", then add as NPM_TOKEN.
+# Requires NPM_TOKEN secret in repo Settings -> Secrets.
 name: Publish to npm
 
 on:
@@ -12,14 +11,19 @@ on:
       - completed
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
-  publish:
+  build-package:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'release' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Pin .NET SDK for CI
       run: |
@@ -32,21 +36,29 @@ jobs:
         }
         EOF
 
-    - name: Extract version
+    - name: Resolve and validate package version
       id: get_version
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
+        REF_NAME: ${{ github.ref }}
       run: |
-        if [ "${{ github.event_name }}" == "release" ]; then
-          VERSION="${{ github.event.release.tag_name }}"
-          VERSION=${VERSION#v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-        elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+        set -euo pipefail
+
+        if [[ "$EVENT_NAME" == "release" ]]; then
+          VERSION=${RELEASE_TAG#v}
+        elif [[ "$REF_NAME" == refs/tags/v* ]]; then
+          VERSION=${REF_NAME#refs/tags/v}
         else
-          VERSION=$(grep -oP '<Version>\K[^<]+' Directory.Build.props)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          VERSION=$(sed -n 's:.*<Version>\([^<]*\)</Version>.*:\1:p' Directory.Build.props | head -n 1)
         fi
-      shell: bash
+
+        if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+          echo "Invalid semantic version" >&2
+          exit 1
+        fi
+
+        printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
@@ -62,41 +74,64 @@ jobs:
     - name: Publish WASM
       run: dotnet publish MLVScan.WASM/MLVScan.WASM.csproj -c Release
 
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: '1.3.5'
+
+    - name: Install dependencies
+      working-directory: MLVScan.WASM/npm
+      run: bun install --frozen-lockfile
+
+    - name: Copy Blazor framework to dist
+      working-directory: MLVScan.WASM/npm
+      run: bun run copy:framework
+
+    - name: Build TypeScript
+      working-directory: MLVScan.WASM/npm
+      run: bun run build
+
+    - name: Set package version
+      working-directory: MLVScan.WASM/npm
+      env:
+        PACKAGE_VERSION: ${{ steps.get_version.outputs.version }}
+      run: bun pm pkg set version="$PACKAGE_VERSION"
+
+    - name: Create npm package archive
+      working-directory: MLVScan.WASM/npm
+      run: bun pm pack --destination ./package-artifact
+
+    - name: Upload npm package artifact
+      uses: actions/upload-artifact@v6
+      with:
+        name: npm-package
+        path: MLVScan.WASM/npm/package-artifact/*.tgz
+        if-no-files-found: error
+
+  publish:
+    needs: build-package
+    runs-on: ubuntu-latest
+    permissions: {}
+
+    steps:
+    - name: Download npm package artifact
+      uses: actions/download-artifact@v6
+      with:
+        name: npm-package
+        path: ./package-artifact
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: '22'
         registry-url: 'https://registry.npmjs.org'
-        cache: 'npm'
-        cache-dependency-path: MLVScan.WASM/npm/package-lock.json
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-    - name: Install npm dependencies
-      working-directory: MLVScan.WASM/npm
-      run: npm ci
-
-    - name: Copy Blazor framework to dist
-      working-directory: MLVScan.WASM/npm
-      run: npm run copy:framework
-
-    - name: Build TypeScript
-      working-directory: MLVScan.WASM/npm
-      run: npm run build
-
-    - name: Set package version
-      working-directory: MLVScan.WASM/npm
-      run: npm version ${{ steps.get_version.outputs.version }} --no-git-tag-version --allow-same-version
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: '1.3.5'
 
     - name: Publish to npm
-      working-directory: MLVScan.WASM/npm
-      run: npm publish --access public
+      run: bun publish ./package-artifact/*.tgz --access public
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-    - name: Summary
-      run: |
-        echo "### ✅ npm package published" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "**Package:** \`@mlvscan/wasm-core\`" >> $GITHUB_STEP_SUMMARY
-        echo "**Version:** ${{ steps.get_version.outputs.version }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -7,16 +7,20 @@ on:
     workflows: ["Auto Release on Version Change"]
     types:
       - completed
-  workflow_dispatch:  # Allow manual triggering
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
-  publish:
+  build-package:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'release' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
-    
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Pin .NET SDK for CI
       run: |
@@ -28,7 +32,7 @@ jobs:
           }
         }
         EOF
-      
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
@@ -36,47 +40,73 @@ jobs:
 
     - name: Restore .NET workloads
       run: dotnet workload restore MLVScan.WASM/MLVScan.WASM.csproj
-        
+
     - name: Restore dependencies
       run: dotnet restore MLVScan.Core.csproj
 
     - name: Verify version drift guard
       run: dotnet test MLVScan.Core.Tests/MLVScan.Core.Tests.csproj --filter "FullyQualifiedName~MLVScanVersionsTests.CoreVersion_MatchesDirectoryBuildPropsVersion"
-      
+
     - name: Build
       run: dotnet build MLVScan.Core.csproj -c Release --no-restore
-      
+
     - name: Run tests
       run: dotnet test MLVScan.Core.Tests/MLVScan.Core.Tests.csproj -c Release --verbosity normal
-      
-    - name: Extract version from release
+
+    - name: Resolve and validate package version
       id: get_version
-      run: |
-        if [ "${{ github.event_name }}" == "release" ]; then
-          # Extract version from release tag (remove 'v' prefix)
-          VERSION="${{ github.event.release.tag_name }}"
-          VERSION=${VERSION#v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-        elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-        else
-          # Fallback: read from Directory.Build.props
-          VERSION=$(grep -oP '<Version>\K[^<]+' Directory.Build.props)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-        fi
-      shell: bash
-      
-    - name: Pack
-      run: dotnet pack MLVScan.Core.csproj -c Release --no-build -p:PackageVersion=${{ steps.get_version.outputs.version }} -o ./nupkg
-      
-    - name: Publish to NuGet
-      run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
       env:
-        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        
-    - name: Upload package as artifact
+        EVENT_NAME: ${{ github.event_name }}
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
+        REF_NAME: ${{ github.ref }}
+      run: |
+        set -euo pipefail
+
+        if [[ "$EVENT_NAME" == "release" ]]; then
+          VERSION=${RELEASE_TAG#v}
+        elif [[ "$REF_NAME" == refs/tags/v* ]]; then
+          VERSION=${REF_NAME#refs/tags/v}
+        else
+          VERSION=$(sed -n 's:.*<Version>\([^<]*\)</Version>.*:\1:p' Directory.Build.props | head -n 1)
+        fi
+
+        if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+          echo "Invalid semantic version" >&2
+          exit 1
+        fi
+
+        printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
+
+    - name: Pack
+      env:
+        PACKAGE_VERSION: ${{ steps.get_version.outputs.version }}
+      run: dotnet pack MLVScan.Core.csproj -c Release --no-build -p:PackageVersion="$PACKAGE_VERSION" -o ./nupkg
+
+    - name: Upload package artifact
       uses: actions/upload-artifact@v6
       with:
         name: nuget-package
         path: ./nupkg/*.nupkg
+        if-no-files-found: error
+
+  publish:
+    needs: build-package
+    runs-on: ubuntu-latest
+    permissions: {}
+
+    steps:
+    - name: Download package artifact
+      uses: actions/download-artifact@v6
+      with:
+        name: nuget-package
+        path: ./nupkg
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Publish to NuGet
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      run: dotnet nuget push ./nupkg/*.nupkg --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/MLVScan.Core.Tests/Integration/ReleaseWorkflowSecurityTests.cs
+++ b/MLVScan.Core.Tests/Integration/ReleaseWorkflowSecurityTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using Xunit;
+
+namespace MLVScan.Core.Tests.Integration;
+
+public sealed class ReleaseWorkflowSecurityTests
+{
+    [Theory]
+    [InlineData("auto-release.yml")]
+    [InlineData("publish-nuget.yml")]
+    [InlineData("publish-npm.yml")]
+    public void ReleaseWorkflow_UsesValidatedEnvironmentValuesAndNonPersistentCheckout(string workflowName)
+    {
+        var workflow = ReadWorkflow(workflowName);
+
+        workflow.Should().Contain("persist-credentials: false");
+        workflow.Should().Contain("Invalid semantic version");
+        workflow.Should().NotContain("PAT_TOKEN");
+        workflow.Should().NotContain("VERSION=\"${{");
+        workflow.Should().NotContain("PackageVersion=${{");
+        workflow.Should().NotContain("npm version ${{");
+    }
+
+    [Theory]
+    [InlineData("publish-nuget.yml", "NUGET_API_KEY")]
+    [InlineData("publish-npm.yml", "NPM_TOKEN")]
+    public void PublishWorkflow_ExposesRegistryCredentialOnlyInIsolatedPublishJob(
+        string workflowName,
+        string credentialName)
+    {
+        var workflow = ReadWorkflow(workflowName);
+        int publishJob = workflow.IndexOf("\n  publish:\n", StringComparison.Ordinal);
+        string secretReference = $"secrets.{credentialName}";
+
+        publishJob.Should().BeGreaterThan(0);
+        workflow.IndexOf("\n    permissions: {}\n", publishJob, StringComparison.Ordinal)
+            .Should().BeGreaterThan(publishJob);
+        workflow[..publishJob].Should().NotContain(secretReference);
+        workflow[publishJob..].Should().Contain(secretReference);
+    }
+
+    private static string ReadWorkflow(string workflowName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "Directory.Build.props")))
+            directory = directory.Parent;
+
+        directory.Should().NotBeNull("the test must run beneath the repository root");
+        return File.ReadAllText(Path.Combine(directory!.FullName, ".github", "workflows", workflowName))
+            .Replace("\r\n", "\n", StringComparison.Ordinal);
+    }
+}

--- a/MLVScan.WASM/npm/bun.lock
+++ b/MLVScan.WASM/npm/bun.lock
@@ -1,0 +1,20 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "@mlvscan/wasm-core",
+      "devDependencies": {
+        "@types/node": "^18.0.0",
+        "typescript": "^5.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+  }
+}


### PR DESCRIPTION
## Summary

- validate release versions before they reach packaging commands
- separate read-only build/package jobs from narrowly scoped publish/release jobs
- remove persistent checkout credentials and the long-lived release token path
- keep NuGet and npm publishing secrets available only to their isolated publish jobs
- move the npm package workflow to the repository-standard Bun toolchain
- add regression tests for the workflow security invariants

## Validation

- workflow security tests: 5 passed
- all edited workflow YAML parsed successfully
- actionlint v1.7.7 passed
- Bun 1.3.5 frozen install, build, and package dry-run passed
- full false-positive and quarantine corpus suite: 1,588 passed, 19 optional skips

This PR intentionally omits reproduction payloads and other attack-path details.