### PR TITLE
Bound data-flow analysis work

### DIFF
--- a/MLVScan.Core.Tests/Unit/Models/ScanConfigTests.cs
+++ b/MLVScan.Core.Tests/Unit/Models/ScanConfigTests.cs
@@ -20,6 +20,13 @@ public class ScanConfigTests
         config.MaxExceptionHandlerFindingsPerMethod.Should().Be(256);
         config.AnalyzeLocalVariables.Should().BeTrue();
         config.AnalyzePropertyAccessors.Should().BeTrue();
+        config.EnableCrossMethodAnalysis.Should().BeTrue();
+        config.MaxCallChainDepth.Should().Be(5);
+        config.MaxDataFlowOperationsPerMethod.Should().Be(2048);
+        config.MaxDataFlowChainsPerMethod.Should().Be(256);
+        config.MaxCrossMethodCallEdges.Should().Be(100000);
+        config.MaxDeepCallChainEdges.Should().Be(10000);
+        config.MaxCrossMethodChains.Should().Be(512);
         config.DeveloperMode.Should().BeFalse();
     }
 
@@ -37,6 +44,13 @@ public class ScanConfigTests
             MaxExceptionHandlerFindingsPerMethod = 2,
             AnalyzeLocalVariables = false,
             AnalyzePropertyAccessors = false,
+            EnableCrossMethodAnalysis = false,
+            MaxCallChainDepth = 2,
+            MaxDataFlowOperationsPerMethod = 128,
+            MaxDataFlowChainsPerMethod = 32,
+            MaxCrossMethodCallEdges = 256,
+            MaxDeepCallChainEdges = 64,
+            MaxCrossMethodChains = 16,
             DeveloperMode = true
         };
 
@@ -49,6 +63,13 @@ public class ScanConfigTests
         config.MaxExceptionHandlerFindingsPerMethod.Should().Be(2);
         config.AnalyzeLocalVariables.Should().BeFalse();
         config.AnalyzePropertyAccessors.Should().BeFalse();
+        config.EnableCrossMethodAnalysis.Should().BeFalse();
+        config.MaxCallChainDepth.Should().Be(2);
+        config.MaxDataFlowOperationsPerMethod.Should().Be(128);
+        config.MaxDataFlowChainsPerMethod.Should().Be(32);
+        config.MaxCrossMethodCallEdges.Should().Be(256);
+        config.MaxDeepCallChainEdges.Should().Be(64);
+        config.MaxCrossMethodChains.Should().Be(16);
         config.DeveloperMode.Should().BeTrue();
     }
 }

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowAnalyzerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowAnalyzerTests.cs
@@ -1204,6 +1204,30 @@ public class DataFlowAnalyzerTests
             finding.Severity == Severity.Medium);
     }
 
+    [Fact]
+    public void AnalyzeCrossMethodFlows_UnresolvedCallsConsumeEdgeBudget()
+    {
+        using var module = ModuleDefinition.CreateModule("UnresolvedCrossMethodBudgetTest", ModuleKind.Dll);
+        var stress = CreateInterestingCallHeavyMethod(module, 8);
+        var config = new DataFlowAnalyzerConfig
+        {
+            MaxCrossMethodCallEdges = 1,
+            MaxCrossMethodChains = 8,
+            MaxCallChainDepth = 5
+        };
+        var analyzer = new DataFlowAnalyzer(
+            RuleFactory.CreateDefaultRules(), new CodeSnippetBuilder(), config);
+
+        analyzer.AnalyzeMethod(stress);
+        analyzer.AnalyzeCrossMethodFlows();
+        var findings = analyzer.BuildDataFlowFindings().ToList();
+
+        findings.Should().ContainSingle(finding =>
+            finding.RuleId == "DataFlowScanWarning" &&
+            finding.Location == "Cross-method data flow analysis" &&
+            finding.Severity == Severity.Medium);
+    }
+
     private static MethodDefinition CreateInterestingCallHeavyMethod(ModuleDefinition module, int callCount)
     {
         var type = new TypeDefinition("TestNamespace", $"InterestingCallHeavy{callCount}",

--- a/MLVScan.Core.Tests/Unit/Services/DataFlowAnalyzerTests.cs
+++ b/MLVScan.Core.Tests/Unit/Services/DataFlowAnalyzerTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using MLVScan.Core.Tests.TestUtilities;
 using MLVScan.Models;
 using MLVScan.Services;
+using MLVScan.Services.Diagnostics;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Xunit;
@@ -1136,6 +1137,98 @@ public class DataFlowAnalyzerTests
         dto.Disposition.Should().NotBeNull();
         dto.Disposition!.Classification.Should().Be("ManualReviewRequired");
         dto.Disposition.BlockingRecommended.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AnalyzeMethod_WhenOperationBudgetIsExhausted_FailsClosedForManualReview()
+    {
+        using var module = ModuleDefinition.CreateModule("DataFlowOperationBudgetTest", ModuleKind.Dll);
+        var stress = CreateInterestingCallHeavyMethod(module, 32);
+        var config = new DataFlowAnalyzerConfig
+        {
+            MaxDataFlowOperationsPerMethod = 4,
+            MaxDataFlowChainsPerMethod = 16
+        };
+        var analyzer = new DataFlowAnalyzer(
+            RuleFactory.CreateDefaultRules(), new CodeSnippetBuilder(), config);
+
+        analyzer.AnalyzeMethod(stress);
+        var findings = analyzer.BuildDataFlowFindings().ToList();
+
+        findings.Should().ContainSingle(finding =>
+            finding.RuleId == "DataFlowScanWarning" && finding.Severity == Severity.Medium);
+    }
+
+    [Fact]
+    public void AnalyzeMethod_ScanConfigOperationBudget_IsAppliedToAnalyzer()
+    {
+        using var module = ModuleDefinition.CreateModule("ScanConfigDataFlowBudgetTest", ModuleKind.Dll);
+        var stress = CreateInterestingCallHeavyMethod(module, 2);
+        var config = new ScanConfig
+        {
+            MaxDataFlowOperationsPerMethod = 0,
+            MaxDataFlowChainsPerMethod = 0
+        };
+        var analyzer = new DataFlowAnalyzer(
+            RuleFactory.CreateDefaultRules(), new CodeSnippetBuilder(), config, new ScanTelemetryHub());
+
+        analyzer.AnalyzeMethod(stress);
+
+        analyzer.BuildDataFlowFindings().Should().ContainSingle(finding =>
+            finding.RuleId == "DataFlowScanWarning" && finding.Severity == Severity.Medium);
+    }
+
+    [Fact]
+    public void AnalyzeCrossMethodFlows_WhenEdgeBudgetIsExhausted_FailsClosedForManualReview()
+    {
+        using var module = ModuleDefinition.CreateModule("CrossMethodBudgetTest", ModuleKind.Dll);
+        var stress = CreateCallHeavyMethod(module, 8);
+        var target = stress.DeclaringType.Methods.Single(method => method.Name == "Consume");
+        var config = new DataFlowAnalyzerConfig
+        {
+            MaxCrossMethodCallEdges = 1,
+            MaxCrossMethodChains = 8,
+            MaxCallChainDepth = 5
+        };
+        var analyzer = new DataFlowAnalyzer(
+            RuleFactory.CreateDefaultRules(), new CodeSnippetBuilder(), config);
+
+        analyzer.AnalyzeMethod(target);
+        analyzer.AnalyzeMethod(stress);
+        analyzer.AnalyzeCrossMethodFlows();
+        var findings = analyzer.BuildDataFlowFindings().ToList();
+
+        findings.Should().ContainSingle(finding =>
+            finding.RuleId == "DataFlowScanWarning" &&
+            finding.Location == "Cross-method data flow analysis" &&
+            finding.Severity == Severity.Medium);
+    }
+
+    private static MethodDefinition CreateInterestingCallHeavyMethod(ModuleDefinition module, int callCount)
+    {
+        var type = new TypeDefinition("TestNamespace", $"InterestingCallHeavy{callCount}",
+            TypeAttributes.Public | TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(type);
+        var method = new MethodDefinition("Stress",
+            MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Void);
+        var processType = new TypeReference("System.Diagnostics", "Process", module, module.TypeSystem.CoreLibrary);
+        var processStart = new MethodReference("Start", processType, processType)
+        {
+            HasThis = false
+        };
+        processStart.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        var il = method.Body.GetILProcessor();
+        for (var index = 0; index < callCount; index++)
+        {
+            il.Emit(OpCodes.Ldstr, "tool.exe");
+            il.Emit(OpCodes.Call, processStart);
+            il.Emit(OpCodes.Pop);
+        }
+
+        il.Emit(OpCodes.Ret);
+        type.Methods.Add(method);
+        return method;
     }
 
     private static MethodDefinition CreateCallHeavyMethod(ModuleDefinition module, int callCount)

--- a/Models/ScanConfig.cs
+++ b/Models/ScanConfig.cs
@@ -56,6 +56,32 @@ namespace MLVScan.Models
         public bool EnableReturnValueTracking { get; set; } = true;
 
         /// <summary>
+        /// Maximum number of interesting data-flow operations retained for one method.
+        /// Reaching this limit marks the analysis as incomplete and requires manual review.
+        /// </summary>
+        public int MaxDataFlowOperationsPerMethod { get; set; } = 2048;
+
+        /// <summary>
+        /// Maximum number of data-flow chains retained for one method.
+        /// </summary>
+        public int MaxDataFlowChainsPerMethod { get; set; } = 256;
+
+        /// <summary>
+        /// Maximum number of call-graph edges evaluated during one cross-method analysis pass.
+        /// </summary>
+        public int MaxCrossMethodCallEdges { get; set; } = 100000;
+
+        /// <summary>
+        /// Maximum number of recursively expanded edges during deep call-chain analysis.
+        /// </summary>
+        public int MaxDeepCallChainEdges { get; set; } = 10000;
+
+        /// <summary>
+        /// Maximum number of cross-method chains retained during one scan.
+        /// </summary>
+        public int MaxCrossMethodChains { get; set; } = 512;
+
+        /// <summary>
         /// Enables recursive scanning of embedded resources that appear to contain managed assemblies.
         /// </summary>
         public bool EnableRecursiveResourceScanning { get; set; } = true;

--- a/Services/AssemblyScanner.cs
+++ b/Services/AssemblyScanner.cs
@@ -67,7 +67,7 @@ namespace MLVScan.Services
             _callGraphBuilder = new CallGraphBuilder(rules, snippetBuilder, entryPointProvider);
 
             // Create data flow analyzer for tracking data movement through operations
-            _dataFlowAnalyzer = new DataFlowAnalyzer(rules, snippetBuilder, _telemetry);
+            _dataFlowAnalyzer = new DataFlowAnalyzer(rules, snippetBuilder, _config, _telemetry);
 
             var reflectionDetector =
                 new ReflectionDetector(rules, signalTracker, stringPatternDetector, snippetBuilder);

--- a/Services/DataFlow/CrossMethodDataFlowAnalyzer.cs
+++ b/Services/DataFlow/CrossMethodDataFlowAnalyzer.cs
@@ -39,13 +39,13 @@ namespace MLVScan.Services.DataFlow
             {
                 foreach (var callSite in callerInfo.OutgoingCalls)
                 {
+                    if (!budget.TryConsumeEdge())
+                        return new CrossMethodAnalysisResult(chains, false);
+
                     if (!state.MethodFlowInfos.TryGetValue(callSite.TargetMethodKey, out var calleeInfo))
                     {
                         continue;
                     }
-
-                    if (!budget.TryConsumeEdge())
-                        return new CrossMethodAnalysisResult(chains, false);
 
                     var crossMethodChain = TryBuildCrossMethodChain(state, callerInfo, callSite, calleeInfo);
                     if (crossMethodChain != null)

--- a/Services/DataFlow/CrossMethodDataFlowAnalyzer.cs
+++ b/Services/DataFlow/CrossMethodDataFlowAnalyzer.cs
@@ -22,14 +22,18 @@ namespace MLVScan.Services.DataFlow
             _deepCallChainAnalyzer = new DeepCallChainAnalyzer(patternEvaluator, nodeFactory, config.MaxCallChainDepth);
         }
 
-        public IReadOnlyList<DataFlowChain> Analyze(DataFlowAnalysisState state)
+        public CrossMethodAnalysisResult Analyze(DataFlowAnalysisState state)
         {
             if (!_config.EnableCrossMethodAnalysis)
             {
-                return Array.Empty<DataFlowChain>();
+                return new CrossMethodAnalysisResult(Array.Empty<DataFlowChain>(), true);
             }
 
             var chains = new List<DataFlowChain>();
+            var budget = new CrossMethodAnalysisBudget(
+                _config.MaxCrossMethodCallEdges,
+                _config.MaxDeepCallChainEdges,
+                _config.MaxCrossMethodChains);
 
             foreach (var callerInfo in state.MethodFlowInfos.Values)
             {
@@ -40,9 +44,15 @@ namespace MLVScan.Services.DataFlow
                         continue;
                     }
 
+                    if (!budget.TryConsumeEdge())
+                        return new CrossMethodAnalysisResult(chains, false);
+
                     var crossMethodChain = TryBuildCrossMethodChain(state, callerInfo, callSite, calleeInfo);
                     if (crossMethodChain != null)
                     {
+                        if (!budget.TryReserveChain())
+                            return new CrossMethodAnalysisResult(chains, false);
+
                         chains.Add(crossMethodChain);
                     }
 
@@ -51,6 +61,9 @@ namespace MLVScan.Services.DataFlow
                         var returnValueChain = TryBuildReturnValueChain(state, callerInfo, callSite, calleeInfo);
                         if (returnValueChain != null)
                         {
+                            if (!budget.TryReserveChain())
+                                return new CrossMethodAnalysisResult(chains, false);
+
                             chains.Add(returnValueChain);
                         }
                     }
@@ -59,10 +72,10 @@ namespace MLVScan.Services.DataFlow
 
             if (_config.MaxCallChainDepth > 2)
             {
-                chains.AddRange(_deepCallChainAnalyzer.Analyze(state));
+                chains.AddRange(_deepCallChainAnalyzer.Analyze(state, budget));
             }
 
-            return chains;
+            return new CrossMethodAnalysisResult(chains, budget.IsComplete);
         }
 
         private DataFlowChain? TryBuildCrossMethodChain(
@@ -265,5 +278,73 @@ namespace MLVScan.Services.DataFlow
                 .ToList();
         }
     }
-#pragma warning restore CS0618
+
+    internal sealed class CrossMethodAnalysisResult
+    {
+        public CrossMethodAnalysisResult(IReadOnlyList<DataFlowChain> chains, bool isComplete)
+        {
+            Chains = chains;
+            IsComplete = isComplete;
+        }
+
+        public IReadOnlyList<DataFlowChain> Chains { get; }
+
+        public bool IsComplete { get; }
+    }
+
+    internal sealed class CrossMethodAnalysisBudget
+    {
+        private readonly int _maxEdges;
+        private readonly int _maxDeepEdges;
+        private readonly int _maxChains;
+        private int _edges;
+        private int _deepEdges;
+        private int _chains;
+
+        public CrossMethodAnalysisBudget(int maxEdges, int maxDeepEdges, int maxChains)
+        {
+            _maxEdges = Math.Max(0, maxEdges);
+            _maxDeepEdges = Math.Max(0, maxDeepEdges);
+            _maxChains = Math.Max(0, maxChains);
+        }
+
+        public bool IsComplete { get; private set; } = true;
+
+        public bool TryConsumeEdge()
+        {
+            if (_edges >= _maxEdges)
+            {
+                IsComplete = false;
+                return false;
+            }
+
+            _edges++;
+            return true;
+        }
+
+        public bool TryConsumeDeepEdge()
+        {
+            if (_deepEdges >= _maxDeepEdges)
+            {
+                IsComplete = false;
+                return false;
+            }
+
+            _deepEdges++;
+            return true;
+        }
+
+        public bool TryReserveChain()
+        {
+            if (_chains >= _maxChains)
+            {
+                IsComplete = false;
+                return false;
+            }
+
+            _chains++;
+            return true;
+        }
+    }
 }
+#pragma warning restore CS0618

--- a/Services/DataFlow/DataFlowAnalysisState.cs
+++ b/Services/DataFlow/DataFlowAnalysisState.cs
@@ -18,6 +18,8 @@ namespace MLVScan.Services.DataFlow
 
         public HashSet<string> IncompleteMethodKeys { get; } = new(StringComparer.Ordinal);
 
+        public bool CrossMethodAnalysisComplete { get; set; } = true;
+
         public void Clear()
         {
             MethodDataFlows.Clear();
@@ -25,6 +27,7 @@ namespace MLVScan.Services.DataFlow
             CrossMethodChains.Clear();
             MethodInstructions.Clear();
             IncompleteMethodKeys.Clear();
+            CrossMethodAnalysisComplete = true;
         }
 
         public void StoreMethodAnalysis(DataFlowMethodAnalysisResult analysis)

--- a/Services/DataFlow/DataFlowMethodAnalyzer.cs
+++ b/Services/DataFlow/DataFlowMethodAnalyzer.cs
@@ -7,17 +7,21 @@ using Mono.Cecil.Cil;
 
 namespace MLVScan.Services.DataFlow
 {
+#pragma warning disable CS0618
     internal sealed class DataFlowMethodAnalyzer
     {
         private readonly DataFlowPatternEvaluator _patternEvaluator;
         private readonly DataFlowNodeFactory _nodeFactory;
+        private readonly DataFlowAnalyzerConfig _config;
 
         public DataFlowMethodAnalyzer(
             DataFlowPatternEvaluator patternEvaluator,
-            DataFlowNodeFactory nodeFactory)
+            DataFlowNodeFactory nodeFactory,
+            DataFlowAnalyzerConfig config)
         {
             _patternEvaluator = patternEvaluator ?? throw new ArgumentNullException(nameof(patternEvaluator));
             _nodeFactory = nodeFactory ?? throw new ArgumentNullException(nameof(nodeFactory));
+            _config = config ?? throw new ArgumentNullException(nameof(config));
         }
 
         public DataFlowMethodAnalysisResult AnalyzeMethod(MethodDefinition method)
@@ -26,9 +30,16 @@ namespace MLVScan.Services.DataFlow
             var instructionHelper = new DataFlowInstructionHelper(instructions);
             var reachingDefinitionAnalysis = instructionHelper.GetReachingDefinitionAnalysis(instructions);
             var operationClassifier = new DataFlowOperationClassifier(instructionHelper);
-            var operations = operationClassifier.IdentifyInterestingOperations(method, instructions);
+            var identifiedOperations = operationClassifier.IdentifyInterestingOperations(method, instructions);
+            var operations = identifiedOperations
+                .Take(_config.MaxDataFlowOperationsPerMethod)
+                .ToList();
+            bool operationsComplete = identifiedOperations.Count <= _config.MaxDataFlowOperationsPerMethod;
             var flowInfo = BuildMethodFlowInfo(method, instructions, operations, instructionHelper);
-            var chains = operations.Count < 2 ? new List<DataFlowChain>() : BuildDataFlowChains(method, instructions, operations);
+            bool chainsComplete = true;
+            var chains = operations.Count < 2
+                ? new List<DataFlowChain>()
+                : BuildDataFlowChains(method, instructions, operations, out chainsComplete);
 
             return new DataFlowMethodAnalysisResult
             {
@@ -36,7 +47,7 @@ namespace MLVScan.Services.DataFlow
                 Instructions = instructions,
                 FlowInfo = flowInfo,
                 Chains = chains,
-                AnalysisComplete = reachingDefinitionAnalysis.IsComplete
+                AnalysisComplete = reachingDefinitionAnalysis.IsComplete && operationsComplete && chainsComplete
             };
         }
 
@@ -121,9 +132,11 @@ namespace MLVScan.Services.DataFlow
         private List<DataFlowChain> BuildDataFlowChains(
             MethodDefinition method,
             Collection<Instruction> instructions,
-            List<DataFlowInterestingOperation> operations)
+            List<DataFlowInterestingOperation> operations,
+            out bool analysisComplete)
         {
             var chains = new List<DataFlowChain>();
+            analysisComplete = true;
 
             var operationsByVariable = operations
                 .Where(static operation => operation.LocalVariableIndex.HasValue)
@@ -140,15 +153,31 @@ namespace MLVScan.Services.DataFlow
 
                 if ((hasSource || hasTransform) && hasSink)
                 {
+                    if (chains.Count >= _config.MaxDataFlowChainsPerMethod)
+                    {
+                        analysisComplete = false;
+                        return chains;
+                    }
+
                     chains.Add(BuildChain(method, instructions, orderedOperations));
                 }
             }
 
-            chains.AddRange(BuildSequentialChains(method, instructions, operations));
+            if (!AppendSequentialChains(method, instructions, operations, chains))
+            {
+                analysisComplete = false;
+                return chains;
+            }
 
             var directDownloadChain = BuildDirectDownloadToExecuteChain(method, instructions, operations);
             if (directDownloadChain != null)
             {
+                if (chains.Count >= _config.MaxDataFlowChainsPerMethod)
+                {
+                    analysisComplete = false;
+                    return chains;
+                }
+
                 chains.Add(directDownloadChain);
             }
 
@@ -193,31 +222,31 @@ namespace MLVScan.Services.DataFlow
             });
         }
 
-        private List<DataFlowChain> BuildSequentialChains(
+        private bool AppendSequentialChains(
             MethodDefinition method,
             Collection<Instruction> instructions,
-            List<DataFlowInterestingOperation> operations)
+            List<DataFlowInterestingOperation> operations,
+            List<DataFlowChain> chains)
         {
             const int maxInstructionDistance = 250;
-            var chains = new List<DataFlowChain>();
 
             for (var index = 0; index < operations.Count - 1; index++)
             {
                 var operation = operations[index];
-                var subsequentOperations = operations
-                    .Skip(index + 1)
-                    .Where(candidate => candidate.InstructionIndex - operation.InstructionIndex <= maxInstructionDistance)
-                    .ToList();
-
-                if (subsequentOperations.Count == 0)
+                var chainOperations = new List<DataFlowInterestingOperation>(6) { operation };
+                for (int candidateIndex = index + 1;
+                     candidateIndex < operations.Count && chainOperations.Count < 6;
+                     candidateIndex++)
                 {
-                    continue;
+                    var candidate = operations[candidateIndex];
+                    if (candidate.InstructionIndex - operation.InstructionIndex > maxInstructionDistance)
+                        break;
+
+                    chainOperations.Add(candidate);
                 }
 
-                var chainOperations = new List<DataFlowInterestingOperation> { operation };
-                chainOperations.AddRange(subsequentOperations.Take(5));
-
-                if (!chainOperations.Any(static candidate => candidate.NodeType == DataFlowNodeType.Sink))
+                if (chainOperations.Count == 1 ||
+                    !chainOperations.Any(static candidate => candidate.NodeType == DataFlowNodeType.Sink))
                 {
                     continue;
                 }
@@ -225,11 +254,14 @@ namespace MLVScan.Services.DataFlow
                 var pattern = _patternEvaluator.RecognizePattern(chainOperations);
                 if (pattern != DataFlowPattern.Legitimate && pattern != DataFlowPattern.Unknown)
                 {
+                    if (chains.Count >= _config.MaxDataFlowChainsPerMethod)
+                        return false;
+
                     chains.Add(BuildChain(method, instructions, chainOperations));
                 }
             }
 
-            return chains;
+            return true;
         }
 
         private DataFlowChain BuildChain(
@@ -256,4 +288,5 @@ namespace MLVScan.Services.DataFlow
             return chain;
         }
     }
+#pragma warning restore CS0618
 }

--- a/Services/DataFlow/DeepCallChainAnalyzer.cs
+++ b/Services/DataFlow/DeepCallChainAnalyzer.cs
@@ -19,7 +19,9 @@ namespace MLVScan.Services.DataFlow
             _maxCallChainDepth = maxCallChainDepth;
         }
 
-        public IReadOnlyList<DataFlowChain> Analyze(DataFlowAnalysisState state)
+        public IReadOnlyList<DataFlowChain> Analyze(
+            DataFlowAnalysisState state,
+            CrossMethodAnalysisBudget budget)
         {
             var chains = new List<DataFlowChain>();
 
@@ -31,6 +33,12 @@ namespace MLVScan.Services.DataFlow
                     {
                         continue;
                     }
+
+                    if (!HasRootFlowIntoCall(pair.Value, callSite))
+                        continue;
+
+                    if (!budget.TryConsumeDeepEdge())
+                        return chains;
 
                     var rootNode = new DataFlowCallChainNode
                     {
@@ -46,11 +54,17 @@ namespace MLVScan.Services.DataFlow
                     };
 
                     rootNode.ChildNodes.Add(targetNode);
-                    ExploreCallChain(state, targetNode, targetInfo, 2);
+                    ExploreCallChain(state, targetNode, targetInfo, 2, budget);
+
+                    if (!budget.IsComplete)
+                        return chains;
 
                     var deepChain = TryBuildDeepCallChain(state, rootNode, targetNode);
                     if (deepChain != null)
                     {
+                        if (!budget.TryReserveChain())
+                            return chains;
+
                         chains.Add(deepChain);
                     }
                 }
@@ -59,11 +73,28 @@ namespace MLVScan.Services.DataFlow
             return chains;
         }
 
+        private static bool HasRootFlowIntoCall(
+            DataFlowMethodFlowInfo rootInfo,
+            DataFlowMethodCallSite callSite)
+        {
+            if (callSite.ParameterMapping.Count == 0)
+                return false;
+
+            var passedLocals = new HashSet<int>(callSite.ParameterMapping.Values);
+            return rootInfo.Operations.Any(operation =>
+                (operation.NodeType == DataFlowNodeType.Source ||
+                 operation.NodeType == DataFlowNodeType.Transform) &&
+                operation.LocalVariableIndex.HasValue &&
+                operation.InstructionIndex < callSite.InstructionIndex &&
+                passedLocals.Contains(operation.LocalVariableIndex.Value));
+        }
+
         private void ExploreCallChain(
             DataFlowAnalysisState state,
             DataFlowCallChainNode currentNode,
             DataFlowMethodFlowInfo currentInfo,
-            int currentDepth)
+            int currentDepth,
+            CrossMethodAnalysisBudget budget)
         {
             if (currentDepth >= _maxCallChainDepth)
             {
@@ -78,6 +109,9 @@ namespace MLVScan.Services.DataFlow
                     continue;
                 }
 
+                if (!budget.TryConsumeDeepEdge())
+                    return;
+
                 var childNode = new DataFlowCallChainNode
                 {
                     MethodInfo = nextInfo,
@@ -89,7 +123,10 @@ namespace MLVScan.Services.DataFlow
                 };
 
                 currentNode.ChildNodes.Add(childNode);
-                ExploreCallChain(state, childNode, nextInfo, currentDepth + 1);
+                ExploreCallChain(state, childNode, nextInfo, currentDepth + 1, budget);
+
+                if (!budget.IsComplete)
+                    return;
             }
         }
 

--- a/Services/DataFlowAnalyzer.cs
+++ b/Services/DataFlowAnalyzer.cs
@@ -29,6 +29,16 @@ namespace MLVScan.Services
         /// Gets or sets a value indicating whether return values should be tracked through the flow graph.
         /// </summary>
         public bool EnableReturnValueTracking { get; set; } = true;
+
+        internal int MaxDataFlowOperationsPerMethod { get; set; } = 2048;
+
+        internal int MaxDataFlowChainsPerMethod { get; set; } = 256;
+
+        internal int MaxCrossMethodCallEdges { get; set; } = 100000;
+
+        internal int MaxDeepCallChainEdges { get; set; } = 10000;
+
+        internal int MaxCrossMethodChains { get; set; } = 512;
     }
 
     /// <summary>
@@ -82,6 +92,15 @@ namespace MLVScan.Services
         internal DataFlowAnalyzer(
             IEnumerable<IScanRule> rules,
             CodeSnippetBuilder snippetBuilder,
+            ScanConfig config,
+            ScanTelemetryHub telemetry)
+            : this(rules, snippetBuilder, CreateDataFlowConfig(config), telemetry)
+        {
+        }
+
+        internal DataFlowAnalyzer(
+            IEnumerable<IScanRule> rules,
+            CodeSnippetBuilder snippetBuilder,
             DataFlowAnalyzerConfig config,
             ScanTelemetryHub telemetry)
         {
@@ -105,8 +124,26 @@ namespace MLVScan.Services
             var nodeFactory = new DataFlowNodeFactory(snippetBuilder);
 
             _patternEvaluator = new DataFlowPatternEvaluator();
-            _methodAnalyzer = new DataFlowMethodAnalyzer(_patternEvaluator, nodeFactory);
+            _methodAnalyzer = new DataFlowMethodAnalyzer(_patternEvaluator, nodeFactory, config);
             _crossMethodAnalyzer = new CrossMethodDataFlowAnalyzer(_patternEvaluator, nodeFactory, config);
+        }
+
+        private static DataFlowAnalyzerConfig CreateDataFlowConfig(ScanConfig config)
+        {
+            if (config == null)
+                throw new ArgumentNullException(nameof(config));
+
+            return new DataFlowAnalyzerConfig
+            {
+                EnableCrossMethodAnalysis = config.EnableCrossMethodAnalysis,
+                MaxCallChainDepth = Math.Clamp(config.MaxCallChainDepth, 0, 32),
+                EnableReturnValueTracking = config.EnableReturnValueTracking,
+                MaxDataFlowOperationsPerMethod = Math.Max(0, config.MaxDataFlowOperationsPerMethod),
+                MaxDataFlowChainsPerMethod = Math.Max(0, config.MaxDataFlowChainsPerMethod),
+                MaxCrossMethodCallEdges = Math.Max(0, config.MaxCrossMethodCallEdges),
+                MaxDeepCallChainEdges = Math.Max(0, config.MaxDeepCallChainEdges),
+                MaxCrossMethodChains = Math.Max(0, config.MaxCrossMethodChains)
+            };
         }
 #pragma warning restore CS0618
 
@@ -149,7 +186,9 @@ namespace MLVScan.Services
         public void AnalyzeCrossMethodFlows()
         {
             var crossMethodStart = _telemetry.StartTimestamp();
-            var chains = _crossMethodAnalyzer.Analyze(_state);
+            var analysis = _crossMethodAnalyzer.Analyze(_state);
+            var chains = analysis.Chains;
+            _state.CrossMethodAnalysisComplete = analysis.IsComplete;
             _telemetry.AddPhaseElapsed("DataFlowAnalyzer.AnalyzeCrossMethodFlows", crossMethodStart);
             _telemetry.IncrementCounter("DataFlowAnalyzer.CrossMethodChainsBuilt", chains.Count);
 
@@ -195,7 +234,18 @@ namespace MLVScan.Services
                 findings.Add(new ScanFinding(
                     methodKey,
                     "Warning: Full IL analysis was skipped after the bounded data-flow work limit was reached. Manual review is required.",
-                    Severity.Low)
+                    Severity.Medium)
+                {
+                    RuleId = "DataFlowScanWarning"
+                });
+            }
+
+            if (!_state.CrossMethodAnalysisComplete)
+            {
+                findings.Add(new ScanFinding(
+                    "Cross-method data flow analysis",
+                    "Warning: Cross-method analysis reached its bounded work limit. Manual review is required.",
+                    Severity.Medium)
                 {
                     RuleId = "DataFlowScanWarning"
                 });


### PR DESCRIPTION
## Summary

- cap retained operations and chains per method
- replace repeated list materialization in sequential flow correlation with a bounded forward scan
- cap shallow call-graph, deep traversal, and cross-method chain work independently
- restrict deep traversal roots to calls that actually receive tracked source/transform data
- emit Medium incomplete-analysis findings so truncated work requires manual review
- expose the budgets through the existing scan configuration and map them into the analyzer

## Validation

- focused data-flow/config tests: 41 passed
- false-positive corpus remains Clean with no threat-family attribution
- quarantine corpus remains KnownThreat for all present required samples
- full corpus-backed suite: 1,586 passed, 19 optional skips

This PR intentionally omits stress-input construction details.